### PR TITLE
DEVDOCS-5756: [new] Store Information, add storefront limits

### DIFF
--- a/reference/settings.v3.yml
+++ b/reference/settings.v3.yml
@@ -2227,7 +2227,8 @@ components:
       title: ScopeIdentifier
       x-internal: false
     StoreProfile:
-      description: 'The basic profile settings for a store, used to give the shopper information about the business from which they are purchasing.'
+      title: Store Profile
+      description: The basic profile settings for a store, used to give the shopper information about the business from which they are purchasing.
       type: object
       x-internal: false
       properties:

--- a/reference/store_information.v2.yml
+++ b/reference/store_information.v2.yml
@@ -88,6 +88,9 @@ paths:
                       sitewidehttps_enabled: false
                       facebook_catalog_id: ''
                       checkout_type: optimized
+                      storefront_limits: 
+                        active: 3
+                        total_including_inactive: 4
   '/time':
     get:
       description: Returns the system timestamp at the time of the request. The time resource is useful for validating API authentication details and testing client connections.
@@ -303,6 +306,22 @@ components:
               type: boolean
             wishlists_enabled:
               type: boolean
+            storefront_limits:
+              type: object
+              properties:
+                active:
+                  type: integer
+                  minimum: 1
+                  default: 1
+                  example: 3
+                  description: -|
+                    Describes the number of storefronts active on the store. If `multi_storefront_enabled` is `false`, this value is `1`.
+                total_including_inactive:
+                  type: integer
+                  minimum: 1
+                  example: 15
+                  description: -|
+                    Describes the total number of storefronts associated with the store, including both active and inactive storefronts. The default varies based on store plan.
         account_uuid:
           type: string
         default_channel_id:

--- a/reference/store_information.v2.yml
+++ b/reference/store_information.v2.yml
@@ -23,7 +23,8 @@ tags:
 paths:
   '/store':
     get:
-      description: Returns metadata about a store.
+      description: -|
+        Returns metadata about the global settings for a store. Some of these values are independently configurable on a per-storefront or per-channel basis. For channel overrides, see [Store Settings](/docs/rest-management/settings).
       summary: Get Store Information
       operationId: getStoreInformation
       tags:
@@ -85,9 +86,13 @@ paths:
                     active_comparison_modules: []
                     features:
                       stencil_enabled: true
-                      sitewidehttps_enabled: false
+                      sitewidehttps_enabled: true
                       facebook_catalog_id: ''
                       checkout_type: optimized
+                      wishlists_enabled: true
+                      graphql_storefront_api_enabled: true
+                      shopper_consent_tracking_enabled: true
+                      multi_storefront_enabled: true
                       storefront_limits: 
                         active: 3
                         total_including_inactive: 4
@@ -278,34 +283,48 @@ components:
             + `facebook_catalog_id` (string)
           type: object
           properties:
-            checkout_type:
-              type: string
-              example: optimized
-              description: 'What type of checkout is enabled on the store. Possible values returned are optimized, single (one page), single_customizable (one page for developers), klarna.'
-            facebook_catalog_id:
-              type: string
-              description: ID of the facebook by meta catalog. If there is none, it returns an empty string.
-            graphql_storefront_api_enabled:
-              type: boolean
             stencil_enabled:
               type: boolean
               example: true
+              default: true
               description: Indicates whether a store is using a Stencil theme.
             sitewidehttps_enabled:
               type: boolean
               example: false
               description: Indicates whether there is site-wide https.
-            multi_storefront_enabled:
-              type: boolean
-              description: |-
-                Indicates whether MSF feature flag is enabled on a store.
-
-                Returns `true` when MSF feature flag is enabled.
-                Returns `false` when MSF feature flag is disabled.
-            shopper_consent_tracking_enabled:
-              type: boolean
+            facebook_catalog_id:
+              type: string
+              description: The ID of the Facebook by Meta catalog. If there is none, this endpoint returns an empty string.
+            checkout_type:
+              type: string
+              example: optimized
+              description: -|
+                What type of checkout is enabled on the store. Possible values returned are optimized, single (one page), single_customizable (one page for developers), klarna.
+              enum:
+                - optimized
+                - single
+                - single_customizable
+                - klarna
             wishlists_enabled:
               type: boolean
+              example: false
+            graphql_storefront_api_enabled:
+              type: boolean
+              default: true
+              example: true
+              description: -|
+                Describes whether you can use the [GraphQL Storefront API](/graphql-storefront/reference) on this store.
+            shopper_consent_tracking_enabled:
+              type: boolean
+              example: true
+              description: -|
+                Indicates whether the store is tracking the values of the cookie and privacy consent settings that the shopper consented to and configured.
+            multi_storefront_enabled:
+              type: boolean
+              example: true
+              default: false
+              description: |-
+                Indicates whether the storeʼs plan provides the possibility of using more than one storefront or sales channel. Internally, this value indicates whether the store has the MSF feature flag enabled. 
             storefront_limits:
               type: object
               properties:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-5756]

## What changed?
<!-- Provide a bulleted list in the present tense -->
* Store Information
  * add storefront limits
  * add detail to the rest of the schema
* Store Settings
  * add schema title


## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* The [Get store information](/docs/rest-management/store-information) endpoint now returns information about storefront limits! The new data includes the number of active storefronts and the total number of storefronts, including inactive ones.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @njb and @bc-traciporter this one has release notes


[DEVDOCS-5756]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ