### PR TITLE
DEVDOCS-5723 [update]: Themes API, add channel_id as a query parameter

### DIFF
--- a/reference/themes.v3.yml
+++ b/reference/themes.v3.yml
@@ -348,6 +348,11 @@ paths:
   '/themes/actions/activate':
     parameters:
       - $ref: '#/components/parameters/Accept'
+      - name: channel_id
+        in: query
+        schema:
+          type: integer
+        description: The ID for the channel where you want to activate the theme.
     post:
       tags:
         - Theme Actions

--- a/reference/themes.v3.yml
+++ b/reference/themes.v3.yml
@@ -1124,7 +1124,6 @@ components:
       description: Request definition for activation endpoint.
       required:
         - variation_id
-        - which
       properties:
         variation_id:
           description: The identifier for the variation to activate.


### PR DESCRIPTION
# [DEVDOCS-5723]


## What changed?
- Add `channel_id` as a query parameter for Activate a Theme endpoint
- Remove required flag from `which` field 


[DEVDOCS-5723]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ