### PR TITLE
DEVDOCS-5834 [Update] make state_or_province required

### DIFF
--- a/reference/checkouts.v3.yml
+++ b/reference/checkouts.v3.yml
@@ -8655,6 +8655,7 @@ components:
             required:
               - country_code
               - email
+              - state_or_province
             type: object
             properties:
               first_name:

--- a/reference/checkouts.v3.yml
+++ b/reference/checkouts.v3.yml
@@ -3948,6 +3948,7 @@ paths:
 
         * `postal_code`
         * `state_or_province`
+        * `phone`
       operationId: addCheckoutConsignment
       parameters:
         - $ref: '#/components/parameters/checkoutId'
@@ -8656,6 +8657,7 @@ components:
               - country_code
               - email
               - state_or_province
+              - phone
             type: object
             properties:
               first_name:

--- a/reference/checkouts.v3.yml
+++ b/reference/checkouts.v3.yml
@@ -3948,7 +3948,7 @@ paths:
 
         * `postal_code`
         * `state_or_province`
-        * `phone`
+        
       operationId: addCheckoutConsignment
       parameters:
         - $ref: '#/components/parameters/checkoutId'
@@ -8657,7 +8657,7 @@ components:
               - country_code
               - email
               - state_or_province
-              - phone
+              - postal_code
             type: object
             properties:
               first_name:

--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -499,6 +499,7 @@ paths:
         * **country_code**
         * **address1**
         * **state_or_province**
+        * **postal_code**
 
         **Notes**
         * A unique customer address is a combination of the following core address fields:
@@ -3636,7 +3637,7 @@ components:
         - country_code
         - customer_id
         - state_or_province
-        - phone
+        - postal_code
       x-examples:
         Example:
           value:

--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -3636,6 +3636,7 @@ components:
         - country_code
         - customer_id
         - state_or_province
+        - phone
       x-examples:
         Example:
           value:

--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -498,6 +498,7 @@ paths:
         * **city**
         * **country_code**
         * **address1**
+        * **state_or_province**
 
         **Notes**
         * A unique customer address is a combination of the following core address fields:
@@ -3634,6 +3635,7 @@ components:
         - city
         - country_code
         - customer_id
+        - state_or_province
       x-examples:
         Example:
           value:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-5834] & [DEVDOCS-5833]


## What changed?
Make state_or_province required in the Add Consignment to Checkout endpoint

## Release notes draft

Bug Fix

## Anything else?
See DEVDOCS tickets for screenshots.

ping {names}


[DEVDOCS-5834]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DEVDOCS-5833]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ