### PR TITLE
[No-Ticket]: [revise] MarketingV2, Fix status code in marketing.v2.yml

### DIFF
--- a/reference/marketing.v2.yml
+++ b/reference/marketing.v2.yml
@@ -839,7 +839,7 @@ paths:
               $ref: '#/components/schemas/giftCertificate_Post'
         required: false
       responses:
-        '200':
+        '201':
           description: ""
           content:
             application/json:


### PR DESCRIPTION
## What changed?

I just checked this endpoint and it returns 201 instead of 200

```shell
curl --verbose --request POST \
  --url "https://api.bigcommerce.com/stores/$HASH/v2/gift_certificates" \
  --header 'Accept: application/json' \
  --header 'Content-Type: application/json' \
  --header "X-Auth-Token: $TOKEN" \
  --data '{"to_name":"John Doe","to_email":"johndoe@example.com","from_name":"Jane Doe","from_email":"janedoe@example.com","amount":"11","balance":"0","purchase_date":"Mon, 19 Jan 1970 07:21:46 CST","expiry_date":"Tue, 20 Jan 1970 08:45:38 CST","customer_id":5,"template":"celebration.html","message":"Congratulations!","code":"ABC-5N4-C7M-S78","status":"active","currency_code":"PLN"}'


```


## Anything else?
![image](https://github.com/bigcommerce/docs/assets/425208/e06acc52-7162-4813-a0bb-deb83db7af44)

