### PR TITLE
(no ticket): [external] Stencil, clarify that similar_by_views property is inactive

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ The following is a set of guidelines for contributing to BigCommerce's Developer
 
 The easiest way to edit a file is using GitHub's web interface:
 
-1. Navigate to the file in GitHub. For example, [making-requests.md](https://github.com/bigcommerce/docs/blob/main/CONTRIBUTING.md).
+1. Navigate to the file in GitHub. For example, [store-logs.mdx](https://github.com/bigcommerce/docs/blob/main/docs/api-docs/store-logs/store-logs.mdx).
 
 2. Click the **pencil** icon to **Edit This File**.
 3. Make the edit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ The following is a set of guidelines for contributing to BigCommerce's Developer
 
 The easiest way to edit a file is using GitHub's web interface:
 
-1. Navigate to the file in GitHub. For example, [making-requests.md](https://github.com/bigcommerce/dev-docs/blob/main/docs/api-docs/getting-started/making-requests.mdx).
+1. Navigate to the file in GitHub. For example, [making-requests.md](https://github.com/bigcommerce/docs/blob/main/CONTRIBUTING.md).
 
 2. Click the **pencil** icon to **Edit This File**.
 3. Make the edit.
@@ -32,7 +32,7 @@ That's it! You're done.
 
 For more complex changes, fork and edit locally:
 
-1. Fork `bigcommerce/dev-docs`.
+1. Fork `bigcommerce/docs`.
 
 2. `git clone` the fork to your local machine.
 
@@ -40,7 +40,7 @@ For more complex changes, fork and edit locally:
 
 4. Commit and push changes to your remote repo.
 
-5. Create a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork) to `bigcommerce:dev-docs/main`.
+5. Create a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork) to `bigcommerce:docs/main`.
 
 
 ## Commit Messages

--- a/docs/stencil-docs/reference-docs/front-matter-reference.mdx
+++ b/docs/stencil-docs/reference-docs/front-matter-reference.mdx
@@ -150,7 +150,7 @@ product:
 ```
 
 <Callout type="info">
-NOTE: The `similar_by_views` property is currently not enabled on the platform.
+NOTE: The `similar_by_views` property is not currently active.
 </Callout>
 
 

--- a/docs/stencil-docs/reference-docs/front-matter-reference.mdx
+++ b/docs/stencil-docs/reference-docs/front-matter-reference.mdx
@@ -149,6 +149,12 @@ product:
       limit: 10        # limits similar products by views to 10
 ```
 
+<Callout type="info">
+NOTE: similar_by_views is currently not enabled on the platform.
+</Callout>
+
+
+
 | Property | Description |
 |:---------|:------------|
 |`product`|When filtering/limiting, products' default sorting is by order id, from lowest to highest.|
@@ -156,7 +162,7 @@ product:
 |`images`|If `product.images` is not defined, you will not return images. If `product.images` is defined, you must also define `product.images.limit`, which throttles the number of images returned. The maximum allowable value for this parameter is five images.|
 |`reviews`|Boolean indicating whether to display product reviews. If `product.reviews` is present and is not explicitly set to `false`, reviews will appear. If not defined, defaults to 10 reviews. When filtering/limiting reviews, the default sorting is by review id, from lowest to highest. If a product has over 250 reviews, you can fetch the rest using the GraphQL Storefront API. See the example GraphQL query below.|
 |`related_products`|Displays products that are related by name. If `limit` absent or undefined, the default behavior is to display all related products. Inserting `limit` with no integer will display 0 products.|
-|`similar_by_views`|Displays products similar to those displayed in the current page context. If `limit` absent or undefined, the default is to display four products.|
+|`similar_by_views`|Displays products similar to those displayed in the current page context. If `limit` absent or undefined, the default is to display four products. (Currently disabled on the platform)|
   
 Sample GraphQL query for product reviews over the limit.
   
@@ -255,7 +261,12 @@ gql: "query productById($productId: Int!) {
   }
 }"
 ```
-  
+
+<Callout type="info">
+NOTE: similar_by_views is currently not enabled on the platform.
+</Callout>`
+
+
 We suggest testing GraphQL queries using the [storefront API playground](https://developer.bigcommerce.com/graphql-playground) to refine them before adding them to your template. If your query contains double quotes `"`, replace them with single quotes `'` or escape the double-quotes `\"`. You can launch the playground from your store by going to **Settings** >  **API** > **Storefront API Playground** in your store control panel.
 
   

--- a/docs/stencil-docs/reference-docs/front-matter-reference.mdx
+++ b/docs/stencil-docs/reference-docs/front-matter-reference.mdx
@@ -264,7 +264,7 @@ gql: "query productById($productId: Int!) {
 
 <Callout type="info">
 NOTE: The `similar_by_views` property is not currently active.
-</Callout>`
+</Callout>
 
 
 We suggest testing GraphQL queries using the [storefront API playground](https://developer.bigcommerce.com/graphql-playground) to refine them before adding them to your template. If your query contains double quotes `"`, replace them with single quotes `'` or escape the double-quotes `\"`. You can launch the playground from your store by going to **Settings** >  **API** > **Storefront API Playground** in your store control panel.

--- a/docs/stencil-docs/reference-docs/front-matter-reference.mdx
+++ b/docs/stencil-docs/reference-docs/front-matter-reference.mdx
@@ -150,7 +150,7 @@ product:
 ```
 
 <Callout type="info">
-NOTE: similar_by_views is currently not enabled on the platform.
+NOTE: The `similar_by_views` property is currently not enabled on the platform.
 </Callout>
 
 
@@ -162,7 +162,7 @@ NOTE: similar_by_views is currently not enabled on the platform.
 |`images`|If `product.images` is not defined, you will not return images. If `product.images` is defined, you must also define `product.images.limit`, which throttles the number of images returned. The maximum allowable value for this parameter is five images.|
 |`reviews`|Boolean indicating whether to display product reviews. If `product.reviews` is present and is not explicitly set to `false`, reviews will appear. If not defined, defaults to 10 reviews. When filtering/limiting reviews, the default sorting is by review id, from lowest to highest. If a product has over 250 reviews, you can fetch the rest using the GraphQL Storefront API. See the example GraphQL query below.|
 |`related_products`|Displays products that are related by name. If `limit` absent or undefined, the default behavior is to display all related products. Inserting `limit` with no integer will display 0 products.|
-|`similar_by_views`|Displays products similar to those displayed in the current page context. If `limit` absent or undefined, the default is to display four products. (Currently disabled on the platform)|
+|`similar_by_views`|Displays products similar to those displayed in the current page context. If `limit` absent or undefined, the default is to display four products. Currently disabled on the platform. |
   
 Sample GraphQL query for product reviews over the limit.
   
@@ -263,7 +263,7 @@ gql: "query productById($productId: Int!) {
 ```
 
 <Callout type="info">
-NOTE: similar_by_views is currently not enabled on the platform.
+NOTE: The `similar_by_views` property is not currently active.
 </Callout>`
 
 

--- a/docs/stencil-docs/storefront-customization/using-front-matter.mdx
+++ b/docs/stencil-docs/storefront-customization/using-front-matter.mdx
@@ -62,6 +62,10 @@ products:
 ```
 
 <Callout type="info">
+NOTE: similar_by_views is currently not enabled on the platform.
+</Callout>
+
+<Callout type="info">
   #### Filtering for Faster Page Loads
   To keep your pages lightweight, specify only the attributes you need per page. Also, use the limit key (with appropriate values) for attributes that accept it.
 </Callout>

--- a/docs/stencil-docs/storefront-customization/using-front-matter.mdx
+++ b/docs/stencil-docs/storefront-customization/using-front-matter.mdx
@@ -62,7 +62,7 @@ products:
 ```
 
 <Callout type="info">
-NOTE: similar_by_views is currently not enabled on the platform.
+NOTE: The `similar_by_views` property is not currently active.
 </Callout>
 
 <Callout type="info">


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-]

Updates to status related to similar_by_views being disabled on the platform currently.


## What changed?
<!-- Provide a bulleted list in the present tense -->
*  Contributing.md updated with latest repository url.
*  Added callouts to pages referencing the `similar_by_views` being currently disabled on BC platform and that no data will be returned.

## Release notes draft
Reduce requests to BC support asking why the `customers also viewed` functionality is not working.


## Anything else?

Related to Merchant support ticket #07492972

