### PR TITLE
[DEVDOCS-5829]: [revise] OrdersV3, Update notes for /refund_quotes endpoint

### DIFF
--- a/reference/orders.v3.yml
+++ b/reference/orders.v3.yml
@@ -161,11 +161,11 @@ paths:
 
         Requires at least one of the following scopes:
         * `store_v2_orders`
-        * `store_v2_transactions`
-
-        **Note:**
-        Create a refund quote before performing a refund request to best avoid a `422` error. Check the refund quote's response body for the `refund_methods` array. The `amount` given in the array must match the `amount` used in the refund request body.
-
+        * `store_v2_transactions`   
+      
+        **Notes:**
+        * Create a refund quote before performing a refund request to best avoid a `422` error. Check the refund quote's response body for the `refund_methods` array. The `amount` given in the array must match the `amount` used in the refund request body.
+        * Order refunds are processed consecutively. Processing synchronous refunds on an order is not yet supported.
       operationId: createOrderRefundQuotes
       parameters:
         - $ref: '#/components/parameters/ContentType'

--- a/reference/orders.v3.yml
+++ b/reference/orders.v3.yml
@@ -164,7 +164,7 @@ paths:
         * `store_v2_transactions`
 
         **Note:**
-        Order refunds are processed consecutively. Processing synchronous refunds on an order are not yet supported.
+        Create a refund quote before performing a refund request to best avoid a `422` error. Check the refund quote's response body for the `refund_methods` array. The `amount` given in the array must match the `amount` used in the refund request body.
 
       operationId: createOrderRefundQuotes
       parameters:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-5829]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Add note describing the logical relationship between the amounts used in the /refunds_quotes endpoint and the /refunds endpoint.

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @bc-vincent-zhao 


[DEVDOCS-5829]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ