### PR TITLE
DEVDOCS-5801: Fix wording for metafields endpoints

### DIFF
--- a/reference/carts.v3.yml
+++ b/reference/carts.v3.yml
@@ -741,10 +741,10 @@ paths:
       - $ref: '#/components/parameters/cart_id'
       - $ref: '#/components/parameters/Accept'
     get:
-      summary: Get All Metafields
+      summary: Get Cart Metafields
       tags:
         - Metafields
-      description: Get all cart metafields.
+      description: Get a cart's metafields.
       operationId: getCartMetafields
       parameters:
         - $ref: '#/components/parameters/PageParam'
@@ -931,7 +931,7 @@ paths:
         description: The unique ID of the subject `Metafield`.
   '/carts/metafields':
     get:
-      summary: Get All Metafields
+      summary: Get All Cart Metafields
       tags:
         - Batch metafields
       description: Get all cart metafields.

--- a/reference/catalog/brands_catalog.v3.yml
+++ b/reference/catalog/brands_catalog.v3.yml
@@ -995,7 +995,7 @@ paths:
     get:
       tags:
         - Metafields
-      summary: Get All Brand Metafields
+      summary: Get Brand Metafields
       description: 'Returns a list of *Brand Metafields*. Optional filter parameters can be passed in. '
       operationId: getBrandMetafields
       parameters:
@@ -1591,7 +1591,7 @@ paths:
       - $ref: '#/components/parameters/BrandIdParam'
   '/catalog/brands/metafields':
     get:
-      summary: Get All Metafields
+      summary: Get All Brand Metafields
       tags:
         - Batch metafields
       description: Get all brand metafields.

--- a/reference/catalog/categories_catalog.v3.yml
+++ b/reference/catalog/categories_catalog.v3.yml
@@ -1185,7 +1185,7 @@ paths:
     get:
       tags:
         - Metafields
-      summary: Get All Category Metafields
+      summary: Get Category Metafields
       description: Returns a list of *Metafields* on a *Category*. Optional filter parameters can be passed in.
       operationId: getCategoryMetafields
       parameters:
@@ -1786,7 +1786,7 @@ paths:
       - $ref: '#/components/parameters/CategoryIdParam'
   '/catalog/categories/metafields':
     get:
-      summary: Get All Metafields
+      summary: Get All Category Metafields
       tags:
         - Batch metafields
       description: Get all category metafields.

--- a/reference/catalog/product-variants_catalog.v3.yml
+++ b/reference/catalog/product-variants_catalog.v3.yml
@@ -556,7 +556,7 @@ paths:
     get:
       tags:
         - Metafields
-      summary: Get All Product Variant Metafields
+      summary: Get Product Variant Metafields
       description: Returns a list of product variant *Metafields*. Optional parameters can be passed in.
       operationId: getProductVariantMetafields
       parameters:
@@ -1719,7 +1719,7 @@ paths:
       - $ref: '#/components/parameters/Accept'
   '/catalog/variants/metafields':
     get:
-      summary: Get All Metafields
+      summary: Get All Product Variant Metafields
       tags:
         - Batch metafields
       description: Get all variant metafields.

--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -4529,7 +4529,7 @@ paths:
     get:
       tags:
         - Metafields
-      summary: Get All Product Metafields
+      summary: Get Product Metafields
       description: Returns a list of *Product Metafields*. Optional parameters can be passed in.
       operationId: getProductMetafields
       parameters:
@@ -5766,7 +5766,7 @@ paths:
       - $ref: '#/components/parameters/Accept'
   '/catalog/products/metafields':
     get:
-      summary: Get All Metafields
+      summary: Get All Product Metafields
       tags:
         - Batch metafields
       description: Get all product metafields.

--- a/reference/channels.v3.yml
+++ b/reference/channels.v3.yml
@@ -761,7 +761,7 @@ paths:
       description: Deletes a single channel metafield.
   '/channels/metafields':
     get:
-      summary: Get All Metafields
+      summary: Get All Channel Metafields
       tags:
         - Batch metafields
       description: Get all channel metafields.

--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -1764,7 +1764,7 @@ paths:
             Response object for customer metafields deletion with success.
   '/customers/metafields':
     get:
-      summary: Get All Metafields
+      summary: Get All Customer Metafields
       tags:
         - Customer Batch Metafields
       description: Get all customer metafields.

--- a/reference/orders.v3.yml
+++ b/reference/orders.v3.yml
@@ -557,7 +557,7 @@ paths:
       - $ref: '#/components/parameters/Accept'
       - $ref: '#/components/parameters/OrderIdParam'
     get:
-      summary: Get Metafields
+      summary: Get Order Metafields
       tags:
         - Metafields
       description: |
@@ -866,7 +866,7 @@ paths:
         required: true
   '/orders/metafields':
     get:
-      summary: Get All Metafields
+      summary: Get All Order Metafields
       tags:
         - Batch metafields
       description: Get all order metafields.


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-5801](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5801?atlOrigin=eyJpIjoiMGQ2ZGZhMjg5NDAxNDZiOGEwYmZhZDNhZTI4OWU0OTciLCJwIjoiamlyYS1zbGFjay1pbnQifQ)


## What changed?
* Rename `Get All Metafields` reference titles to be more relevant to the resource type being retrieved.

## Release notes draft
* The metafield endpoints in the reference will be more relevant to the resource being fetched, and there won't be duplicate names across different schemas.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @bigcommerce/dev-docs 


[DEVDOCS-5801]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ