### PR TITLE
TAX-2050: Add performance/timeout section to tax provider API documentation

### DIFF
--- a/docs/api-docs/provider-apis/tax/overview.mdx
+++ b/docs/api-docs/provider-apis/tax/overview.mdx
@@ -143,6 +143,16 @@ BigCommerce sends requests for tax estimates on product item, shipping, and hand
 
 [View the Estimate Taxes API reference](/docs/rest-contracts/tax#estimate-taxes).
 
+### Performance
+
+Merchants expect fast tax estimate responses to facilitate a streamlined checkout experience for their shoppers. Hence performance is an essential consideration for a tax provider.
+
+To protect the shopper checkout experience from overly slow tax responses, tax estimate requests will time out after a set period of time. The default timeout threshold of four seconds is intended to support a wide variety of use cases (e.g. large tax estimate requests).
+
+<Callout type="info">
+  You may request a lower timeout threshold to provide a better service to merchants.
+</Callout>
+
 ## Document submission
 
 Document submission enables you to persist a tax quote request, replace it with another one, or invalidate it if necessary.


### PR DESCRIPTION
On the back of a recent incident we identified there was an opportunity to speak more about performance and our timeout expectations in our Tax Provider API documentation.

Here we are introducing a new section on this topic. Further comments inline.