### PR TITLE
doc(customers): CUST-2597 Customers-Subscribers overview page

### DIFF
--- a/docs/api-docs/customers/customers-subscribers-overview.mdx
+++ b/docs/api-docs/customers/customers-subscribers-overview.mdx
@@ -170,7 +170,40 @@ The V3 Customers API offers two ways to set a customer's password:
 
 ## Subscribers API
 
-The Subscribers API allows you to manage subscribers who have signed up for the store’s newsletter.
+The Subscribers API allows you to manage subscribers who have signed up for the store’s newsletter or have signed up for abandoned cart emails.
+An important field to note is `consents` - this is what determines whether the Subscriber has been signed up for marketing newsletter emails, abandoned cart emails, or both. This can also be empty, meaning they have not subscribed to either (or may have opted out).
+
+```http filename="Example request: Create a Subscriber V3" showLineNumbers
+POST https://api.bigcommerce.com/stores/{{store_hash}}/v3/customers/subscribers
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "email": "string@test.com",
+  "first_name": "string",
+  "last_name": "string",
+  "channel_id": 1,
+  "consents": ["marketing_newsletter", "abandoned_cart"],
+  "source": "storefront"
+}
+```
+
+```http filename="Example request: Update a Subscriber V3" showLineNumbers
+POST https://api.bigcommerce.com/stores/{{store_hash}}/v3/customers/subscribers/1
+X-Auth-Token: {{ACCESS_TOKEN}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "email": "string@test.com",
+  "first_name": "string",
+  "last_name": "string",
+  "channel_id": 1,
+  "consents": [],
+  "source": "order"
+}
+```
 
 ## FAQ
 


### PR DESCRIPTION
# [CUST-2597]


## What changed?
* Added examples of POST/PUT requests for subscribers
* Added information around the importance of `consents` determining whether a subscriber has opted in or not

## Release notes draft
Currently there is ambiguity around what it means to be a subscriber or not. When a shopper is created during checkout, regardless a subscriber will be created (however they may not be opted in, a record exists regardless).

## Anything else?
N/A

ping @bc-tgomez @bigcommerce/team-customers 


[CUST-2597]: https://bigcommercecloud.atlassian.net/browse/CUST-2597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ