### PR TITLE
Fix invalid schema in categories_catalog.v3.yml

### DIFF
--- a/reference/catalog/categories_catalog.v3.yml
+++ b/reference/catalog/categories_catalog.v3.yml
@@ -1733,7 +1733,6 @@ paths:
           description: The requested category was not found.
           content:
             application/json:
-              title: Not Found 
               schema:
                 $ref: '#/components/schemas/error_Base'
     put:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
n/a


## What changed?
Remove invalid `title` schema field in `categories_catalog.v3.yml`

While working on an internal tool, I noticed that the swagger parser began failing after pulling the latest API schema due to this file.

## Release notes draft
 * Fixed `categories_catalog.v3.yml` to ensure it is a valid Swagger format

## Anything else?
n/a

ping {names}
