### PR TITLE
feat(payment): PAYPAL-3377 Add support of braintree.ach in payments API

### DIFF
--- a/docs/api-docs/payments/payments-api-overview.mdx
+++ b/docs/api-docs/payments/payments-api-overview.mdx
@@ -95,7 +95,7 @@ To learn more about the BigCommerce-compatible features of these gateways, see [
 
 ## Stored cards, PayPal and bank accounts
 
-There are three steps to using a stored card, PayPal or bank account to make a payment.
+There are three steps to using a stored card, PayPal, or bank account to make a payment.
 
 1. [Get Payment Methods](/docs/rest-payments/methods#get-accepted-payment-methods)
 2. [Create a Payment Access Token](/docs/rest-payments/tokens#create-payment-access-token) or request a payment access token when you complete checkout with the [GraphQL Storefront API](/docs/storefront/cart-checkout/guide/graphql-storefront#handling-payments)
@@ -118,9 +118,9 @@ Use the active MSF-enabled store's control panel to enable charging stored credi
 
 ### Using Braintree ACH stored bank accounts
 
-Additionally to previous prerequisites, in order to use Braintree ACH in payments API your store need to:
-* have stored ACH accounts enabled.
-* contact support to enable this method in API.
+In addition to the [prerequisites](/docs/store-operations/payments#prerequisites-for-charging-stored-payment-instruments) above, to use Braintree ACH in payments API, your store needs to:
+* Have stored ACH accounts enabled.
+* Have this method enabled in the API. (contact support)
 
 ### Charging stored instruments
 

--- a/docs/api-docs/payments/payments-api-overview.mdx
+++ b/docs/api-docs/payments/payments-api-overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Payments API
-keywords: payments, bigpay, currencies, currency, rest, v3, payment access token, pat, rate limits, 
+keywords: payments, bigpay, currencies, currency, rest, v3, payment access token, pat, rate limits,
 ---
 
 # Payments API
@@ -52,14 +52,14 @@ The following table lists the payment gateways that are compatible with our publ
 | Bolt              | &check;            | &check;         |
 | CardConnect       |                    | &check;         |
 | Chase Integrated Payments |            | &check;         |
-| Chase Merchant Services   | &check;    | &check;         | 
+| Chase Merchant Services   | &check;    | &check;         |
 | Checkout.com      | &check;            | &check;         |
 | Commonwealth Bank | &check;            | &check;         |
 | Cybersource       | &check;            | &check;         |
 | Cybersource V2    | &check;            | &check;         |
 | Eway Rapid        |                    | &check;         |
 | First Data Payeezy Gateway |           | &check;         |
-| Heartland Payment Systems  |           | &check;         | 
+| Heartland Payment Systems  |           | &check;         |
 | Mercado Pago      |                    | &check;         |
 | MIGS              |                    | &check;         |
 | Mollie            | &check;            |                 |
@@ -91,11 +91,11 @@ The following table lists the payment gateways that are compatible with our publ
 The Payments API does not support the [BigCommerce Test Payment Gateway](https://support.bigcommerce.com/s/article/Testing-Shipping-Tax-and-Payment-Settings?language=en_US#test-gateway).
 </Callout>
 
-To learn more about the BigCommerce-compatible features of these gateways, see [All Available Payment Gateways](https://support.bigcommerce.com/s/article/Available-Payment-Gateways#all-available). 
+To learn more about the BigCommerce-compatible features of these gateways, see [All Available Payment Gateways](https://support.bigcommerce.com/s/article/Available-Payment-Gateways#all-available).
 
-## Stored cards and PayPal accounts
+## Stored cards, PayPal and bank accounts
 
-There are three steps to using a stored card or PayPal account to make a payment.
+There are three steps to using a stored card, PayPal or bank account to make a payment.
 
 1. [Get Payment Methods](/docs/rest-payments/methods#get-accepted-payment-methods)
 2. [Create a Payment Access Token](/docs/rest-payments/tokens#create-payment-access-token) or request a payment access token when you complete checkout with the [GraphQL Storefront API](/docs/storefront/cart-checkout/guide/graphql-storefront#handling-payments)
@@ -115,6 +115,12 @@ The store must:
 * have stored credit cards enabled.
 
 Use the active MSF-enabled store's control panel to enable charging stored credit cards. Navigate to **Settings ›  Setup > Payments** and click the tab for your payment gateway. Toggle the switch to enable Stored Credit Cards and click **Save**. For more on enabling stored payment methods, see [Enabling Stored Payment Methods](https://support.bigcommerce.com/s/article/Enabling-Stored-Credit-Cards).
+
+### Using Braintree ACH stored bank accounts
+
+Additionally to previous prerequisites, in order to use Braintree ACH in payments API your store need to:
+* have stored ACH accounts enabled.
+* contact support to enable this method in API.
 
 ### Charging stored instruments
 
@@ -294,7 +300,7 @@ Content-Type: application/json
 }
 ```
 
-To process a payment using a stored PayPal account, set the `type` to `stored_paypal_account`. 
+To process a payment using a stored PayPal account, set the `type` to `stored_paypal_account`.
 
 <Tabs items={['Request', 'Response']}>
 <Tab>
@@ -608,9 +614,9 @@ Yes, checkouts and orders with more than one consignment can use the Payments AP
 
 **Is store credit supported?**
 
-Yes, the Payments API supports the store credit payment method under the following conditions: 
-- The shopper is transacting in the store's default currency. 
-- The shopper has a positive store credit balance. 
+Yes, the Payments API supports the store credit payment method under the following conditions:
+- The shopper is transacting in the store's default currency.
+- The shopper has a positive store credit balance.
 
 Store credit is _not_ available for orders created by guest shoppers.
 

--- a/reference/payments/process_payments.yml
+++ b/reference/payments/process_payments.yml
@@ -3,12 +3,12 @@ info:
   version: ''
   title: Payment Processing
   description: |
-    > The Payments API processes payments using payment instruments such as credit cards or PayPal accounts. To learn more about Payments, see the [Payments Overview](/docs/store-operations/payments). 
+    > The Payments API processes payments using payment instruments such as credit cards or PayPal accounts. To learn more about Payments, see the [Payments Overview](/docs/store-operations/payments).
 
     The Payment Processing API uses BigCommerce's PCI-compliant payments server and a supported payment gateway to charge customers. The payment portal you choose may support charging stored instruments and/or making refund transactions. For a list of compatible payment gateways, as well as a guide through the API call sequence needed to make charges, see the [Payments Overview](/docs/store-operations/payments#compatible-payment-gateways).
 
     A Payment Access Token (_PAT_) is required to authorize payment processing requests. The X-Auth-Token header is not required in requests to the payment processing endpoint. To generate a PAT, use the [Create a Payment Access Token](/docs/rest-payments/tokens#create-payment-access-token) endpoint or the `completeCheckout` mutation in the [GraphQL Storefront API](/docs/storefront/cart-checkout/guide/graphql-storefront#handling-payments). For a payment processing authentication example request, see the related section in our [Authentication article](/docs/start/authentication#bigcommerce-generated-jwts).
-    
+
     Also note that payment processing requests use the BigCommerce Payments Gateway, which uses a different server than our other REST APIs. Please see the server URL for the payment processing endpoint.
 
     > To learn more about authenticating Payments endpoints, locate the **Authentication** section at the top of each endpoint, then click **Show Details**.
@@ -18,15 +18,15 @@ info:
     * [Payments Overview](/docs/store-operations/payments)
     * [Process payments authentication example request](/docs/start/authentication#bigcommerce-generated-jwts)
     * [Orders Overview](/docs/store-operations/orders)
-    
+
      ### Webhooks
-    
+
     * [Carts](https://developer.bigcommerce.com/api-docs/channels/guide/webhooks#carts)
     * [Orders](https://developer.bigcommerce.com/api-docs/store-management/webhooks/webhook-events#orders)
     * [Price list assignment](https://developer.bigcommerce.com/api-docs/channels/guide/webhooks#price-list-assignments)
 
     ### Additional Payments endpoints
-    
+
     * [Get accepted payment methods](/docs/rest-payments/methods#get-accepted-payment-methods)
     * [Create a Payment Access Token](/docs/rest-payments/tokens#create-payment-access-token)
     * [Get a customer's stored instruments](/docs/rest-management/customers/customer-stored-instruments#get-stored-instruments)
@@ -81,6 +81,7 @@ paths:
                         - $ref: '#/components/schemas/GiftCertificate'
                         - $ref: '#/components/schemas/StoreCredit'
                         - $ref: '#/components/schemas/TokenizedCard'
+                        - $ref: '#/components/schemas/StoredBankAccount'
                     payment_method_id:
                       description: Identifier for payment method that will be used for this payment and `id` from the Get Accepted Payment Methods API
                       type: string
@@ -121,6 +122,13 @@ paths:
                       type: stored_paypal_account
                       token: 2c129313bcffe4501ec5fa2764c8c16320e38c7ba9e8cdf95583b541bb05ad91
                     payment_method_id: braintree.paypal
+              Stored Bank Account:
+                value:
+                  payment:
+                    instrument:
+                      type: stored_bank_account
+                      token: 2c129313bcffe4501ec5fa2764c8c16320e38c7ba9e8cdf95583b541bb05ad91
+                    payment_method_id: braintree.ach
               Gift Certificate:
                 value:
                   payment:
@@ -136,7 +144,7 @@ paths:
                     payment_method_id: bigcommerce.store_credit
               Tokenized Card:
                 value:
-                  payment: 
+                  payment:
                     instrument:
                       type: tokenized_card
                       token: K7KW-M9GX-6PQ3
@@ -475,6 +483,25 @@ components:
         example-1:
           type: stored_paypal_account
           token: stringstringstringstringstringstringstringstringstringstringstri
+    StoredBankAccount:
+      title: StoredBankAccount
+      type: object
+      x-internal: false
+      properties:
+        type:
+          type: string
+          description: Type to classify this payment instrument (required)
+          enum:
+            - stored_bank_account
+        token:
+          description: Identifier representing this stored bank account (required)
+          type: string
+          minLength: 64
+          maxLength: 64
+      x-examples:
+        example-1:
+          type: stored_bank_account
+          token: stringstringstringstringstringstringstringstringstringstringstri
     GiftCertificate:
       title: GiftCertificate
       type: object
@@ -545,15 +572,15 @@ components:
         The required scopes are granted to the `payment_access_token` upon generation.
 
         ### Authentication header
-        
+
         | Header | Argument | Description |
         |:-------|:---------|:------------|
         |`Authorization`|`PAT {{PAYMENT_ACCESS_TOKEN}}`| Obtained using the Create Access Token endpoint.|
 
         ### Further reading
-        
+
         For an outline of the Process Payment API call flow and more information about authenticating, see [Authentication and Example Requests](/docs/start/authentication#bigcommerce-generated-jwts).
-        
+
         For a list of API status codes, see [API Status Codes](/docs/start/about/status-codes).
       type: http
       scheme: bearer


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [PAYPAL-3377]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Added bank account instrument to payments API doc.
* Added Braintree ACH block to payments overview. 

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[PAYPAL-3377]: https://bigcommercecloud.atlassian.net/browse/PAYPAL-3377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ