### PR TITLE
(no ticket): [external] node-sass, correct scss-autofix commands

### DIFF
--- a/docs/stencil-docs/installing-stencil-cli/node-sass.mdx
+++ b/docs/stencil-docs/installing-stencil-cli/node-sass.mdx
@@ -25,13 +25,13 @@ stencil bundle
 a. Use the "dry run" option to see potential changes without making or saving those changes.
 
 ```shell copy
-stencil -scss-autofix.js --dry
+stencil scss-autofix --dry
 ```
 
 b. To make the changes and revalidate, run the following:
   
 ```shell copy
-stencil -scss-autofix.js
+stencil scss-autofix
 ```
 
 ```shell copy


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-]
These commands are not recognized using the latest version of the stencil-cli. The command that works is `stencil scss-autofix`.

## What changed?
<!-- Provide a bulleted list in the present tense -->
* Updated the autofix-scss commands since the listed commands do not work in  the latest version of the stencil cli

## Release notes draft

Fixed typos in the stencil cli autofix-scss commands

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}
