### PR TITLE
DEVDOCS-5807 [new]: Settings API, remove Channel ID query parameter

### DIFF
--- a/reference/settings.v3.yml
+++ b/reference/settings.v3.yml
@@ -795,7 +795,6 @@ paths:
       description: Returns global locale settings.
       parameters:
         - $ref: '#/components/parameters/Accept'
-        - $ref: '#/components/parameters/ChannelIdParam'
       responses:
         '200':
           description: ''
@@ -823,12 +822,9 @@ paths:
       operationId: updateSettingsLocale
       description: |-
         Updates global locale settings.
-
-        Set a channel override by using the `channel_id` query parameter. To remove a channel override, set `null` for a field. The field then inherits the global value.
       parameters:
         - $ref: '#/components/parameters/Accept'
         - $ref: '#/components/parameters/ContentType'
-        - $ref: '#/components/parameters/ChannelIdParam'
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
# [DEVDOCS-5807]


## What changed?
- Remove Channel ID query parameter from locale endpoints  


No changelog entry 


[DEVDOCS-5807]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ