### PR TITLE
DEVDOCS-5856: [update] added deliveryException hooks to webhook events

### DIFF
--- a/docs/api-docs/webhooks/webhook-events.mdx
+++ b/docs/api-docs/webhooks/webhook-events.mdx
@@ -339,7 +339,7 @@ Payload objects with the following scopes take the form that follows:
 
 | Name / Scope             | Description |
 |:-------------------------|:------------|
-| store/hook/deliveryException | Once configured by the API client, this hook fires when the platform has issues delivering regular hooks. The system will attempt to send this new hook and provide information regarding unsuccessful webhook delivery. There can only be one hook per store_id or clientId. The destination must be different from all other hook destinations.  |
+| store/hook/deliveryException | Once configured by the API client, this hook fires when the destination has issues responding to regular hooks. The system will send deliveryException hook to a different destination and provide information regarding unsuccessful webhook delivery. There can only be one deliveryException hook per storeId/clientId. The destination **must** be different from all other hook destinations.  |
 
 There are three different error codes available:
 * 90001 - The hook couldn’t be delivered, but system will retry. This type is limited to be sent only once in 10 minutes per destination.

--- a/docs/api-docs/webhooks/webhook-events.mdx
+++ b/docs/api-docs/webhooks/webhook-events.mdx
@@ -335,6 +335,31 @@ Payload objects with the following scopes take the form that follows:
 }
 ```
 
+## Delivery exception hooks
+
+| Name / Scope             | Description |
+|:-------------------------|:------------|
+| store/webhook/deliveryException | This hook fires when client hooks are undeliverable.|
+
+Payload objects with the following scopes take the form that follows:
+
+* `store/webhook/deliveryException`
+
+```json filename="Example delivery exception payload object" showLineNumbers copy
+{
+  "scope": "store/webhook/deliveryException",
+  "store_id": "1025646",
+  "data": {
+    "type": "webhook",
+    "id": 123, // ID of the webhook
+    "error_code": 90001, // some error code for type of failure? retry vs deactivation, etc
+    "message": "Non-200 response received when delivering to https://app.com/bc/webhook, will retry"
+  },
+  "hash": "e0c298b8097a6a2f39d17e593a9b360f5b2fef7d",
+  "created_at": 1561482670,
+  "producer": "stores/{store_hash}"
+}
+```
 
 ## Emails
 

--- a/docs/api-docs/webhooks/webhook-events.mdx
+++ b/docs/api-docs/webhooks/webhook-events.mdx
@@ -339,15 +339,23 @@ Payload objects with the following scopes take the form that follows:
 
 | Name / Scope             | Description |
 |:-------------------------|:------------|
-| store/webhook/deliveryException | This hook fires when client hooks are undeliverable.|
+| store/hook/deliveryException | Once configured by the API client, this hook fires when the platform has issues delivering regular hooks. The system will attempt to send this new hook and provide information regarding unsuccessful webhook delivery. There can only be one hook per store_id or clientId. The destination must be different from all other hook destinations.  |
+
+There are three different error codes available:
+* 90001 - The hook couldn’t be delivered, but system will retry. This type is limited to be sent only once in 10 minutes per destination.
+* 90002 - The hook couldn’t be delivered. All attempts are exhausted. The hook is going to be disabled.
+* 90003 - The hook couldn’t be delivered because domain was blocked.
+
+See [Webhooks Overview](/docs/integrations/webhooks) and [Troubleshooting](/docs/integrations/webhooks) documentation for more information.
+
 
 Payload objects with the following scopes take the form that follows:
 
-* `store/webhook/deliveryException`
+* `store/hook/deliveryException`
 
 ```json filename="Example delivery exception payload object" showLineNumbers copy
 {
-  "scope": "store/webhook/deliveryException",
+  "scope": "store/hook/deliveryException",
   "store_id": "1025646",
   "data": {
     "type": "webhook",

--- a/docs/api-docs/webhooks/webhook-events.mdx
+++ b/docs/api-docs/webhooks/webhook-events.mdx
@@ -344,7 +344,7 @@ Payload objects with the following scopes take the form that follows:
 There are three different error codes available:
 * 90001 - The hook couldn’t be delivered, but system will retry. This type is limited to be sent only once in 10 minutes per destination.
 * 90002 - The hook couldn’t be delivered. All attempts are exhausted. The hook is going to be disabled.
-* 90003 - The hook couldn’t be delivered because domain was blocked.
+* 90003 - The hook couldn’t be delivered because the destination domain was temporarily blocked due to many unsuccessful attempts to deliver hooks.
 
 See [Webhooks Overview](/docs/integrations/webhooks) and [Troubleshooting](/docs/integrations/webhooks) documentation for more information.
 


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-5856]


## What changed?
Added deliveryException hooks to webhook events

## Release notes draft
The newly-released delivery exception webhooks alert users of delivery issues at their primary delivery destination.


## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-5856]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ