### PR TITLE
DEVDOCS-5168 [revise]: GQL SF API Faceted Search, clarify price sort order

### DIFF
--- a/docs/api-docs/storefront/graphql/graphql-faceted-textual-search.mdx
+++ b/docs/api-docs/storefront/graphql/graphql-faceted-textual-search.mdx
@@ -219,6 +219,8 @@ query {
 
 The `sort` affects only the list of products returned. A merchant's [product filtering settings](https://support.bigcommerce.com/s/article/Product-Filtering-Settings?language=en_US#setup) determine how facets are sorted. 
 
+If you sort by price, the products sort by either their `salePrice` or `basePrice` if `sortPrice` doesn't exist.
+
 <Callout type="info">
   For a list of product fields that `searchTerm` searches, see the [Store Search Product Fields](https://support.bigcommerce.com/s/article/Store-Search?language=en_US#best-practices) article.
 </Callout>


### PR DESCRIPTION
# [DEVDOCS-5168]

## What changed?
- Clarified how API handles price sort order


[DEVDOCS-5168]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ