### PR TITLE
doc(catalog): CATALOG-8071 Add date_last_imported to V3 API catalog/products

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -179,14 +179,19 @@ paths:
           schema:
             type: string
             format: date-time
+        - name: 'date_last_imported:not'
+          in: query
+          description: 'Filter items by date_last_imported. For example, `date_last_imported:not=2015-08-21T22%3A53%3A23%2B00%3A00`.'
+          schema:
+            type: string
         - name: 'date_last_imported:max'
           in: query
-          description: 'Filter items by date_last_imported. For example, `date_last_imported:max=2020-06-15`.'
+          description: 'Filter items by date_last_imported. For example, `date_last_imported:max=2015-08-21T22%3A53%3A23%2B00%3A00`.'
           schema:
             type: string
         - name: 'date_last_imported:min'
           in: query
-          description: 'Filter items by date_last_imported. For example, `date_last_imported:min=2018-06-15`.'
+          description: 'Filter items by date_last_imported. For example, `date_last_imported:min=2015-08-21T22%3A53%3A23%2B00%3A00`.'
           schema:
             type: string
         - name: is_visible
@@ -507,6 +512,7 @@ paths:
                     brand_name: Common Good
                     gtin: string
                     mpn: string
+                    date_last_imported: '2015-07-03T18:16:02+00:00'
                     reviews_rating_sum: 3
                     reviews_count: 4
                     total_sold: 80
@@ -627,6 +633,7 @@ paths:
                         brand_name: Common Good
                         gtin: string
                         mpn: string
+                        date_last_imported: '2015-07-03T18:16:02+00:00'
                         reviews_rating_sum: 3
                         reviews_count: 4
                         total_sold: 80
@@ -988,6 +995,7 @@ paths:
                 brand_name: Common Good
                 gtin: string
                 mpn: string
+                date_last_imported: '2015-07-03T18:16:02+00:00'
                 reviews_rating_sum: 3.2
                 reviews_count: 4
                 total_sold: 80
@@ -1292,7 +1300,7 @@ paths:
             format: date-time
         - name: date_last_imported
           in: query
-          description: 'Filter items by date_last_imported. For example `v3/catalog/products?date_last_imported:min=2018-06-15`'
+          description: 'Filter items by date_last_imported. For example `v3/catalog/products?date_last_imported:min=2015-08-21T22%3A53%3A23%2B00%3A00`'
           schema:
             type: string
             format: date-time
@@ -7362,6 +7370,7 @@ components:
             brand_name: Common Good
             gtin: string
             mpn: string
+            date_last_imported: '2015-07-03T18:16:02+00:00'
             reviews_rating_sum: 3.2
             reviews_count: 4
             total_sold: 80
@@ -7638,6 +7647,7 @@ components:
           brand_name: Common Good
           gtin: string
           mpn: string
+          date_last_imported: '2015-07-03T18:16:02+00:00'
           reviews_rating_sum: 3.2
           reviews_count: 4
           total_sold: 80
@@ -8029,6 +8039,9 @@ components:
         mpn:
           type: string
           description: Manufacturer Part Number
+        date_last_imported:
+          type: string
+          description: the date when the Product had been imported
         reviews_rating_sum:
           type: integer
           description: |


### PR DESCRIPTION
# [CATALOG-8071](https://bigcommercecloud.atlassian.net/browse/CATALOG-8071)


## What changed?
* “date_last_imported“ field is added to the Product model


## Release notes draft
“date_last_imported“ field is added to the Product model. The field format is _nullable datetime string_ (e.g.: "2024-01-24T14:36:56+00:00”). The field is modifiable & filterable.



----

ping @bigcommerce/catalog-dt-php 


[CATALOG-8071]: https://bigcommercecloud.atlassian.net/browse/CATALOG-8071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ