### PR TITLE
#144 Add 'read-only' marker, Remove enum of accepted values for tax_p…

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -3850,15 +3850,12 @@ components:
           type: string
         tax_provider_id:
           description: |
+            Read-only.
             BasicTaxProvider - Tax is set to manual and order is created in the store.
             
             AvaTaxProvider - Tax is set to automatic and order is created in the store. Used for Avalara.
             
             "" (empty string) - The order is created with the API, or the tax provider is unknown.
-          enum:
-            - BasicTaxProvider
-            - AvaTaxProvider
-            - ''
           type: string
         customer_locale:
           type: string
@@ -4550,15 +4547,12 @@ components:
               type: string
             tax_provider_id:
               description: |
+                Read-only.
                 BasicTaxProvider - Tax is set to manual and order is created in the store.
                 
                 AvaTaxProvider - Tax is set to automatic and order is created in the store. Used for Avalara.
                 
                 "" (empty string) - The order is created with the API, or the tax provider is unknown.
-              enum:
-                - BasicTaxProvider
-                - AvaTaxProvider
-                - ''
               type: string
             customer_locale:
               type: string


### PR DESCRIPTION
…rovider_id on OrdersV2 create/update

<!-- Ticket number or summary of work -->
#144 


## What changed?
* Add 'read-only' marker to tax_provider_id on OrdersV2 create/update
* Remove enum of accepted values for tax_provider_id on OrdersV2 create/update

## Release notes draft
* Ensures developers understand that any value will be ignored when using the endpoint.

## Anything else?
N/A

ping @bc-traciporter 
