### PR TITLE
DEVDOCS-5796 [new]: Scripts API, add integrity hash

### DIFF
--- a/docs/api-docs/storefront/scripts-overview.mdx
+++ b/docs/api-docs/storefront/scripts-overview.mdx
@@ -113,7 +113,7 @@ Release notes can work for all storefronts. Changes to the [OAuth scopes](/docs/
 All scripts on the checkout page need at least one SRI hash to meet [PCI 4.0 - 6.4.3 requirements](https://pcipolicies.com/blogs/news/how-to-comply-with-the-new-pci-dss-requirement-6-4-3). 
 
 You can [generate SRI hashes](https://www.srihash.org/) or work with a script provider or host to generate a hash. We support all the hashing algorithms the SRI standard allows, including SHA-256, SHA-384, and SHA-512.
-The hash corresponds to the contents of the script. When you update the contents of your script, you must generate a new hash. 
+The hash corresponds to the contents of the script. If you modify the contents of your script at its original location, you must generate a new hash. 
 
 You can add SRI hashes through the [Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager) or using the REST Management API's [scripts feature](/docs/rest-management/scripts).  
 For _external SRC scripts_, BigCommerce will set the `integrity` attribute when we generate the `script` tag from your external SRC script.

--- a/docs/api-docs/storefront/scripts-overview.mdx
+++ b/docs/api-docs/storefront/scripts-overview.mdx
@@ -115,7 +115,7 @@ All scripts on the checkout page need at least one SRI hash to meet [PCI 4.0 - 6
 You can [generate SRI hashes](https://www.srihash.org/) or work with a script provider or host to generate a hash. We support all the hashing algorithms the SRI standard allows, including SHA-256, SHA-384, and SHA-512.
 The hash corresponds to the contents of the script. When you update the contents of your script, you must generate a new hash.
 
-You can supply SRI hashes through [Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager) or the [Scripts API](/docs/rest-management/scripts).  
+You can add SRI hashes through the [Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager) or using the REST Management API's [scripts feature](/docs/rest-management/scripts).  
 For _external SRC scripts_, BigCommerce will set the `integrity` attribute when we generate the `script` tag from your external SRC script.
 
 We support multiple hashes so that the script provider can update the script without invalidating it.

--- a/docs/api-docs/storefront/scripts-overview.mdx
+++ b/docs/api-docs/storefront/scripts-overview.mdx
@@ -113,7 +113,7 @@ Release notes can work for all storefronts. Changes to the [OAuth scopes](/docs/
 All scripts on the checkout page need at least one SRI hash to meet [PCI 4.0 - 6.4.3 requirements](https://pcipolicies.com/blogs/news/how-to-comply-with-the-new-pci-dss-requirement-6-4-3). 
 
 You can [generate SRI hashes](https://www.srihash.org/) or work with a script provider or host to generate a hash. We support all the hashing algorithms the SRI standard allows, including SHA-256, SHA-384, and SHA-512.
-The hash corresponds to the contents of the script. You need to generate a different hash if you update the contents of your script.
+The hash corresponds to the contents of the script. When you update the contents of your script, you must generate a new hash.
 
 You can supply SRI hashes through [Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager) or the [Scripts API](/docs/rest-management/scripts).  
 For _external SRC scripts_, BigCommerce will set the `integrity` attribute when we generate the `script` tag from your external SRC script.

--- a/docs/api-docs/storefront/scripts-overview.mdx
+++ b/docs/api-docs/storefront/scripts-overview.mdx
@@ -108,7 +108,7 @@ Release notes can work for all storefronts. Changes to the [OAuth scopes](/docs/
 
 ## Subresource integrity
 
-[Subresource integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) is a security feature browsers use to verify that attackers have not manipulated the script. 
+[Subresource integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) is a security feature browsers use to verify that attackers have not manipulated a script. 
 
 All scripts on the checkout page need at least one SRI hash to meet [PCI 4.0 - 6.4.3 requirements](https://pcipolicies.com/blogs/news/how-to-comply-with-the-new-pci-dss-requirement-6-4-3). 
 

--- a/docs/api-docs/storefront/scripts-overview.mdx
+++ b/docs/api-docs/storefront/scripts-overview.mdx
@@ -124,7 +124,7 @@ You should supply another hash before the contents of the script change. The bro
 You can add up to 5 hashes and remove SRI hashes when they are no longer valid. 
 
 <Callout type="warning">
-  If there is a change to the host script and you don't update or add a valid hash, the script will fail to execute. The browser console will show an error that the script failed to execute because the hash didn't match the contents of the script.
+  If there is a change to the host script, you must update or add a valid hash. If no hashes match the contents of the script, the browser console will show an error that the script failed to execute.
 </Callout>
 
 ## Troubleshooting

--- a/docs/api-docs/storefront/scripts-overview.mdx
+++ b/docs/api-docs/storefront/scripts-overview.mdx
@@ -121,7 +121,7 @@ For _external SRC scripts_, BigCommerce will use the provided hashes within the 
 A hash becomes invalid when the contents of a script change, and the script will fail to execute. 
 To prevent this from happening, we support multiple hashes so that a script can always have a valid hash while the script provider updates the script.
 You should supply another hash before the contents of the script change. The browser will check each hash to see if any of them match a corresponding script. 
-You can add up to five hashes and remove SRI hashes when they are no longer valid. The browser will typically check hashes starting from the leftmost hash in the `integrity` attribute and proceed to the right until it finds a match. For this reason, you can use the allotted five hashes to sort hashes in decreasing algorithmic strength, allowing browsers to use the strongest available hash.
+You can add up to five SRI hashes and remove hashes when they are no longer valid. The browser will typically check hashes starting from the leftmost hash in the `integrity` attribute and proceed to the right until it finds a match. For this reason, you can use the allotted five hashes to sort hashes in decreasing algorithmic strength so that browsers use the strongest available hash.
 
 <Callout type="warning">
   If there is a change to the host script, you must update or add a valid hash. If no hashes match the contents of the script, the browser console will show an error that the script failed to execute.

--- a/docs/api-docs/storefront/scripts-overview.mdx
+++ b/docs/api-docs/storefront/scripts-overview.mdx
@@ -112,11 +112,11 @@ Release notes can work for all storefronts. Changes to the [OAuth scopes](/docs/
 
 All scripts on the checkout page need at least one SRI hash to meet [PCI 4.0 - 6.4.3 requirements](https://pcipolicies.com/blogs/news/how-to-comply-with-the-new-pci-dss-requirement-6-4-3). 
 
-You can supply SRI hashes through [Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager) or the [Scripts API](/docs/rest-management/scripts).  
-For _external SRC scripts_, BigCommerce will set the `integrity` attribute when we generate the `script` tag from your external SRC script.
-
 You can [generate SRI hashes](https://www.srihash.org/) or work with a script provider or host to generate a hash. We support any of the algorithms (SHA-256, SHA-384, SHA-512) used to generate the hash.
 The hash corresponds to the contents of the script. You need to generate a different hash if you update the contents of your script.
+
+You can supply SRI hashes through [Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager) or the [Scripts API](/docs/rest-management/scripts).  
+For _external SRC scripts_, BigCommerce will set the `integrity` attribute when we generate the `script` tag from your external SRC script.
 
 We support multiple hashes so that the script provider can update the script without invaliating it.
 Before the contents of the script change, you should supply another hash. The browser will check each hash to see if any of them match a corresponding script. 

--- a/docs/api-docs/storefront/scripts-overview.mdx
+++ b/docs/api-docs/storefront/scripts-overview.mdx
@@ -116,12 +116,12 @@ You can [generate SRI hashes](https://www.srihash.org/) or work with a script pr
 The hash corresponds to the contents of the script. If you modify the contents of your script at its original location, you must generate a new hash. 
 
 You can add SRI hashes through the [Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager) or using the REST Management API's [scripts feature](/docs/rest-management/scripts).  
-For _external SRC scripts_, BigCommerce will use the provided hashes within the `integrity` attribute when we generate the `script` tag from your external SRC script. BigCommerce will also set the `crossorigin` attribute of the script to `anonymous` since SRI requires that the browser doesn't include any credentials (like cookies or HTTP authentication) in the request when fetching the resource. 
+For _external SRC scripts_, BigCommerce will use the provided hashes within the `integrity` attribute when we generate the `script` tag from your external SRC script. BigCommerce will also set the `crossorigin` attribute of the script to `anonymous`. This is because SRI requires that browsers don't include any credentials (like cookies or HTTP authentication) in the request when fetching the resource. 
 
 A hash becomes invalid when the contents of a script change, and the script will fail to execute. 
 To prevent this from happening, we support multiple hashes so that a script can always have a valid hash while the script provider updates the script.
 You should supply another hash before the contents of the script change. The browser will check each hash to see if any of them match a corresponding script. 
-You can add up to five hashes and remove SRI hashes when they are no longer valid. 
+You can add up to five hashes and remove SRI hashes when they are no longer valid. The browser will typically check hashes starting from the leftmost hash in the `integrity` attribute and proceed to the right until it finds a match. For this reason, you can use the allotted five hashes to sort hashes in decreasing algorithmic strength, allowing browsers to use the strongest available hash.
 
 <Callout type="warning">
   If there is a change to the host script, you must update or add a valid hash. If no hashes match the contents of the script, the browser console will show an error that the script failed to execute.

--- a/docs/api-docs/storefront/scripts-overview.mdx
+++ b/docs/api-docs/storefront/scripts-overview.mdx
@@ -112,7 +112,7 @@ Release notes can work for all storefronts. Changes to the [OAuth scopes](/docs/
 
 All scripts on the checkout page need at least one SRI hash to meet [PCI 4.0 - 6.4.3 requirements](https://pcipolicies.com/blogs/news/how-to-comply-with-the-new-pci-dss-requirement-6-4-3). 
 
-You can [generate SRI hashes](https://www.srihash.org/) or work with a script provider or host to generate a hash. We support any of the algorithms (SHA-256, SHA-384, SHA-512) used to generate the hash.
+You can [generate SRI hashes](https://www.srihash.org/) or work with a script provider or host to generate a hash. We support all the hashing algorithms the SRI standard allows, including SHA-256, SHA-384, and SHA-512.
 The hash corresponds to the contents of the script. You need to generate a different hash if you update the contents of your script.
 
 You can supply SRI hashes through [Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager) or the [Scripts API](/docs/rest-management/scripts).  

--- a/docs/api-docs/storefront/scripts-overview.mdx
+++ b/docs/api-docs/storefront/scripts-overview.mdx
@@ -116,7 +116,7 @@ You can [generate SRI hashes](https://www.srihash.org/) or work with a script pr
 The hash corresponds to the contents of the script. If you modify the contents of your script at its original location, you must generate a new hash. 
 
 You can add SRI hashes through the [Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager) or using the REST Management API's [scripts feature](/docs/rest-management/scripts).  
-For _external SRC scripts_, BigCommerce will set the `integrity` attribute when we generate the `script` tag from your external SRC script.
+For _external SRC scripts_, BigCommerce will use the provided hashes within the `integrity` attribute when we generate the `script` tag from your external SRC script. BigCommerce will also set the `crossorigin` attribute of the script to `anonymous` since SRI requires that the browser doesn't include any credentials (like cookies or HTTP authentication) in the request when fetching the resource. 
 
 A hash becomes invalid when the contents of a script change, and the script will fail to execute. 
 To prevent this from happening, we support multiple hashes so that a script can always have a valid hash while the script provider updates the script.

--- a/docs/api-docs/storefront/scripts-overview.mdx
+++ b/docs/api-docs/storefront/scripts-overview.mdx
@@ -118,7 +118,7 @@ The hash corresponds to the contents of the script. You need to generate a diffe
 You can supply SRI hashes through [Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager) or the [Scripts API](/docs/rest-management/scripts).  
 For _external SRC scripts_, BigCommerce will set the `integrity` attribute when we generate the `script` tag from your external SRC script.
 
-We support multiple hashes so that the script provider can update the script without invaliating it.
+We support multiple hashes so that the script provider can update the script without invalidating it.
 Before the contents of the script change, you should supply another hash. The browser will check each hash to see if any of them match a corresponding script. 
 You can add up to 5 hashes or remove SRI hashes when they are no longer valid. 
 

--- a/docs/api-docs/storefront/scripts-overview.mdx
+++ b/docs/api-docs/storefront/scripts-overview.mdx
@@ -106,6 +106,26 @@ Solutions that add dynamic script support using revisions to or additions of scr
 
 Release notes can work for all storefronts. Changes to the [OAuth scopes](/docs/start/authentication/api-accounts#oauth-scopes) of apps that use [app-level API accounts](/docs/start/authentication/api-accounts#app-level-api-accounts) require the store owner or other authorized user to accept the new scopes, which could provide a mechanism to trigger release note display. Store owners aren't prompted to reauthorize until they next open an app in the control panel, so direct contact may be advisable from a conversion perspective. You can't change the OAuth scopes for a [store-level API account](/docs/start/authentication/api-accounts#store-level-api-accounts), so directly contacting the store or stores that you want to change may be your only option for disclosure.
 
+## Subresource integrity
+
+[Subresource integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) is a security feature browsers use to verify that attackers have not manipulated the script. 
+
+All scripts on the checkout page need at least one SRI hash to meet [PCI 4.0 - 6.4.3 requirements](https://pcipolicies.com/blogs/news/how-to-comply-with-the-new-pci-dss-requirement-6-4-3). 
+
+You can supply SRI hashes through [Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager) or the [Scripts API](/docs/rest-management/scripts).  
+For _external SRC scripts_, BigCommerce will set the `integrity` attribute when we generate the `script` tag from your external SRC script.
+
+You can [generate SRI hashes](https://www.srihash.org/) or work with a script provider or host to generate a hash. We support any of the algorithms (SHA-256, SHA-384, SHA-512) used to generate the hash.
+The hash corresponds to the contents of the script. You need to generate a different hash if you update the contents of your script.
+
+We support multiple hashes so that the script provider can update the script without invaliating it.
+Before the contents of the script change, you should supply another hash. The browser will check each hash to see if any of them match a corresponding script. 
+You can add up to 5 hashes or remove SRI hashes when they are no longer valid. 
+
+<Callout type="warning">
+  If there is a change to the host script and you don't update or add a valid hash, the script will fail to execute. The browser console will show an error that the script failed to execute because the hash didn't match the contents of the script.
+</Callout>
+
 ## Troubleshooting
 
 Your app installation may find itself unexpectedly missing one or more scripts. Below are some possible causes of this issue.
@@ -151,9 +171,15 @@ Stencil themes from the marketplace support [Optimized One-Page Checkout (Help C
 * [Apps Guide: Auth Flow](/docs/integrations/apps/guide/auth)
 * [Apps Guide: Callbacks](/docs/integrations/apps/guide/callbacks)
 * [Multi-Storefront App Compatibility](/docs/integrations/apps/multi-storefront)
+* [Subresource Integrity - SRI hashes (MDN Web Docs)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)
+* [PCI 4.0 - 6.4.3 requirements](https://pcipolicies.com/blogs/news/how-to-comply-with-the-new-pci-dss-requirement-6-4-3)
 
 ### Help center
 
 * [Installing Apps (Help Center)](https://support.bigcommerce.com/s/article/How-do-I-access-and-install-the-new-single-click-apps-within-my-Bigcommerce-store-control-panel?language=en_US#installing)
 * [Optimized One-Page Checkout (Help Center)](https://support.bigcommerce.com/articles/Public/Optimized-Single-Page-Checkout#signup)
+* [Script Manager (Help Center)](https://support.bigcommerce.com/s/article/Using-Script-Manager)
 
+### Tools
+
+* [SRI Hash Generator](https://www.srihash.org/)

--- a/docs/api-docs/storefront/scripts-overview.mdx
+++ b/docs/api-docs/storefront/scripts-overview.mdx
@@ -121,7 +121,7 @@ For _external SRC scripts_, BigCommerce will set the `integrity` attribute when 
 A hash becomes invalid when the contents of a script change, and the script will fail to execute. 
 To prevent this from happening, we support multiple hashes so that a script can always have a valid hash while the script provider updates the script.
 You should supply another hash before the contents of the script change. The browser will check each hash to see if any of them match a corresponding script. 
-You can add up to 5 hashes and remove SRI hashes when they are no longer valid. 
+You can add up to five hashes and remove SRI hashes when they are no longer valid. 
 
 <Callout type="warning">
   If there is a change to the host script, you must update or add a valid hash. If no hashes match the contents of the script, the browser console will show an error that the script failed to execute.

--- a/docs/api-docs/storefront/scripts-overview.mdx
+++ b/docs/api-docs/storefront/scripts-overview.mdx
@@ -118,9 +118,10 @@ The hash corresponds to the contents of the script. When you update the contents
 You can add SRI hashes through the [Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager) or using the REST Management API's [scripts feature](/docs/rest-management/scripts).  
 For _external SRC scripts_, BigCommerce will set the `integrity` attribute when we generate the `script` tag from your external SRC script.
 
-A hash becomes invalid when a script's contents change. We support multiple hashes so that the script provider can update the script without invalidating it.
-Before the contents of the script change, you should supply another hash. The browser will check each hash to see if any of them match a corresponding script. 
-You can add up to 5 hashes or remove SRI hashes when they are no longer valid. 
+A hash becomes invalid when the contents of a script change, and the script will fail to execute. 
+To prevent this from happening, we support multiple hashes so that a script can always have a valid hash while the script provider updates the script.
+You should supply another hash before the contents of the script change. The browser will check each hash to see if any of them match a corresponding script. 
+You can add up to 5 hashes and remove SRI hashes when they are no longer valid. 
 
 <Callout type="warning">
   If there is a change to the host script and you don't update or add a valid hash, the script will fail to execute. The browser console will show an error that the script failed to execute because the hash didn't match the contents of the script.

--- a/docs/api-docs/storefront/scripts-overview.mdx
+++ b/docs/api-docs/storefront/scripts-overview.mdx
@@ -108,17 +108,17 @@ Release notes can work for all storefronts. Changes to the [OAuth scopes](/docs/
 
 ## Subresource integrity
 
-[Subresource integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) is a security feature browsers use to verify that attackers have not manipulated a script. 
+[Subresource integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) is a security feature browsers use to verify that attackers have not manipulated external hosted resources, including scripts. 
 
 All scripts on the checkout page need at least one SRI hash to meet [PCI 4.0 - 6.4.3 requirements](https://pcipolicies.com/blogs/news/how-to-comply-with-the-new-pci-dss-requirement-6-4-3). 
 
 You can [generate SRI hashes](https://www.srihash.org/) or work with a script provider or host to generate a hash. We support all the hashing algorithms the SRI standard allows, including SHA-256, SHA-384, and SHA-512.
-The hash corresponds to the contents of the script. When you update the contents of your script, you must generate a new hash.
+The hash corresponds to the contents of the script. When you update the contents of your script, you must generate a new hash. 
 
 You can add SRI hashes through the [Script Manager](https://support.bigcommerce.com/s/article/Using-Script-Manager) or using the REST Management API's [scripts feature](/docs/rest-management/scripts).  
 For _external SRC scripts_, BigCommerce will set the `integrity` attribute when we generate the `script` tag from your external SRC script.
 
-We support multiple hashes so that the script provider can update the script without invalidating it.
+A hash becomes invalid when a script's contents change. We support multiple hashes so that the script provider can update the script without invalidating it.
 Before the contents of the script change, you should supply another hash. The browser will check each hash to see if any of them match a corresponding script. 
 You can add up to 5 hashes or remove SRI hashes when they are no longer valid. 
 

--- a/reference/scripts.v3.yml
+++ b/reference/scripts.v3.yml
@@ -984,11 +984,11 @@ components:
         integrity_hashes:
           type: array
           description: |
-            Array of [SRI hashes](https://www.srihash.org/) for external SRC scripts that lets browsers validate the contents of the script.
+            Array of [Subresource integrity (SRI) hashes](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) for external SRC scripts that lets browsers validate the contents of the script.
+
+            The hash is set as the `integrity` attribute on the `script` tag. You can add up to five hashes for a script and generate them using any of the algorithms (SHA-256, SHA-384, or SHA-512).
           items:
             type: string
-            description: |
-              SRI hash that gets added as an attribute on the script tag. You can add up to five hashes for a script and generate them using any of the algorithms (SHA-256, SHA-384, or SHA-512).
           example:
             - "sha384-DgtwqxoPLKnJSER+TUmSPIpE6ZbVb2ZZwR241HHiqJipLiZQPN/JkKX5xxrEHUTt"
             - "sha384-UiwrqEuzfCtJKLI+dXmPNOpE6ZvBh2IIqT371rJiqJxyKjZ6PP/JmSD5hdsEUPOl"

--- a/reference/scripts.v3.yml
+++ b/reference/scripts.v3.yml
@@ -986,7 +986,7 @@ components:
           description: |
             Array of [Subresource integrity (SRI) hashes](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) for external SRC scripts that lets browsers validate the contents of the script.
 
-            The hash is set as the `integrity` attribute on the `script` tag. You can add up to five hashes for a script and generate them using any of the algorithms (SHA-256, SHA-384, or SHA-512).
+            The hash is set as the `integrity` attribute on the `script` tag. You can add up to five hashes for a script and generate them using any of the SRI standard-supported algorithms, including SHA-256, SHA-384, and SHA-512.
           items:
             type: string
           example:

--- a/reference/scripts.v3.yml
+++ b/reference/scripts.v3.yml
@@ -986,7 +986,7 @@ components:
           description: |
             Array of [Subresource integrity (SRI) hashes](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) for external SRC scripts that lets browsers validate the contents of the script.
 
-            The hash is the `integrity` attribute on the `script` tag. You can add up to five hashes for a script and generate them using any SRI standard-supported algorithm, including SHA-256, SHA-384, and SHA-512.
+            The hash is the `integrity` attribute on the `script` tag. You can add up to five hashes for a script and generate them using any SRI standard-supported algorithm, including SHA-256, SHA-384, and SHA-512. If you provide more than one hash, they will all be added to the `integrity` attribute in order, separated by whitespace.
           items:
             type: string
           example:

--- a/reference/scripts.v3.yml
+++ b/reference/scripts.v3.yml
@@ -981,3 +981,14 @@ components:
           type: integer
           example: 1
           minimum: 1
+        integrity_hashes:
+          type: array
+          description: |
+            Array of [SRI hashes](https://www.srihash.org/) for external SRC scripts that lets browsers validate the contents of the script.
+          items:
+            type: string
+            description: |
+              SRI hash that gets added as an attribute on the script tag. You can add up to five hashes for a script and generate them using any of the algorithms (SHA-256, SHA-384, or SHA-512).
+          example:
+            - "sha384-DgtwqxoPLKnJSER+TUmSPIpE6ZbVb2ZZwR241HHiqJipLiZQPN/JkKX5xxrEHUTt"
+            - "sha384-UiwrqEuzfCtJKLI+dXmPNOpE6ZvBh2IIqT371rJiqJxyKjZ6PP/JmSD5hdsEUPOl"

--- a/reference/scripts.v3.yml
+++ b/reference/scripts.v3.yml
@@ -986,7 +986,7 @@ components:
           description: |
             Array of [Subresource integrity (SRI) hashes](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) for external SRC scripts that lets browsers validate the contents of the script.
 
-            The hash is set as the `integrity` attribute on the `script` tag. You can add up to five hashes for a script and generate them using any of the SRI standard-supported algorithms, including SHA-256, SHA-384, and SHA-512.
+            The hash is the `integrity` attribute on the `script` tag. You can add up to five hashes for a script and generate them using any SRI standard-supported algorithm, including SHA-256, SHA-384, and SHA-512.
           items:
             type: string
           example:


### PR DESCRIPTION
# [DEVDOCS-5796]


## What changed?
- update Scripts yml file to include hash property
- update Scripts doc to include info about how BC handles integrity hashes

## Release notes draft

* The newly-released SRI hash feature is now available to use. Now, you’ll be able to add SRI hashes to external SRC scripts.



[DEVDOCS-5796]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ