### PR TITLE
PSE-904:[update] Catalog Brands, add some missing titles

### DIFF
--- a/reference/catalog/brands_catalog.v3.yml
+++ b/reference/catalog/brands_catalog.v3.yml
@@ -1509,6 +1509,7 @@ paths:
           content:
             application/json:
               schema:
+                title: Brand Image Response
                 type: object
                 properties:
                   data:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [PSE-904](https://bigcommercecloud.atlassian.net/browse/PSE-904)

## What changed?
Added some missing title fields to catalog brands API spec. 

## Release notes draft
These additions will allow for better type naming for code clients auto-generated from the spec. 

Changes types "InlineResponse200" to "BrandImageResponse"


[PSE-904]: https://bigcommercecloud.atlassian.net/browse/PSE-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ