### PR TITLE
ISSUE-57: [update] Catalog Category Tree Categories, change id to category_id

### DIFF
--- a/reference/catalog/category-trees_catalog.v3.yml
+++ b/reference/catalog/category-trees_catalog.v3.yml
@@ -144,7 +144,7 @@ paths:
                 example-1:
                   value:
                     data:
-                      - id: 0
+                      - category_id: 0
                         parent_id: 2
                         name: Bath
                         description: <p>We offer a wide variety of products perfect for relaxing</p>
@@ -564,7 +564,7 @@ components:
         - Models
       title: Category
       allOf:
-        - $ref: '#/components/schemas/id'
+        - $ref: '#/components/schemas/category_id'
         - $ref: '#/components/schemas/parent_id'
         - $ref: '#/components/schemas/name'
         - $ref: '#/components/schemas/description'
@@ -1067,11 +1067,11 @@ components:
           type: string
           description: |
             Custom meta description for the category page. If not defined, the store's default meta description will be used.
-    id:
-      title: id
+    category_id:
+      title: category_id
       type: object
       properties:
-        id:
+        category_id:
           type: integer
           description: |-
             Unique ID of the *Category*. Increments sequentially.


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# ISSUE-57
* #57


## What changed?
<!-- Provide a bulleted list in the present tense -->
* change id to category_id where appropriate

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* We fixed a bug in the Category Trees spec that incorrectly described a category response object as containing `id`s, rather than `categories`. Thanks to @atensoftware for raising this in Issue 57!

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}
