### PR TITLE
DEVDOCS-5641 [update]: Tax Provider API, remove full refund from Adjust endpoint

### DIFF
--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -310,7 +310,7 @@ paths:
     post:
       summary: Void Tax Quote
       description: |- 
-        Invalidate the persisted tax quote as identified by the given unique ID. Relevant to order cancellations or when moving an order from a paid status to an unpaid status.
+        Invalidate the persisted tax quote as identified by the given unique ID. Relevant to order cancellations, full refunds, or moving an order from a paid status to an unpaid status.
 
         > Server URL
         > - For supporting tax providers, the server URL contains the tax provider's profile field; for example, `your_profile.example.com`.

--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -843,7 +843,7 @@ paths:
       description: |-
         Replace the persisted tax quote (identified by the given unique ID) with the provided quote request (represented by the **AdjustRequest**).
 
-        Relevant for partial refunds, full refunds, returns, and other Order modifications where there have been changes to the tax liabilities.
+        Relevant for returns, partial refunds, and other Order modifications where there have been changes to the tax liabilities.
 
         The returned **Tax Quote** response is expected to be the same to a response returned by an equivalent response to **estimate** or **commit** methods.
 


### PR DESCRIPTION
# [DEVDOCS-5641]

## What changed?
* remove full refund for description of Adjust endpoint (Tax Provider API)
* add full refund for description of Void endpoint (Tax Provider API)

[DEVDOCS-5641]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ