### PR TITLE
(no ticket): [update] Webhooks, remove empty allOf sections

### DIFF
--- a/reference/webhooks.v3.yml
+++ b/reference/webhooks.v3.yml
@@ -1162,7 +1162,6 @@ components:
       description: |
         Fires for all `store/category` events.
       x-examples: {}
-      allOf: []
       x-tags:
         - created
       x-internal: false
@@ -1293,7 +1292,6 @@ components:
     store_channel_wildcard:
       title: store/channel/*
       description: Fires for all `store/channel` events.
-      allOf: []
       x-tags:
         - created
       x-internal: false
@@ -1395,7 +1393,6 @@ components:
       description: |
         Fires for all `store/customer` events.
       x-examples: {}
-      allOf: []
       x-tags:
         - created
       x-internal: false


### PR DESCRIPTION
## What changed?
Remove empty `allOf` sections.
Moreover a lot of these schemas are unused so it is safe to merge. 

Rule: disallow empty `allOf`, `oneOf` sections

## Release notes draft
none
