### PR TITLE
PSE-909: [update] Better return type for Mult-Status response

### DIFF
--- a/reference/catalog/product-variants_catalog.v3.yml
+++ b/reference/catalog/product-variants_catalog.v3.yml
@@ -338,14 +338,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  data:
-                    $ref: '#/components/schemas/productVariant_Full'
-                  errors: 
-                    $ref: '#/components/schemas/errorMultiStatus'
-                  meta:
-                    $ref: '#/components/schemas/metaCollection_Full'
+                $ref: '#/components/schemas/MultiStatus'
         '404':
           description: |
             The resource was not found.
@@ -521,14 +514,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  data:
-                    $ref: '#/components/schemas/productVariant_Full'
-                  errors: 
-                    $ref: '#/components/schemas/errorMultiStatus'
-                  meta:
-                    $ref: '#/components/schemas/metaCollection_Full'
+                $ref: '#/components/schemas/MultiStatus'
         '404':
           description: |
             The resource was not found.
@@ -2214,6 +2200,15 @@ components:
           $ref: '#/components/schemas/pagination_Full'
       description: 'Data about the response, including pagination and collection totals.'
       x-internal: false
+    MultiStatus:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/productVariant_Full'
+        errors: 
+          $ref: '#/components/schemas/errorMultiStatus'
+        meta:
+          $ref: '#/components/schemas/metaCollection_Full'
     pagination_Full:
       title: pagination_Full
       type: object


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [PSE-909](https://bigcommercecloud.atlassian.net/browse/PSE-909)

## What changed?
Added some missing title fields to catalog product-variants API spec. 

## Release notes draft
These additions will allow for better type naming for code clients 
Changes types "InlineResponse2007" to "MultiStatus"

[PSE-909]: https://bigcommercecloud.atlassian.net/browse/PSE-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ