### PR TITLE
ISSUE-1468: [update] Catalog, remove caveat about swatch defaults

### DIFF
--- a/reference/catalog/product-modifiers_catalog.v3.yml
+++ b/reference/catalog/product-modifiers_catalog.v3.yml
@@ -365,7 +365,7 @@ paths:
                                   is_default:
                                     type: boolean
                                     description: |
-                                      The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                                      The flag for preselecting a value as the default on the storefront.
                                     example: false
                                   label:
                                     type: string
@@ -670,7 +670,7 @@ paths:
                                         is_default:
                                           type: boolean
                                           description: |
-                                            The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                                            The flag for preselecting a value as the default on the storefront.
                                           example: false
                                         label:
                                           type: string
@@ -1300,7 +1300,7 @@ paths:
                                         is_default:
                                           type: boolean
                                           description: |
-                                            The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                                            The flag for preselecting a value as the default on the storefront.
                                           example: false
                                         label:
                                           type: string
@@ -1613,7 +1613,7 @@ paths:
                         is_default:
                           type: boolean
                           description: |
-                            The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                            The flag for preselecting a value as the default on the storefront.
                           example: false
                         label:
                           type: string
@@ -1721,7 +1721,7 @@ paths:
                               is_default:
                                 type: boolean
                                 description: |
-                                  The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                                  The flag for preselecting a value as the default on the storefront.
                                 example: false
                               label:
                                 type: string
@@ -1993,7 +1993,7 @@ paths:
                         is_default:
                           type: boolean
                           description: |
-                            The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                            The flag for preselecting a value as the default on the storefront.
                           example: false
                         label:
                           type: string
@@ -2109,7 +2109,7 @@ paths:
                               is_default:
                                 type: boolean
                                 description: |
-                                  The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                                  The flag for preselecting a value as the default on the storefront.
                                 example: false
                               label:
                                 type: string
@@ -2481,7 +2481,7 @@ components:
         is_default:
           type: boolean
           description: |
-            The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+            The flag for preselecting a value as the default on the storefront.
           example: false
         label:
           type: string

--- a/reference/catalog/product-variant-options_catalog.v3.yml
+++ b/reference/catalog/product-variant-options_catalog.v3.yml
@@ -351,7 +351,7 @@ paths:
                               is_default:
                                 type: boolean
                                 description: |
-                                  The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                                  The flag for preselecting a value as the default on the storefront.
                                 example: false
                               label:
                                 type: string
@@ -600,7 +600,7 @@ paths:
                                     is_default:
                                       type: boolean
                                       description: |
-                                        The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                                        The flag for preselecting a value as the default on the storefront.
                                       example: false
                                     label:
                                       type: string
@@ -1065,7 +1065,7 @@ paths:
                               is_default:
                                 type: boolean
                                 description: |
-                                  The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                                  The flag for preselecting a value as the default on the storefront.
                                 example: false
                               label:
                                 type: string
@@ -1315,7 +1315,7 @@ paths:
                                     is_default:
                                       type: boolean
                                       description: |
-                                        The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                                        The flag for preselecting a value as the default on the storefront.
                                       example: false
                                     label:
                                       type: string
@@ -1528,7 +1528,7 @@ paths:
                             is_default:
                               type: boolean
                               description: |
-                                The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                                The flag for preselecting a value as the default on the storefront.
                               example: false
                             label:
                               type: string
@@ -1643,7 +1643,7 @@ paths:
                     is_default:
                       type: boolean
                       description: |
-                        The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                        The flag for preselecting a value as the default on the storefront.
                       example: false
                     label:
                       type: string
@@ -1690,7 +1690,7 @@ paths:
                           is_default:
                             type: boolean
                             description: |
-                              The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                              The flag for preselecting a value as the default on the storefront.
                             example: false
                           label:
                             type: string
@@ -1818,7 +1818,7 @@ paths:
                           is_default:
                             type: boolean
                             description: |
-                              The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                              The flag for preselecting a value as the default on the storefront.
                             example: false
                           label:
                             type: string
@@ -1925,7 +1925,7 @@ paths:
                     is_default:
                       type: boolean
                       description: |
-                        The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                        The flag for preselecting a value as the default on the storefront.
                       example: false
                     label:
                       type: string
@@ -1980,7 +1980,7 @@ paths:
                           is_default:
                             type: boolean
                             description: |
-                              The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+                              The flag for preselecting a value as the default on the storefront.
                             example: false
                           label:
                             type: string
@@ -2160,7 +2160,7 @@ components:
         is_default:
           type: boolean
           description: |
-            The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+            The flag for preselecting a value as the default on the storefront.
           example: false
         label:
           type: string

--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -6362,7 +6362,7 @@ components:
         is_default:
           type: boolean
           description: |
-            The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+            The flag for preselecting a value as the default on the storefront.
           example: false
         label:
           type: string
@@ -6812,7 +6812,7 @@ components:
         is_default:
           type: boolean
           description: |
-            The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
+            The flag for preselecting a value as the default on the storefront.
           example: false
         label:
           type: string


### PR DESCRIPTION
# [bigcommerce/api-specs issue-1468](https://github.com/bigcommerce/api-specs/issues/1468)

## What changed?
* remove incorrect caveat about swatch defaults

## Release notes draft
* Removed an incorrect caveat about swatch defaults. It is possible to set a default value for swatch options and modifiers.

## Anything else?
* [bigcommerce/api-specs issue-1468](https://github.com/bigcommerce/api-specs/issues/1468)

ping @bobbyshaw @kristinapototska
