### PR TITLE
No ticket: Tax Provider API, add `fee` tax item type to `tax_item` types

### DIFF
--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -1293,6 +1293,7 @@ components:
       enum:
         - item
         - refund
+        - fee
     shipping_type:
       type: string
       description: |-


### PR DESCRIPTION
## What changed?
- Add `fee` to tax item types.
 
## Release notes draft
No need for release notes, minor additive change that reflects an adjustment from some months ago.

## Anything else?
Nope.