### PR TITLE
[DEVDOCS-5319]: [revise] Catalog/Products/Metafields, Update platform limits across Metafield endpoints

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -6981,7 +6981,7 @@ components:
     metafield_Base:
       title: metafield_Base
       type: object
-      description: 'Metafield for products, categories, variants, and brands; the max number of metafields allowed on each is 50. For more information, see [Platform Limits](https://support.bigcommerce.com/s/article/Platform-Limits) in the Help Center.'
+      description: 'Metafield for products, categories, variants, and brands; the max number of metafields allowed on each is 250. For more information, see [Platform Limits](https://support.bigcommerce.com/s/article/Platform-Limits) in the Help Center.'
       x-internal: false
       properties:
         key:


### PR DESCRIPTION
# [DEVDOCS-5319]


## What changed?

* Update limit from 50 to 250 across the metafield endpoints

## Release notes draft

* Correction: Corrected Metafield endpoint limits to reflect accurate limits from 50 to 250. 

## Anything else?



[DEVDOCS-5319]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ