### PR TITLE
SBD-955: [remove] legacy channel app references

### DIFF
--- a/docs/api-docs/apps/guide/apps-01-introduction.mdx
+++ b/docs/api-docs/apps/guide/apps-01-introduction.mdx
@@ -81,7 +81,6 @@ Here's how to get started with BigCommerce development:
 * [PHP / Silex](https://github.com/bigcommerce/hello-world-app-php-silex)
 * [Ruby / Sinatra](https://github.com/bigcommerce/hello-world-app-ruby-sinatra)
 * [Laravel / React](https://github.com/bigcommerce/laravel-react-sample-app)
-* [Node / FaunaDB / Netlify](https://github.com/bigcommerce/channels-app/)
 
 ### Tools
 * [Node API Client](https://github.com/bigcommerce/node-bigcommerce/)

--- a/docs/api-docs/apps/guide/apps-02-types.mdx
+++ b/docs/api-docs/apps/guide/apps-02-types.mdx
@@ -57,7 +57,6 @@ There are three visibility options for apps: **Draft**, **Unlisted**, and **Publ
 * [PHP / Silex](https://github.com/bigcommerce/hello-world-app-php-silex)
 * [Ruby / Sinatra](https://github.com/bigcommerce/hello-world-app-ruby-sinatra)
 * [Laravel / React](https://github.com/bigcommerce/laravel-react-sample-app)
-* [Node / FaunaDB / Netlify](https://github.com/bigcommerce/channels-app/)
 
 ### Tools
 * [Node API Client](https://github.com/bigcommerce/node-bigcommerce/)

--- a/docs/api-docs/apps/guide/apps-03-developing.mdx
+++ b/docs/api-docs/apps/guide/apps-03-developing.mdx
@@ -20,7 +20,6 @@ Alternatively, you can clone the GitHub repo for your preferred stack:
 * [PHP / Silex](https://github.com/bigcommerce/hello-world-app-php-silex)
 * [Ruby / Sinatra](https://github.com/bigcommerce/hello-world-app-ruby-sinatra)
 * [Laravel / React](https://github.com/bigcommerce/laravel-react-sample-app)
-* [Node / FaunaDB / Netlify](https://github.com/bigcommerce/channels-app/)
 
 ## Testing locally with ngrok
 You can use [ngrok](https://ngrok.com/) to test apps locally. It's easy to install and works well with [Express](https://expressjs.com/):
@@ -79,7 +78,6 @@ Any store registered to the same email as your [Developer Portal](https://devtoo
 * [PHP / Silex](https://github.com/bigcommerce/hello-world-app-php-silex)
 * [Ruby / Sinatra](https://github.com/bigcommerce/hello-world-app-ruby-sinatra)
 * [Laravel / React](https://github.com/bigcommerce/laravel-react-sample-app)
-* [Node / FaunaDB / Netlify](https://github.com/bigcommerce/channels-app/)
 
 ### Tools
 * [Node API Client](https://github.com/bigcommerce/node-bigcommerce/)

--- a/docs/api-docs/apps/guide/apps-05-oauth.mdx
+++ b/docs/api-docs/apps/guide/apps-05-oauth.mdx
@@ -195,7 +195,6 @@ The following BigCommerce API clients expose helper methods for BigCommerce's co
 * [PHP / Silex](https://github.com/bigcommerce/hello-world-app-php-silex)
 * [Ruby / Sinatra](https://github.com/bigcommerce/hello-world-app-ruby-sinatra)
 * [Laravel / React](https://github.com/bigcommerce/laravel-react-sample-app)
-* [Node / FaunaDB / Netlify](https://github.com/bigcommerce/channels-app/)
 
 ### Tools
 * [Node API Client](https://github.com/bigcommerce/node-bigcommerce/)

--- a/docs/api-docs/apps/guide/apps-06-callbacks.mdx
+++ b/docs/api-docs/apps/guide/apps-06-callbacks.mdx
@@ -143,7 +143,6 @@ The following BigCommerce API clients expose helper methods for verifying the `s
 * [PHP / Silex](https://github.com/bigcommerce/hello-world-app-php-silex)
 * [Ruby / Sinatra](https://github.com/bigcommerce/hello-world-app-ruby-sinatra)
 * [Laravel / React](https://github.com/bigcommerce/laravel-react-sample-app)
-* [Node / FaunaDB / Netlify](https://github.com/bigcommerce/channels-app/)
 
 ### Tools
 * [Node API Client](https://github.com/bigcommerce/node-bigcommerce/)

--- a/docs/api-docs/apps/guide/apps-07-users.mdx
+++ b/docs/api-docs/apps/guide/apps-07-users.mdx
@@ -46,7 +46,6 @@ For details about remove user and load requests, see [Single-click App Callbacks
 * [PHP / Silex](https://github.com/bigcommerce/hello-world-app-php-silex)
 * [Ruby / Sinatra](https://github.com/bigcommerce/hello-world-app-ruby-sinatra)
 * [Laravel / React](https://github.com/bigcommerce/laravel-react-sample-app)
-* [Node / FaunaDB / Netlify](https://github.com/bigcommerce/channels-app/)
 
 ### Tools
 * [Node API Client](https://github.com/bigcommerce/node-bigcommerce/)

--- a/docs/api-docs/apps/guide/apps-08-events.mdx
+++ b/docs/api-docs/apps/guide/apps-08-events.mdx
@@ -62,7 +62,6 @@ Accept: application/json
 * [PHP / Silex](https://github.com/bigcommerce/hello-world-app-php-silex)
 * [Ruby / Sinatra](https://github.com/bigcommerce/hello-world-app-ruby-sinatra)
 * [Laravel / React](https://github.com/bigcommerce/laravel-react-sample-app)
-* [Node / FaunaDB / Netlify](https://github.com/bigcommerce/channels-app/)
 
 ### Tools
 * [Node API Client](https://github.com/bigcommerce/node-bigcommerce/)

--- a/docs/api-docs/apps/guide/apps-09-ui.mdx
+++ b/docs/api-docs/apps/guide/apps-09-ui.mdx
@@ -42,11 +42,6 @@ The BigDesign Playground demonstrates the visual style and behavior of each BigD
 
 [Go to the BigDesign Developer Playground](https://developer.bigcommerce.com/big-design).
 
-### Example app
-We've built a channels app that serves as a reference implementation for BigDesign React Components. You can install it on your store [here](https://apps.bigcommerce.com/details/18212) (apps.bigcommerce.com) to view the components.
-
-[Learn more about the channels app](https://github.com/bigcommerce/channels-app).
-
 ### Design kits
 
 Do you design with Figma? If so, check out our design kit:
@@ -81,7 +76,6 @@ To load inside the control panel iFrame, your app must do the following:
 * [PHP / Silex](https://github.com/bigcommerce/hello-world-app-php-silex)
 * [Ruby / Sinatra](https://github.com/bigcommerce/hello-world-app-ruby-sinatra)
 * [Laravel / React](https://github.com/bigcommerce/laravel-react-sample-app)
-* [Node / FaunaDB / Netlify](https://github.com/bigcommerce/channels-app/)
 
 ### Tools
 * [Node API Client](https://github.com/bigcommerce/node-bigcommerce/)

--- a/docs/api-docs/apps/guide/apps-10-buttons.mdx
+++ b/docs/api-docs/apps/guide/apps-10-buttons.mdx
@@ -79,7 +79,6 @@ end
 * [PHP / Silex](https://github.com/bigcommerce/hello-world-app-php-silex)
 * [Ruby / Sinatra](https://github.com/bigcommerce/hello-world-app-ruby-sinatra)
 * [Laravel / React](https://github.com/bigcommerce/laravel-react-sample-app)
-* [Node / FaunaDB / Netlify](https://github.com/bigcommerce/channels-app/)
 
 ### Tools
 * [Node API Client](https://github.com/bigcommerce/node-bigcommerce/)

--- a/docs/api-docs/apps/guide/apps-11-best-practices.mdx
+++ b/docs/api-docs/apps/guide/apps-11-best-practices.mdx
@@ -91,7 +91,6 @@ BigCommerce hosts [Google Cloud Platform](https://cloud.google.com/) in the [us-
 * [PHP / Silex](https://github.com/bigcommerce/hello-world-app-php-silex)
 * [Ruby / Sinatra](https://github.com/bigcommerce/hello-world-app-ruby-sinatra)
 * [Laravel / React](https://github.com/bigcommerce/laravel-react-sample-app)
-* [Node / FaunaDB / Netlify](https://github.com/bigcommerce/channels-app/)
 
 ### Tools
 * [Node API Client](https://github.com/bigcommerce/node-bigcommerce/)

--- a/docs/api-docs/apps/guide/apps-12-requirements.mdx
+++ b/docs/api-docs/apps/guide/apps-12-requirements.mdx
@@ -67,7 +67,6 @@ For App Marketplace approval, you'll need to fill out all fields on your listing
 * [PHP / Silex](https://github.com/bigcommerce/hello-world-app-php-silex)
 * [Ruby / Sinatra](https://github.com/bigcommerce/hello-world-app-ruby-sinatra)
 * [Laravel / React](https://github.com/bigcommerce/laravel-react-sample-app)
-* [Node / FaunaDB / Netlify](https://github.com/bigcommerce/channels-app/)
 
 ### Tools
 

--- a/docs/api-docs/apps/guide/apps-13-publishing.mdx
+++ b/docs/api-docs/apps/guide/apps-13-publishing.mdx
@@ -130,7 +130,6 @@ can take up to 24 hours to appear on the App Marketplace. Feel free to use this 
 * [PHP / Silex](https://github.com/bigcommerce/hello-world-app-php-silex)
 * [Ruby / Sinatra](https://github.com/bigcommerce/hello-world-app-ruby-sinatra)
 * [Laravel / React](https://github.com/bigcommerce/laravel-react-sample-app)
-* [Node / FaunaDB / Netlify](https://github.com/bigcommerce/channels-app/)
 
 ### Tools
 * [Node API Client](https://github.com/bigcommerce/node-bigcommerce/)

--- a/docs/api-docs/channels/building-channel-apps.mdx
+++ b/docs/api-docs/channels/building-channel-apps.mdx
@@ -145,7 +145,7 @@ Accept: application/json
 
 [Filters](/docs/start/about/common-query-params) can be used in this call to retrieve subsets of the merchant's catalog. Also, keep in mind that you will more than likely need to handle pagination to retrieve all products in a merchant's catalog.
 
-To support these workflows from a UI perspective, you may need to include the following components (please see the [sample channel app](https://github.com/bigcommerce/channels-app) for a visual on how this functions):
+To support these workflows from a UI perspective, you may need to include the following components:
 
 - Panel
 - Table

--- a/docs/api-docs/channels/channel-app-best-practices.mdx
+++ b/docs/api-docs/channels/channel-app-best-practices.mdx
@@ -79,7 +79,3 @@ These logs would provide more granular details on the event that took place and 
 - [App Store Approval Requirements](/docs/integrations/apps/guide/requirements)
 - [BigDesign Component Library](https://developer.bigcommerce.com/big-design/?path=/story/badge--overview)
 - [Sell Everywhere with Channel Manager](https://support.bigcommerce.com/s/article/Selling-Everywhere-with-Channel-Manager)
-
-### Tools
-
-- [Channels Sample App](https://github.com/bigcommerce/channels-app)


### PR DESCRIPTION

## What changed?
Removes the initial sample app for channels that was created in 2019. That repo is now archived.

## Release notes draft
_Release note not needed_
