### PR TITLE
fix(customers): Fix letter case in response mapping for the Get Stored Instrument API operation

### DIFF
--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -1576,7 +1576,7 @@ paths:
                     propertyName: type
                     mapping:
                       stored_card: '#/components/schemas/CardInstrument'
-                      stored_paypal_account: '#/components/schemas/PaypalAccountInstrument'
+                      stored_paypal_account: '#/components/schemas/PayPalAccountInstrument'
                       stored_bank_account: '#/components/schemas/BankAccountInstrument'
               examples:
                 example-1:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-5880]

Fixes #212

## What changed?
Changes mapping value from #/components/schemas/PaypalAccountInstrument to #/components/schemas/PayPalAccountInstrument in response for the Get Stored Instrument API operation in the Customers V3 OpenAPI spec

## Release notes draft
Updates OpenAPI spec: Fixes letter case in response mapping for the `PayPalAccountInstrument` when querying the V3 customers API for Stored Instruments

## Anything else?
n/a

[DEVDOCS-5880]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ