### PR TITLE
doc(orders): ORDERS-6248 avoid duplicated fields with "allOf" openapi schemas in Orders v2 API

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -3711,8 +3711,6 @@ components:
           description: The value of the base wrapping cost expressed as a floating point number to four decimal places in string format.
           example: '0.0000'
           type: string
-        billing_address:
-          $ref: '#/components/schemas/billingAddress_Base'
         channel_id:
           description: Shows where the order originated. The channel_id will default to 1.
           example: 1
@@ -4111,12 +4109,7 @@ components:
           example: 7
           description: The status ID of the order.
         billing_address:
-          type: object
-          properties:
-            form_fields:
-              type: array
-              items:
-                $ref: '#/components/schemas/formFields'
+          $ref: '#/components/schemas/billingAddress_Resp'
     orderCustomProduct_Put:
       type: object
       title: Custom product
@@ -4582,6 +4575,8 @@ components:
       allOf:
         - type: object
           properties:
+            billing_address:
+              $ref: '#/components/schemas/billingAddress_Base'
             default_currency_code:
               description: The currency code of the transactional currency the shopper pays in; writeable when multi-currency is enabled.
               type: string
@@ -4609,6 +4604,15 @@ components:
               items:
                 $ref: '#/components/schemas/formFields'
     billingAddress_Put:
+      allOf:
+        - $ref: '#/components/schemas/billingAddress_Base'
+        - type: object
+          properties:
+            form_fields:
+              type: array
+              items:
+                $ref: '#/components/schemas/formFields'
+    billingAddress_Resp:
       allOf:
         - $ref: '#/components/schemas/billingAddress_Base'
         - type: object

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -4578,7 +4578,7 @@ components:
             billing_address:
               $ref: '#/components/schemas/billingAddress_Base'
             default_currency_code:
-              description: The currency code of the transactional currency the shopper pays in; writeable when multi-currency is enabled.
+              description: The currency code of the transactional currency the shopper pays in is writeable when multi-currency is enabled.
               type: string
             products:
               type: array

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -3726,9 +3726,6 @@ components:
         date_created:
           description: The date the order was created, formatted in the RFC-2822 standard. You set this attribute on Order creation (POST) to support the migration of historical orders. If you do not provide a value, then it will default to the current date/time. e.g., `Tue, 20 Nov 2012 00:00:00 +0000`.
           type: string
-        default_currency_code:
-          description: The currency code of the transactional currency the shopper pays in; writeable when multi-currency is enabled.
-          type: string
         discount_amount:
           description: Amount of discount for this transaction. (Float, Float-As-String, Integer)
           example: '0.0000'
@@ -4585,6 +4582,9 @@ components:
       allOf:
         - type: object
           properties:
+            default_currency_code:
+              description: The currency code of the transactional currency the shopper pays in; writeable when multi-currency is enabled.
+              type: string
             products:
               type: array
               items:


### PR DESCRIPTION
# [ORDERS-6248]

Context: https://bigcommerce.slack.com/archives/C96P5T3J4/p1709383968237619

we have order_Resp https://github.com/bigcommerce/docs/blob/main/reference/orders.v2.oas2.yml#L2690
```
    order_Resp:
      title: order_Resp
      description: Order object returned in responses.
      allOf:
        - $ref: '#/components/schemas/order_RespOnly'
        - $ref: '#/components/schemas/order_Shared'
```

The below fields exists in both the `order_RespOnly` and `order_Shared`, so it leads to duplication problem in our [BC public API doc](https://developer.bigcommerce.com/docs/rest-management/orders#create-an-order) and error in the API client generator: 

- `billing_address`:  

![image](https://github.com/bigcommerce/docs/assets/63274600/0f02534f-b7a1-46cc-a62f-534b18a6809a)

![image](https://github.com/bigcommerce/docs/assets/63274600/a3c0b139-4331-4e35-a06d-2151f1713fe7)

- `default_currency_code`:

<img width="344" alt="image" src="https://github.com/bigcommerce/docs/assets/63274600/f2b2fbae-d30a-4159-917a-979e0d5cff4d">

<img width="364" alt="image" src="https://github.com/bigcommerce/docs/assets/63274600/7f787ac9-88db-4e7d-a315-933a2e018336">

## What changed?
Remove the duplications of those fields in the `order_RespOnly` and `order_Shared`

## Release notes draft
- Fix a bug that show duplication of `default_currency_code` and `billing_address` fields in Orders V2 API response body

ping @bigcommerce/team-orders @bc-traciporter 


[ORDERS-6248]: https://bigcommercecloud.atlassian.net/browse/ORDERS-6248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ