### PR TITLE
[DEVDOCS-5379]: [update] OrdersV2, Order/id/ PUT needs clarification about the default behavior in the description

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -97,7 +97,7 @@ paths:
         
         To remove a product from an order, set that product’s `quantity` to `0`.
 
-        All discounts and promotions applied to the order are cleared after the update. Since the order data syncs with other ERP systems, like Amazon or eBay, the updated order recalculates to the default setting and removes any applied discounts.
+        All discounts and promotions applied to the order are cleared after the update. Since the order data syncs with other ERP systems, like Amazon or eBay, the updated order returns to the default setting removing any applied discounts.
         
         To learn more about creating or updating orders, see [Orders Overview](/docs/store-operations/orders).
       summary: Update an Order

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -97,7 +97,7 @@ paths:
         
         To remove a product from an order, set that product’s `quantity` to `0`.
 
-After the update, the PUT request clears all discounts and promotions applied to the order. Since the order data syncs with other ERP systems, like Amazon or eBay, the updated order returns to the default setting, removing any applied discounts.
+        After the update, the PUT request clears all discounts and promotions applied to the order. Since the order data syncs with other ERP systems, like Amazon or eBay, the updated order returns to the default setting, removing any applied discounts.
         
         To learn more about creating or updating orders, see [Orders Overview](/docs/store-operations/orders).
       summary: Update an Order

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -97,7 +97,7 @@ paths:
         
         To remove a product from an order, set that product’s `quantity` to `0`.
 
-        All discounts and promotions applied to the order are cleared after the update. Since the order data syncs with other ERP systems, like Amazon or eBay, the updated order returns to the default setting removing any applied discounts.
+After the update, the PUT request clears all discounts and promotions applied to the order. Since the order data syncs with other ERP systems, like Amazon or eBay, the updated order returns to the default setting, removing any applied discounts.
         
         To learn more about creating or updating orders, see [Orders Overview](/docs/store-operations/orders).
       summary: Update an Order


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-5379]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Add the default PUT behavior for OrdersV2 in the endpoint description

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* Does this need one if it's an omission?

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @bc-vincent-zhao 


[DEVDOCS-5379]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ