### PR TITLE
DEVDOCS-5627 [update]: Remark linter 

### DIFF
--- a/.github/actions/retext-style-guide/action.yml
+++ b/.github/actions/retext-style-guide/action.yml
@@ -28,6 +28,12 @@ inputs:
   reviewdog_flags:
     description: 'Additional reviewdog flags'
     default: ''
+  before_commit:
+    description: 'Commit SHA before you triggered the event'
+    default: '${{ github.event.before }}'
+  after_commit:
+    description: 'Commit SHA after you triggered the event'
+    default: '${{ github.sha }}'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/.github/actions/retext-style-guide/entrypoint.sh
+++ b/.github/actions/retext-style-guide/entrypoint.sh
@@ -18,3 +18,4 @@ find ${GITHUB_WORKSPACE} -type f -name '*.mdx' -exec quality-docs {} + \
       -level="${INPUT_LEVEL}" \
       ${INPUT_REVIEWDOG_FLAGS} \
       -tee
+      -diff="git diff --unified=0 ${INPUT_BEFORE_COMMIT} ${INPUT_AFTER_COMMIT}"

--- a/.github/actions/retext-style-guide/entrypoint.sh
+++ b/.github/actions/retext-style-guide/entrypoint.sh
@@ -17,5 +17,5 @@ find ${GITHUB_WORKSPACE} -type f -name '*.mdx' -exec quality-docs {} + \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
       -level="${INPUT_LEVEL}" \
       ${INPUT_REVIEWDOG_FLAGS} \
-      -tee
+      -tee \
       -diff="git diff --unified=0 ${INPUT_BEFORE_COMMIT} ${INPUT_AFTER_COMMIT}"

--- a/.github/workflows/retext-style-guide.yml
+++ b/.github/workflows/retext-style-guide.yml
@@ -5,9 +5,15 @@ jobs:
     name: runner / retext-style-guide
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - uses: ./.github/actions/retext-style-guide
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           filter_mode: added
+          before_commit: ${{ github.event.before }}
+          after_commit: ${{ github.sha }}


### PR DESCRIPTION
# [DEVDOCS-5627]

## What changed?

Before: 
- When I make a commit, Reviewdog (re)comments on all the lines in the PR 

After:
- When I make a commit, Reviewdog comments on only the lines included in the commit 

[DEVDOCS-5627]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ