### PR TITLE
[DEVDOCS-5931]: [update] Ordersv2, Remove outdated shipper from create order shipment list

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -643,7 +643,6 @@ paths:
          - `royalmail`
          - `ups`
          - `upsready`
-         - `upsonline`
          - `shipperhq`
          - `carrier_{your_carrier_id}`, when the carrier is a [third-party Shipping Provider](/docs/integrations/shipping) 
         


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-5931]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Remove UPSOnline from the list of shippers

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
*  Create an order shipment no longer supports UPSOnline as a shipper

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-5931]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ