### PR TITLE
CATALOG-9219: [update] Catalog, update all Product Custom Fields endpoints

### DIFF
--- a/archive/rest-catalog/custom-fields.v2.yml
+++ b/archive/rest-catalog/custom-fields.v2.yml
@@ -1,0 +1,389 @@
+openapi: '3.0.3'
+info:
+  title: Catalog - Custom Fields V2
+  termsOfService: 'https://www.bigcommerce.com/terms'
+  contact:
+    name: BigCommerce
+    url: 'https://www.bigcommerce.com'
+    email: support@bigcommerce.com
+  version: '1.0.1'
+servers:
+  - url: 'https://{{store_url}}/api/v2'
+    variables:
+      store_url:
+        default: store_url
+        description: Permanent url of the BigCommerce store.
+    description: BigCommerce API Gateway
+security:
+  - basicAuth: []
+tags:
+  - name: Custom Fields V2
+paths:
+  '/products/{product_id}/custom_fields':
+    get:
+      tags:
+        - Custom Fields V2
+      summary: List Custom Fields
+      description: Gets custom fields associated with a product.
+      operationId: getProductCustomFields
+      parameters:
+        - name: page
+          in: query
+          description: Specifies the page number in a limited (paginated) list of custom fields.
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: |-
+            Controls the number of items per page in a limited (paginated) list of custom fields.
+            The maximum limit is 250. If a limit isn’t provided, up to 50 custom_fields are returned by default.
+          schema:
+            type: integer
+      responses:
+        '200':
+          $ref: '#/components/responses/customfields'
+        '401':
+          $ref: '#/components/responses/errors'
+        '403':
+          $ref: '#/components/responses/errors'
+        '404':
+          $ref: '#/components/responses/errors'
+        '405':
+          $ref: '#/components/responses/errors'
+    post:
+      tags:
+        - Custom Fields V2
+      summary: Create a Product Custom Field.
+      description: |-
+        Creates a new custom field associated with a product.
+
+        **Required Fields:**
+        - name
+        - text
+
+        **Name-Value Pair Uniqueness**
+        - Every name-text pair must be unique inside a product.
+
+        **Limits**
+        - 200 custom fields per product limit.
+        - 250 characters per custom field limit.
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/customfieldrequest'
+          'application/xml':
+            schema:
+              $ref: '#/components/schemas/customfieldrequest'
+        required: true
+      responses:
+        '201':
+          $ref: '#/components/responses/customfield'
+        '400':
+          $ref: '#/components/responses/errors'
+        '401':
+          $ref: '#/components/responses/errors'
+        '403':
+          $ref: '#/components/responses/errors'
+        '404':
+          $ref: '#/components/responses/errors'
+        '405':
+          $ref: '#/components/responses/errors'
+        '406':
+          $ref: '#/components/responses/errors'
+        '415':
+          $ref: '#/components/responses/errors'
+        '422':
+          $ref: '#/components/responses/errors'
+    delete:
+      tags:
+        - Custom Fields V2
+      summary: Deletes multiple custom fields.
+      description: Deletes multiple custom field associated with a product.
+      operationId: deleteProductCustomFields
+      parameters:
+        - name: page
+          in: query
+          description: Specifies the page number in a limited (paginated) list of custom fields you can delete.
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: |-
+            Controls the number of items per page in a limited (paginated) list of custom fields you can delete.
+            The maximum limit is 250. You can use up to 50 `custom_fields` by default if you do not provide a limit.
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: 204 No Content
+          content: {}
+        '401':
+          $ref: '#/components/responses/errors'
+        '403':
+          $ref: '#/components/responses/errors'
+        '404':
+          $ref: '#/components/responses/errors'
+        '405':
+          $ref: '#/components/responses/errors'
+    parameters:
+      - $ref: '#/components/parameters/ProductIdParam'
+  '/products/{product_id}/custom_fields/{id}':
+    get:
+      tags:
+        - Custom Fields V2
+      summary: Get a Product Custom Field.
+      description: Gets a custom field associated with a product.
+      operationId: getProductCustomField
+      responses:
+        '200':
+          $ref: '#/components/responses/customfield'
+        '401':
+          $ref: '#/components/responses/errors'
+        '403':
+          $ref: '#/components/responses/errors'
+        '404':
+          $ref: '#/components/responses/errors'
+        '405':
+          $ref: '#/components/responses/errors'
+    put:
+      tags:
+        - Custom Fields V2
+      summary: Update a Custom Field.
+      description: |-
+        Updates an existing custom field associated with a product.
+
+        **Required Fields**
+        - name
+        - text
+
+        **Read-Only**
+        - product_id
+      operationId: updateProductCustomField
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/customfieldrequest'
+          'application/xml':
+            schema:
+              $ref: '#/components/schemas/customfieldrequest'
+        required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/customfield'
+        '400':
+          $ref: '#/components/responses/errors'
+        '401':
+          $ref: '#/components/responses/errors'
+        '403':
+          $ref: '#/components/responses/errors'
+        '404':
+          $ref: '#/components/responses/errors'
+        '405':
+          $ref: '#/components/responses/errors'
+        '406':
+          $ref: '#/components/responses/errors'
+        '415':
+          $ref: '#/components/responses/errors'
+        '422':
+          $ref: '#/components/responses/errors'
+    delete:
+      tags:
+        - Custom Fields V2
+      summary: Delete a Product Custom Field.
+      description: Deletes a custom field associated with a product.
+      operationId: deleteProductCustomField
+      responses:
+        '204':
+          description: 204 No Content.
+          content: {}
+        '401':
+          $ref: '#/components/responses/errors'
+        '403':
+          $ref: '#/components/responses/errors'
+        '404':
+          $ref: '#/components/responses/errors'
+        '405':
+          $ref: '#/components/responses/errors'
+    parameters:
+      - $ref: '#/components/parameters/ProductIdParam'
+      - $ref: '#/components/parameters/CustomFieldIdParam'
+  /products/custom_fields/count:
+    get:
+      tags:
+        - Custom Fields V2
+      summary: Count Custom Fields
+      description: Gets a count of the number of custom fields in the store.
+      operationId: getProductCustomFieldsCount
+      responses:
+        '200':
+          $ref: '#/components/responses/customfieldscount'
+        '401':
+          $ref: '#/components/responses/errors'
+        '403':
+          $ref: '#/components/responses/errors'
+        '404':
+          $ref: '#/components/responses/errors'
+        '405':
+          $ref: '#/components/responses/errors'
+components:
+  schemas:
+    customfield:
+      title: Custom Field response
+      required:
+        - id
+        - product_id
+        - name
+        - text
+      type: object
+      xml:
+        name: customfield
+      properties:
+        id:
+          minimum: 1
+          type: integer
+          description: |-
+            The unique numeric ID of the custom field increments sequentially. Read-Only.
+          example: 6
+        product_id:
+          minimum: 1
+          type: integer
+          description: |-
+            ID of the associated product.
+            Read-Only
+          example: 6
+        name:
+          maxLength: 250
+          minLength: 1
+          type: string
+          description: |
+            The name of the field, shown on the storefront, orders, etc. This field is a requirement for /POST requests.
+          example: 'ISBN'
+        text:
+          maxLength: 250
+          minLength: 1
+          type: string
+          description: |
+            The value of the field, shown on the storefront, orders, etc. This field is a requirement for /POST requests.
+          example: '1234567890123'
+      description: 'Gets custom field associated with a product.'
+    customfieldrequest:
+      title: Custom Field request body
+      required:
+        - name
+        - text
+      type: object
+      properties:
+        name:
+          maxLength: 250
+          minLength: 1
+          type: string
+          description: |
+            The name of the field, shown on the storefront, orders, etc. This field is a requirement for /POST requests.
+          example: 'ISBN'
+        text:
+          maxLength: 250
+          minLength: 1
+          type: string
+          description: |
+            The value of the field, shown on the storefront, orders, etc. This field is a requirement for /POST requests.
+          example: '1234567890123'
+      description: 'Request body for custom field create/update'
+    customfieldscount:
+      title: Custom Field Count
+      required:
+        - count
+      type: object
+      properties:
+        count:
+          type: integer
+          description:  A count of the number of custom fields in the store.
+          example: 100
+    error:
+      title: Custom Field response
+      type: object
+      required:
+        - status
+        - message
+      xml:
+        name: error
+      properties:
+        status:
+          type: integer
+          description: The HTTP status code.
+        message:
+          type: string
+          description: Error message
+  responses:
+    errors:
+      description: General error
+      content:
+        'application/json':
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/error'
+        'application/xml':
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/error'
+            xml:
+              name: errors
+              wrapped: true
+    customfield:
+      description: Get Custom Field Response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/customfield'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/customfield'
+    customfields:
+      description: Gets array of Custom Fields Response
+      content:
+        'application/json':
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/customfield'
+        'application/xml':
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/customfield'
+            xml:
+              name: customfields
+              wrapped: true
+    customfieldscount:
+      description: 'Gets a count of the total number of custom fields in the store.'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/customfieldscount'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/customfieldscount'
+  parameters:
+    CustomFieldIdParam:
+      name: id
+      description: |
+        The ID of the `CustomField`.
+      required: true
+      in: path
+      schema:
+        type: integer
+    ProductIdParam:
+      name: product_id
+      in: path
+      description: |
+        The ID of the `Product` to which the resource belongs.
+      required: true
+      schema:
+        type: integer
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic

--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -4159,7 +4159,11 @@ paths:
       tags:
         - Custom Fields
       summary: Get a Product Custom Field
-      description: Returns a single *Custom Field*. You can pass in optional parameters.
+      description: |
+        Returns a *Custom Field*.
+        
+        **Note:**
+        The default rate limit for this endpoint is 40 concurrent requests.
       operationId: getProductCustomField
       parameters:
         - name: include_fields
@@ -4195,6 +4199,9 @@ paths:
 
         **Read-Only**
         - id
+
+        **Note:**
+        The default rate limit for this endpoint is 40 concurrent requests.
       operationId: updateProductCustomField
       requestBody:
         content:

--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -4070,7 +4070,7 @@ paths:
         - Custom Fields
       summary: Get Product Custom Fields
       description: |-
-        Returns a list of product *Custom Fields*. Optional parameters can be passed in.
+        Returns a list of product *Custom Fields*. You can pass in optional parameters.
 
         **Note:**
         The default rate limit for this endpoint is 40 concurrent requests.
@@ -4078,12 +4078,12 @@ paths:
       parameters:
         - name: include_fields
           in: query
-          description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
+          description: 'Fields to include in a comma-separated list; returned fields are the ID and specified fields.'
           schema:
             type: string
         - name: exclude_fields
           in: query
-          description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
+          description: 'Fields to exclude in a comma-separated list; responses do not include specified fields, and you can not exclude the ID.'
           schema:
             type: string
         - name: page
@@ -4098,66 +4098,15 @@ paths:
             type: integer
       responses:
         '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                title: 'Get Product Custom Fields Response'
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      title: Custom Field
-                      required:
-                        - name
-                        - value
-                      type: object
-                      properties:
-                        id:
-                          minimum: 1
-                          type: integer
-                          description: |-
-                            The unique numeric ID of the custom field; increments sequentially.
-                            Read-Only
-                          example: 6
-                        name:
-                          maxLength: 250
-                          minLength: 1
-                          type: string
-                          description: |
-                            The name of the field, shown on the storefront, orders, etc. Required for /POST
-                          example: ISBN
-                          x-required:
-                            - post
-                        value:
-                          maxLength: 250
-                          minLength: 1
-                          type: string
-                          description: |
-                            The name of the field, shown on the storefront, orders, etc. Required for /POST
-                          example: '1234567890123'
-                          x-required:
-                            - post
-                      description: 'Gets custom fields associated with a product. These allow you to specify additional information that will appear on the product’s page, such as a book’s ISBN or a DVD’s release date.'
-                  meta:
-                    $ref: '#/components/schemas/metaCollection_Full'
-              example:
-                data:
-                  - name: Release year
-                    value: '1987'
-                    id: 1
-                meta:
-                  pagination:
-                    total: 1
-                    count: 1
-                    per_page: 50
-                    current_page: 1
-                    total_pages: 1
-                    links:
-                      previous: '?page=1&limit=50'
-                      current: '?page=1&limit=50'
-                      next: '?page=1&limit=50'
+          $ref: '#/components/responses/CustomFieldsResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/GeneralErrorWithErrors'
+        '404':
+          $ref: '#/components/responses/GeneralError'
+        '405':
+          $ref: '#/components/responses/MethodNotAllowedError'
     post:
       tags:
         - Custom Fields
@@ -4169,207 +4118,71 @@ paths:
         - name
         - value
 
+        **Name-Value Pair Uniqueness**
+        - Every name-value pair must be unique inside a product.
+
         **Read-Only:**
         - id
 
         **Limits**
         - 200 custom fields per product limit.
-        - 255 characters per custom field limit.
-        
+        - 250 characters per custom field limit.
+
         **Note:**
-        The default rate limit for this endpoint is 40 concurrent requests. 
+        The default rate limit for this endpoint is 40 concurrent requests.
       operationId: createProductCustomField
-      parameters:
-        - $ref: '#/components/parameters/ContentType'
       requestBody:
         content:
-          application/json:
+          'application/json':
             schema:
-              title: Custom Field
-              required:
-                - name
-                - value
-              type: object
-              properties:
-                name:
-                  maxLength: 250
-                  minLength: 1
-                  type: string
-                  description: |
-                    The name of the field, shown on the storefront, orders, etc. Required for /POST
-                  example: ISBN
-                  x-required:
-                    - post
-                value:
-                  maxLength: 250
-                  minLength: 1
-                  type: string
-                  description: |
-                    The name of the field, shown on the storefront, orders, etc. Required for /POST
-                  example: '1234567890123'
-                  x-required:
-                    - post
-              description: 'Gets custom fields associated with a product. These allow you to specify additional information that will appear on the product’s page, such as a book’s ISBN or a DVD’s release date.'
+              $ref: '#/components/schemas/customFieldPost'
         required: true
       responses:
         '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                title: 'Create Product Custom Field Response'
-                type: object
-                properties:
-                  data:
-                    title: Custom Field
-                    required:
-                      - name
-                      - value
-                    type: object
-                    properties:
-                      id:
-                        minimum: 1
-                        type: integer
-                        description: |-
-                          The unique numeric ID of the custom field; increments sequentially.
-                          Read-Only
-                        example: 6
-                      name:
-                        maxLength: 250
-                        minLength: 1
-                        type: string
-                        description: |
-                          The name of the field, shown on the storefront, orders, etc. Required for /POST
-                        example: ISBN
-                        x-required:
-                          - post
-                      value:
-                        maxLength: 250
-                        minLength: 1
-                        type: string
-                        description: |
-                          The name of the field, shown on the storefront, orders, etc. Required for /POST
-                        example: '1234567890123'
-                        x-required:
-                          - post
-                    description: 'Gets custom fields associated with a product. These allow you to specify additional information that will appear on the product’s page, such as a book’s ISBN or a DVD’s release date.'
-                  meta:
-                    $ref: '#/components/schemas/metaEmpty_Full'
-              example:
-                data:
-                  name: Release Year
-                  value: '1976'
-                  id: 2
-                meta: {}
+          $ref: '#/components/responses/CustomFieldResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/GeneralErrorWithErrors'
         '404':
-          description: |
-            The parent resource was not found.
-          content:
-            application/json:
-              schema:
-                title: Not Found
-                type: object
-                properties:
-                  status:
-                    type: integer
-                    description: |
-                      404 HTTP status code.
-                  title:
-                    type: string
-                    description: The error title describing the particular error.
-                  type:
-                    type: string
-                  instance:
-                    type: string
-                description: Error payload for the BigCommerce API.
+          $ref: '#/components/responses/GeneralError'
+        '405':
+          $ref: '#/components/responses/MethodNotAllowedError'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeError'
         '422':
-          description: |
-            The `CustomField` was not valid. This is the result of missing required fields, or of invalid data. See the response for more details.
-          content:
-            application/json:
-              schema:
-                title: Error Response
-                type: object
-                properties:
-                  errors:
-                    title: Detailed Errors
-                    type: object
-                    properties: {}
-                    additionalProperties: true
-                  instance:
-                    type: string
-                  status:
-                    type: integer
-                    description: |
-                      The HTTP status code.
-                  title:
-                    type: string
-                    description: |
-                      The error title describing the particular error.
-                  type:
-                    type: string
-      x-codegen-request-body-name: CustomField
+          $ref: '#/components/responses/GeneralError'
     parameters:
-      - $ref: '#/components/parameters/Accept'
       - $ref: '#/components/parameters/ProductIdParam'
   '/catalog/products/{product_id}/custom-fields/{custom_field_id}':
     get:
       tags:
         - Custom Fields
       summary: Get a Product Custom Field
-      description: Returns a single *Custom Field*. Optional parameters can be passed in.
+      description: Returns a single *Custom Field*. You can pass in optional parameters.
       operationId: getProductCustomField
       parameters:
         - name: include_fields
           in: query
-          description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
+          description: 'Fields to include in a comma-separated list; returned fields are the ID and specified fields.'
           schema:
             type: string
         - name: exclude_fields
           in: query
-          description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
+          description: 'Fields to exclude in a comma-separated list; responses do not include specified fields, and you can not exclude the ID.'
           schema:
             type: string
       responses:
         '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                title: 'Get Product Custom Field Response'
-                type: object
-                properties:
-                  data:
-                    $ref: '#/components/schemas/productCustomField_Base'
-                  meta:
-                    $ref: '#/components/schemas/metaEmpty_Full'
-              example:
-                data:
-                  name: Release Year
-                  value: '1976'
-                  id: 2
-                meta: {}
+          $ref: '#/components/responses/CustomFieldResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/GeneralErrorWithErrors'
         '404':
-          description: |
-            The resource was not found.
-          content:
-            application/json:
-              schema:
-                title: Not Found
-                type: object
-                properties:
-                  status:
-                    type: integer
-                    description: |
-                      404 HTTP status code.
-                  title:
-                    type: string
-                    description: The error title describing the particular error.
-                  type:
-                    type: string
-                  instance:
-                    type: string
-                description: Error payload for the BigCommerce API.
+          $ref: '#/components/responses/GeneralError'
+        '405':
+          $ref: '#/components/responses/MethodNotAllowedError'
     put:
       tags:
         - Custom Fields
@@ -4383,143 +4196,27 @@ paths:
         **Read-Only**
         - id
       operationId: updateProductCustomField
-      parameters:
-        - $ref: '#/components/parameters/ContentType'
       requestBody:
         content:
-          application/json:
+          'application/json':
             schema:
-              title: Custom Field
-              required:
-                - name
-                - value
-              type: object
-              properties:
-                id:
-                  minimum: 1
-                  type: integer
-                  description: |-
-                    The unique numeric ID of the custom field; increments sequentially.
-                    Read-Only
-                  example: 6
-                name:
-                  maxLength: 250
-                  minLength: 1
-                  type: string
-                  description: |
-                    The name of the field, shown on the storefront, orders, etc. Required for /POST
-                  example: ISBN
-                  x-required:
-                    - post
-                value:
-                  maxLength: 250
-                  minLength: 1
-                  type: string
-                  description: |
-                    The name of the field, shown on the storefront, orders, etc. Required for /POST
-                  example: '1234567890123'
-                  x-required:
-                    - post
-              description: 'Gets custom fields associated with a product. These allow you to specify additional information that will appear on the product’s page, such as a book’s ISBN or a DVD’s release date.'
+              $ref: '#/components/schemas/customFieldPut'
         required: true
       responses:
         '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                title: 'Update Product Custom Field Response'
-                type: object
-                properties:
-                  data:
-                    title: Custom Field
-                    required:
-                      - name
-                      - value
-                    type: object
-                    properties:
-                      id:
-                        minimum: 1
-                        type: integer
-                        description: |-
-                          The unique numeric ID of the custom field; increments sequentially.
-                          Read-Only
-                        example: 6
-                      name:
-                        maxLength: 250
-                        minLength: 1
-                        type: string
-                        description: |
-                          The name of the field, shown on the storefront, orders, etc. Required for /POST
-                        example: ISBN
-                        x-required:
-                          - post
-                      value:
-                        maxLength: 250
-                        minLength: 1
-                        type: string
-                        description: |
-                          The name of the field, shown on the storefront, orders, etc. Required for /POST
-                        example: '1234567890123'
-                        x-required:
-                          - post
-                    description: 'Gets custom fields associated with a product. These allow you to specify additional information that will appear on the product’s page, such as a book’s ISBN or a DVD’s release date.'
-                  meta:
-                    $ref: '#/components/schemas/metaEmpty_Full'
-              example:
-                data:
-                  name: Release Year
-                  value: '1976'
-                  id: 2
-                meta: {}
+          $ref: '#/components/responses/CustomFieldResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/GeneralErrorWithErrors'
         '404':
-          description: |
-            The resource was not found.
-          content:
-            application/json:
-              schema:
-                title: Not Found
-                type: object
-                properties:
-                  status:
-                    type: integer
-                    description: |
-                      404 HTTP status code.
-                  title:
-                    type: string
-                    description: The error title describing the particular error.
-                  type:
-                    type: string
-                  instance:
-                    type: string
-                description: Error payload for the BigCommerce API.
+          $ref: '#/components/responses/GeneralError'
+        '405':
+          $ref: '#/components/responses/MethodNotAllowedError'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeError'
         '422':
-          description: |
-            The `CustomField` was not valid. This is the result of missing required fields, or of invalid data. See the response for more details.
-          content:
-            application/json:
-              schema:
-                title: Error Response
-                type: object
-                properties:
-                  errors:
-                    title: Detailed Errors
-                    type: object
-                    properties: {}
-                    additionalProperties: true
-                  instance:
-                    type: string
-                  status:
-                    type: integer
-                    description: |
-                      The HTTP status code.
-                  title:
-                    type: string
-                    description: |
-                      The error title describing the particular error.
-                  type:
-                    type: string
-      x-codegen-request-body-name: CustomField
+          $ref: '#/components/responses/GeneralError'
     delete:
       tags:
         - Custom Fields
@@ -4532,273 +4229,19 @@ paths:
       operationId: deleteProductCustomField
       responses:
         '204':
-          description: '`204 No Content`. Action has been enacted and no further information is to be supplied. `null` is returned.'
+          description: '204 No Content'
           content: {}
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/GeneralErrorWithErrors'
         '404':
-          description: |
-            The resource was not found.
-          content:
-            application/json:
-              schema:
-                title: Not Found
-                type: object
-                properties:
-                  status:
-                    type: integer
-                    description: |
-                      404 HTTP status code.
-                  title:
-                    type: string
-                    description: The error title describing the particular error.
-                  type:
-                    type: string
-                  instance:
-                    type: string
-                description: Error payload for the BigCommerce API.
+          $ref: '#/components/responses/GeneralError'
+        '405':
+          $ref: '#/components/responses/MethodNotAllowedError'
     parameters:
-      - $ref: '#/components/parameters/Accept'
       - $ref: '#/components/parameters/ProductIdParam'
       - $ref: '#/components/parameters/CustomFieldIdParam'
-  '/catalog/products/{product_id}/bulk-pricing-rules':
-    get:
-      tags:
-        - Bulk Pricing Rules
-      summary: Get All Bulk Pricing Rules
-      description: Returns a list of *Bulk Pricing Rules*. Optional parameters can be passed in.
-      operationId: getBulkPricingRules
-      parameters:
-        - name: include_fields
-          in: query
-          description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
-          schema:
-            type: string
-        - name: exclude_fields
-          in: query
-          description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
-          schema:
-            type: string
-        - name: page
-          in: query
-          description: Specifies the page number in a limited (paginated) list of products.
-          schema:
-            type: integer
-        - name: limit
-          in: query
-          description: Controls the number of items per page in a limited (paginated) list of products.
-          schema:
-            type: integer
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                title: 'Get Bulk Pricing Rules Response'
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      allOf:
-                        - type: object
-                          properties:
-                            id:
-                              type: integer
-                              description: Unique ID of the *Bulk Pricing Rule*. Read-Only.
-                              readOnly: true
-                          required:
-                            - id
-                        - $ref: '#/components/schemas/bulkPricingRule_Full'
-                  meta:
-                    $ref: '#/components/schemas/metaCollection_Full'
-              example:
-                data:
-                  - id: 83
-                    quantity_min: 1
-                    quantity_max: 3
-                    type: price
-                    amount: 1
-                  - id: 84
-                    quantity_min: 4
-                    quantity_max: 0
-                    type: price
-                    amount: 1
-                meta:
-                  pagination:
-                    total: 2
-                    count: 2
-                    per_page: 50
-                    current_page: 1
-                    total_pages: 1
-                    links:
-                      current: '?page=1&limit=50'
-        '404':
-          description: |
-            The parent resource was not found.
-          content:
-            application/json:
-              schema:
-                title: Not Found
-                type: object
-                properties:
-                  status:
-                    type: integer
-                    description: |
-                      404 HTTP status code.
-                  title:
-                    type: string
-                    description: The error title describing the particular error.
-                  type:
-                    type: string
-                  instance:
-                    type: string
-                description: Error payload for the BigCommerce API.
-    post:
-      tags:
-        - Bulk Pricing Rules
-      summary: Create a Bulk Pricing Rule
-      description: |-
-        Creates a *Bulk Pricing Rule*.
-
-        **Required Fields**
-        - quantity_min
-        - quantity_max
-        - type
-        - amount
-
-        **Read-Only Fields**
-        - id
-
-        **Limits**
-        - 50 bulk pricing rule per product limit.
-      operationId: createBulkPricingRule
-      parameters:
-        - $ref: '#/components/parameters/ContentType'
-        - name: page
-          in: query
-          description: Specifies the page number in a limited (paginated) list of products.
-          schema:
-            type: integer
-        - name: limit
-          in: query
-          description: Controls the number of items per page in a limited (paginated) list of products.
-          schema:
-            type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/bulkPricingRule_Full'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                title: 'Create Bulk Pricing Rule Response'
-                type: object
-                properties:
-                  data:
-                    allOf:
-                      - type: object
-                        properties:
-                          id:
-                            type: integer
-                            description: Unique ID of the *Bulk Pricing Rule*. Read-Only.
-                            readOnly: true
-                        required:
-                          - id
-                      - $ref: '#/components/schemas/bulkPricingRule_Full'
-                  meta:
-                    title: Meta
-                    type: object
-                    description: Empty meta object; may be used later.
-              example:
-                data:
-                  id: 83
-                  quantity_min: 1
-                  quantity_max: 3
-                  type: price
-                  amount: 1
-                meta: {}
-        '404':
-          description: |
-            The parent resource was not found.
-          content:
-            application/json:
-              schema:
-                title: Not Found
-                type: object
-                properties:
-                  status:
-                    type: integer
-                    description: |
-                      404 HTTP status code.
-                  title:
-                    type: string
-                    description: The error title describing the particular error.
-                  type:
-                    type: string
-                  instance:
-                    type: string
-                description: Error payload for the BigCommerce API.
-        '409':
-          description: |
-            The `BulkPricingRule` was in conflict with another bulk pricing rule. This is the result of quantity range overlapping with existing bulk pricing rules.
-          content:
-            application/json:
-              schema:
-                title: Error Response
-                type: object
-                properties:
-                  errors:
-                    title: Detailed Errors
-                    type: object
-                    properties: {}
-                    additionalProperties: true
-                  instance:
-                    type: string
-                  status:
-                    type: integer
-                    description: |
-                      The HTTP status code.
-                  title:
-                    type: string
-                    description: |
-                      The error title describing the particular error.
-                  type:
-                    type: string
-        '422':
-          description: |
-            The `BulkPricingRule` was not valid. This is the result of missing required fields, or of invalid data. See the response for more details.
-          content:
-            application/json:
-              schema:
-                title: Error Response
-                type: object
-                properties:
-                  errors:
-                    title: Detailed Errors
-                    type: object
-                    properties: {}
-                    additionalProperties: true
-                  instance:
-                    type: string
-                  status:
-                    type: integer
-                    description: |
-                      The HTTP status code.
-                  title:
-                    type: string
-                    description: |
-                      The error title describing the particular error.
-                  type:
-                    type: string
-      x-codegen-request-body-name: BulkPricingRule
-    parameters:
-      - $ref: '#/components/parameters/Accept'
-      - $ref: '#/components/parameters/ProductIdParam'
   '/catalog/products/{product_id}/bulk-pricing-rules/{bulk_pricing_rule_id}':
     get:
       tags:
@@ -9238,6 +8681,248 @@ components:
           minLength: 0
           maxLength: 255
           example: Name of Staff Member
+    customFieldData:
+      title: Product Custom Field Data
+      type: object
+      properties:
+        id:
+          minimum: 1
+          type: integer
+          description: |-
+            The unique numeric ID of the custom field increments sequentially. Read-Only.
+          example: 6
+        name:
+          maxLength: 250
+          minLength: 1
+          type: string
+          description: |
+            The name of the field, shown on the storefront, orders, etc. This field is a requirement for /POST requests.
+          example: 'ISBN'
+        value:
+          maxLength: 250
+          minLength: 1
+          type: string
+          description: |
+            The value of the field, shown on the storefront, orders, etc. This field is a requirement for /POST requests.
+          example: '1234567890123'
+      description: 'Gets custom fields associated with a product. These allow you to specify additional information that will appear on the product’s page, such as a book’s ISBN or a DVD’s release date.'
+    customFieldPost:
+      title: Custom Field Post
+      required:
+        - name
+        - value
+      type: object
+      properties:
+        name:
+          maxLength: 250
+          minLength: 1
+          type: string
+          description: |
+            The name of the field, shown on the storefront, orders, etc. This field is a requirement for /POST requests.
+          example: 'ISBN'
+        value:
+          maxLength: 250
+          minLength: 1
+          type: string
+          description: |
+            The value of the field, shown on the storefront, orders, etc. This field is a requirement for /POST requests.
+          example: '1234567890123'
+      description: 'Payload for POST request to create custom fields associated with a product.'
+    customFieldPut:
+      title: Custom Field Put
+      type: object
+      properties:
+        name:
+          maxLength: 250
+          minLength: 1
+          type: string
+          description: |
+            The value of the field, shown on the storefront, orders, etc. This field is a requirement for /POST requests.
+          example: 'ISBN'
+        value:
+          maxLength: 250
+          minLength: 1
+          type: string
+          description: |
+            The value of the field, shown on the storefront, orders, etc. This field is a requirement for /POST requests.
+          example: '1234567890123'
+      description: 'Payload for PUT request to update custom fields associated with a product.'
+    metaCollectionFull:
+      title: metaCollectionFull
+      type: object
+      properties:
+        pagination:
+          type: object
+          properties:
+            total:
+              type: integer
+              description: |
+                Total number of items in the result set.
+              example: 36
+            count:
+              type: integer
+              description: |
+                Total number of items in the collection response.
+              example: 36
+            per_page:
+              type: integer
+              description: |
+                The amount of items returned in the collection per page, controlled by the limit parameter.
+              example: 50
+            current_page:
+              type: integer
+              description: |
+                The page you are currently on within the collection.
+              example: 2
+            total_pages:
+              type: integer
+              description: |
+                The total number of pages in the collection.
+              example: 3
+            links:
+              type: object
+              properties:
+                previous:
+                  type: string
+                  description: |
+                    Link to the previous page returned in the response.
+                  example: '?page=1&limit=50'
+                current:
+                  type: string
+                  description: |
+                    Link to the current page returned in the response.
+                  example: '?page=2&limit=50'
+                next:
+                  type: string
+                  description: |
+                    Link to the next page returned in the response.
+                  example: '?page=3&limit=50'
+              description: |
+                Pagination links for the previous and next parts of the whole collection.
+          description: 'Data about the response, including pagination and collection totals.'
+      description: 'Data about the response, including pagination and collection totals.'
+    metaEmptyFull:
+      type: object
+      title: Response meta
+      properties: {}
+      additionalProperties: true
+      description: Response metadata.
+    GeneralErrorWithErrors:
+      required:
+        - status
+        - title
+        - type
+        - errors
+      title: Error Response
+      type: object
+      properties:
+        status:
+          type: integer
+          description: The HTTP status code.
+        title:
+          type: string
+          description: The error title describes the particular error.
+        type:
+          type: string
+        errors:
+          title: Detailed Errors
+          type: object
+          properties: {}
+          additionalProperties: true
+    GeneralError:
+      required:
+        - status
+        - title
+        - type
+      title: Error Response
+      type: object
+      properties:
+        status:
+          type: integer
+          description: The HTTP status code.
+        title:
+          type: string
+          description: The error title describes the particular error.
+        type:
+          type: string
+        code:
+          type: integer
+          description: The custom code of the error.
+    MethodNotAllowedError:
+      required:
+        - status
+        - title
+        - type
+        - detail
+      title: Error Response
+      type: object
+      properties:
+        status:
+          type: integer
+          description: The HTTP status code.
+          example: 405
+        title:
+          type: string
+          description: The error title describes the particular error.
+        type:
+          type: string
+        detail:
+          title: Detailed Errors
+          type: string
+          description: The detailed title describes the particular error.
+  responses:
+    GeneralError:
+      description: General Error.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GeneralError'
+    GeneralErrorWithErrors:
+      description: General Error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GeneralErrorWithErrors'
+    UnauthorizedError:
+      description: 401 Unauthorized
+      content:
+        plain/text:
+          schema:
+            type: string
+    MethodNotAllowedError:
+      description: 405 Method Not Allowed
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MethodNotAllowedError'
+    UnsupportedMediaTypeError:
+      description: 415 Unsupported Media Type
+      content:
+        text/html:
+          schema:
+            type: string
+    CustomFieldsResponse:
+      description: Gets array of Custom fields.
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/customFieldData'
+              meta:
+                $ref: '#/components/schemas/metaCollectionFull'
+    CustomFieldResponse:
+      description: Gets Custom field.
+      content:
+        application/json:
+          schema:
+            properties:
+              data:
+                $ref: '#/components/schemas/customFieldData'
+              meta:
+                $ref: '#/components/schemas/metaEmptyFull'
   parameters:
     ProductIdParam:
       name: product_id


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# CATALOG-9219 Review and update public API documentation for the POST|GET|PUT|DELETE v3/catalog/products/:productId/custom-fields


## What changed?
* Updated v3 custom-fields swagger scheme

## Release notes draft
* updated error messaging for custom fields;
* clarified info about limitation of 250 max allowed characters for the name and value in custom fields.


ping @bigcommerce/team-catalog 
