### PR TITLE
Update meta_keywords descriptions and examples for brands_catalog.v3

### DIFF
--- a/reference/catalog/brands_catalog.v3.yml
+++ b/reference/catalog/brands_catalog.v3.yml
@@ -185,8 +185,8 @@ paths:
                     page_title: OFS
                     meta_keywords:
                       - modern
-                      - ' clean'
-                      - ' contemporary'
+                      - clean
+                      - contemporary
                     meta_description: OFS is a modern brand.
                     image_url: ''
                     search_keywords: 'kitchen, laundry, cart, storage'
@@ -392,10 +392,13 @@ paths:
                 meta_keywords:
                   type: array
                   description: |
-                    Comma-separated list of meta keywords to include in the HTML.
+                    An array of meta keywords to include in the HTML.
                   items:
                     type: string
-                    example: 'modern, clean, contemporary'
+                  example: 
+                    - modern
+                    - clean
+                    - contemporary
                 meta_description:
                   maxLength: 65535
                   minLength: 0
@@ -473,10 +476,13 @@ paths:
                       meta_keywords:
                         type: array
                         description: |
-                          Comma-separated list of meta keywords to include in the HTML.
+                          An array of meta keywords to include in the HTML.
                         items:
                           type: string
-                          example: 'modern, clean, contemporary'
+                        example: 
+                          - modern
+                          - clean
+                          - contemporary
                       meta_description:
                         maxLength: 65535
                         minLength: 0
@@ -526,7 +532,9 @@ paths:
                   id: 50
                   name: Common Good
                   meta_keywords:
-                    - 'modern, clean, contemporary'
+                    - modern
+                    - clean
+                    - contemporary
                   meta_description: Common Good is a modern brand
                   image_url: ''
                   search_keywords: 'kitchen, laundry, cart, storage'
@@ -660,7 +668,9 @@ paths:
                   id: 50
                   name: Common Good
                   meta_keywords:
-                    - 'modern, clean, contemporary'
+                    - modern
+                    - clean
+                    - contemporary
                   meta_description: Common Good is a modern brand
                   image_url: ''
                   search_keywords: 'kitchen, laundry, cart, storage'
@@ -740,11 +750,13 @@ paths:
                 meta_keywords:
                   type: array
                   description: |
-                    Comma-separated list of meta keywords to include in the HTML.
-                  example:
-                    - 'modern, clean, contemporary'
+                    An array of meta keywords to include in the HTML.
                   items:
                     type: string
+                  example:
+                    - modern
+                    - clean
+                    - contemporary
                 meta_description:
                   maxLength: 65535
                   minLength: 0
@@ -823,11 +835,13 @@ paths:
                       meta_keywords:
                         type: array
                         description: |
-                          Comma-separated list of meta keywords to include in the HTML.
-                        example:
-                          - 'modern, clean, contemporary'
+                          An array of meta keywords to include in the HTML.
                         items:
                           type: string
+                        example:
+                          - modern
+                          - clean
+                          - contemporary
                       meta_description:
                         maxLength: 65535
                         minLength: 0
@@ -877,7 +891,9 @@ paths:
                   id: 50
                   name: Common Good
                   meta_keywords:
-                    - 'modern, clean, contemporary'
+                    - modern
+                    - clean
+                    - contemporary
                   meta_description: Common Good is a modern brand
                   image_url: ''
                   search_keywords: 'kitchen, laundry, cart, storage'
@@ -1604,10 +1620,13 @@ components:
         meta_keywords:
           type: array
           description: |
-            Comma-separated list of meta keywords to include in the HTML.
+            An array of meta keywords to include in the HTML.
           items:
             type: string
-            example: 'modern, clean, contemporary'
+          example:
+            - modern
+            - clean
+            - contemporary
         meta_description:
           maxLength: 65535
           minLength: 0


### PR DESCRIPTION
While working through the API I noticed the description and examples for meta_kaywords don't reflect what is received back from the actual request. This hopefully should fix that.