### PR TITLE
feat(iam): ANA-4629 Update AddUserToStore docs to reflect security patch

### DIFF
--- a/docs/api-docs/users/overview.mdx
+++ b/docs/api-docs/users/overview.mdx
@@ -13,7 +13,7 @@ A user is an account that can sign in to the BigCommerce control panel for an ac
 Before getting started with the GraphQL Users API, make sure you have the following:
 
 * BigCommerce store
-* A valid access token from an account-level API account that has sufficient permissions to make the desired requests. 
+* A valid access token from an account-level API account that has sufficient permissions to make the desired requests.
 
 To learn more about making requests, see the next section on [Getting Started](#getting-started).
 
@@ -73,7 +73,7 @@ The following query returns details about an account:
       }
     }
     ```
-    
+
   </Tab>
   <Tab>
 
@@ -827,11 +827,11 @@ The following mutation creates a user:
       user {
         createUserWithPassword(
           input: {
-            email: "jane.doe@example.com", 
-            firstName: "Jane", 
-            lastName: "Doe",  
-            locale: "en-US", 
-            password: "Password1234!", 
+            email: "jane.doe@example.com",
+            firstName: "Jane",
+            lastName: "Doe",
+            locale: "en-US",
+            password: "Password1234!",
             passwordConfirmation: "Password1234!"
           }
         ) {
@@ -865,8 +865,9 @@ The following mutation creates a user:
 
 ### Add user to store
 
-The following mutation adds a user to a store:
+The following mutations add a user to a store:
 
+Example using the user's ID to add the user to the store, the user in this case must be part of the account:
 <Tabs items={['Request', 'Response']}>
   <Tab>
 
@@ -877,6 +878,45 @@ The following mutation adds a user to a store:
           input: {
             user: {
               id: "bc/account/user/{user_id}"
+            },
+            storeId:"bc/account/store/{store_id}"
+          }
+        ) {
+          storeId
+        }
+      }
+    }
+    ```
+
+  </Tab>
+  <Tab>
+
+    ```json filename="Example mutation: Add user to store" showLineNumbers copy
+    {
+      "data": {
+        "user": {
+          "addUserToStore": {
+            "storeId": "bc/account/store/{store_hash}"
+          }
+        }
+      }
+    }
+    ```
+
+  </Tab>
+</Tabs>
+
+Example using the user's email to add the user to the store:
+<Tabs items={['Request', 'Response']}>
+  <Tab>
+
+    ```graphql filename="Example mutation: Add user to store" showLineNumbers copy
+    mutation {
+      user {
+        addUserToStore(
+          input: {
+            user: {
+              email: "bc/account/user/{user_email}"
             },
             storeId:"bc/account/store/{store_id}"
           }


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-]
Jira: [ANA-4629](https://bigcommercecloud.atlassian.net/browse/ANA-4629)


## What changed?
* Updating the AddUserToStore documentation to reflect the security patch that the IAM team tackled as part of ANA-4629. The vulnerability there was that it was possible for attackers to enumerate through user ID's and retrieve all the emails of users throughout the platform if they were successful in using an ID that belongs to someone. The IAM team recommends that we instead use email as the identifier for users as part of this specific mutation, however we are still allowing for a set of accounts that have existing Users API tokens to continue using the original API contract as before.


## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[ANA-4629]: https://bigcommercecloud.atlassian.net/browse/ANA-4629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ