### PR TITLE
DEVDOCS-5767: Create a storefront token API allows 2 domains

### DIFF
--- a/reference/storefront_tokens.v3.yml
+++ b/reference/storefront_tokens.v3.yml
@@ -263,7 +263,7 @@ components:
           maxItems: 2
           minItems: 1
           type: array
-          description: List of allowed domains for Cross-Origin Request Sharing. Currently accepts a maximum of two domains per token being created.
+          description: List of allowed domains for Cross-Origin Request Sharing. Currently accepts a maximum of two domains per created token.
           items:
             maxLength: 1
             minLength: 1

--- a/reference/storefront_tokens.v3.yml
+++ b/reference/storefront_tokens.v3.yml
@@ -260,10 +260,10 @@ components:
       type: object
       properties:
         allowed_cors_origins:
-          maxItems: 1
+          maxItems: 2
           minItems: 1
           type: array
-          description: List of allowed domains for Cross-Origin Request Sharing. Currently only accepts a single element.
+          description: List of allowed domains for Cross-Origin Request Sharing. Currently accepts a maximum of two domains per token being created.
           items:
             maxLength: 1
             minLength: 1


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-5767] : [update] Storefront Token, Update the Create a storefront token endpoint's allowed CORS origins max limit


## What changed?
* BigCommerce currently allows sending two domains for CORS, API doc updated to change the limit from 1 to 2.

## Release notes draft
* Create GraphQL token API docs - updated the number of allowed domains for CORS to 2.


## Anything else?
BigCommerce currently allows sending two domains, we get this error when we send more than 2 origins : "Allowed CORS origins list length should not be greater than 2".


[DEVDOCS-5767]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ