### PR TITLE
fix category assignments link

### DIFF
--- a/docs/api-docs/channels/channel-webhooks.mdx
+++ b/docs/api-docs/channels/channel-webhooks.mdx
@@ -378,7 +378,7 @@ The following product assignment webhook events fire in response to actions that
 |:-------------|:------------|:-----------------------|
 | `store/channel/{channel_id}/product/assigned`            | Fires when a product is assigned to the specified channel. | [Create product channel assignments](/docs/rest-catalog/products/channel-assignments#create-products-channel-assignments) |
 | `store/channel/{channel_id}/product/unassigned`          | Fires when a product is removed from the specified channel. | [Delete product channel assignments](/docs/rest-catalog/products/channel-assignments#delete-products-channel-assignments) |
-| `store/channel/{channel_id}/category/product/assigned`   | Fires when a product is assigned to a category in the specified channel's category tree. | [Create product category assignments](/docs/rest-catalog/products/category-assignments#create-products-category-assignments.) |
+| `store/channel/{channel_id}/category/product/assigned`   | Fires when a product is assigned to a category in the specified channel's category tree. | [Create product category assignments](/docs/rest-catalog/products/category-assignments#create-products-category-assignments) |
 | `store/channel/{channel_id}/category/product/unassigned` | Fires when a product is removed from a category in the specified channel's category tree. | [Delete product category assignments](/docs/rest-catalog/products/category-assignments#delete-products-category-assignments) |
 
 Product assignment payload objects take the form that follows:

--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -5044,7 +5044,7 @@ paths:
                   meta:
                     $ref: '#/components/schemas/MetaPaginationObject'
     put:
-      summary: Create Products Category Assignments.
+      summary: Create Products Category Assignments
       description: Creates products category assignments.
       operationId: createProductsCategoryAssignments
       parameters:


### PR DESCRIPTION
## What changed?
* Removed dot from the end of the `PUT Create Products Category Assignments` summary
* Updated link to category assignments on the Channel Webhooks page
These changes with broken link (because of dot sign at the end):

https://github.com/bigcommerce/docs/assets/79109064/49baa6df-354d-4c18-9ba7-a3915e844429



## Release notes draft
Not sure what to put here, need help from Dev Docs team.

Bug Fix
