### PR TITLE
Fix for GraphQL complexity limit example error message

### DIFF
--- a/docs/api-docs/storefront/graphql/graphql-api-overview.mdx
+++ b/docs/api-docs/storefront/graphql/graphql-api-overview.mdx
@@ -513,9 +513,11 @@ If a query's complexity score exceeds the complexity limit, an error response si
 
 ```json filename="Example response with complexity error" showLineNumbers copy
 {
-  "error": {
-    "error": "The query is too complex as it has a complexity score of 12230 out of 10000. Please remove some elements and try again"
-  }
+  "errors": [
+    {
+      "message": "The query is too complex as it has a complexity score of 12230 out of 10000. Please remove some elements and try again"
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
# Fix for GraphQL complexity limit example error message


## What changed?
* Re-formatted the example GraphQL complexity limit error message to match what is actually returned: An `errors` array with a `message` property in the error object.

## Release notes draft
* Fixed incorrect formatting of the example error message for GraphQL complexity limits.