### PR TITLE
ISSUE-280 + ISSUE-281: [update] Product variant metafields, reorder fields + populate response example

### DIFF
--- a/reference/catalog/product-variants_catalog.v3.yml
+++ b/reference/catalog/product-variants_catalog.v3.yml
@@ -2593,17 +2593,6 @@ components:
           description: Client ID for the metafieldʼs creator.
           example: asdfasdfasdfasdfasdfasdfasdf
           readOnly: true
-      required:
-        - namespace
-        - key
-        - value
-        - permission_set
-        - resource_type
-        - resource_id
-        - description
-        - id
-        - date_created
-        - date_modified
     MetaFieldCollectionResponse:
       type: object
       description: |

--- a/reference/catalog/product-variants_catalog.v3.yml
+++ b/reference/catalog/product-variants_catalog.v3.yml
@@ -2506,7 +2506,7 @@ components:
     Metafield:
       type: object
       description: |
-        Common Metafield properties.
+        Common metafield properties.
       x-internal: false
       properties:
         id:
@@ -2570,7 +2570,6 @@ components:
           description: |
             The unique identifier for the resource with which the metafield is associated.
           example: 424242
-          readOnly: true
         description:
           type: string
           description: |
@@ -2592,7 +2591,6 @@ components:
           type: string
           description: Client ID for the metafieldʼs creator.
           example: asdfasdfasdfasdfasdfasdfasdf
-          readOnly: true
     MetaFieldCollectionResponse:
       type: object
       description: |

--- a/reference/catalog/product-variants_catalog.v3.yml
+++ b/reference/catalog/product-variants_catalog.v3.yml
@@ -2824,9 +2824,30 @@ components:
     MetafieldBase_Post:
       type: object
       description: |
-        Common Metafield properties.
+        Common metafield properties.
       x-internal: false
       properties:
+        key:
+          type: string
+          description: |
+            The name of the field, for example: `location_id`, `color`.
+          minLength: 1
+          maxLength: 64
+          example: Staff Name
+        value:
+          type: string
+          description: |
+            The value of the field, for example: `1`, `blue`.
+          minLength: 1
+          maxLength: 65535
+          example: Ronaldo
+        namespace:
+          type: string
+          description: |
+            Namespace for the metafield, for organizational purposes.
+          example: Sales Department
+          minLength: 1
+          maxLength: 64
         permission_set:
           type: string
           description: |
@@ -2844,27 +2865,6 @@ components:
             - write
             - read_and_sf_access
             - write_and_sf_access
-        namespace:
-          type: string
-          description: |
-            Namespace for the metafield, for organizational purposes.
-          example: Sales Department
-          minLength: 1
-          maxLength: 64
-        key:
-          type: string
-          description: |
-            The name of the field, for example: `location_id`, `color`.
-          minLength: 1
-          maxLength: 64
-          example: Staff Name
-        value:
-          type: string
-          description: |
-            The value of the field, for example: `1`, `blue`.
-          minLength: 1
-          maxLength: 65535
-          example: Ronaldo
         description:
           type: string
           description: |
@@ -2883,6 +2883,27 @@ components:
         Common Metafield properties.
       x-internal: false
       properties:
+        key:
+          type: string
+          description: |
+            The name of the field, for example: `location_id`, `color`.
+          minLength: 1
+          maxLength: 64
+          example: Staff Name
+        value:
+          type: string
+          description: |
+            The value of the field, for example: `1`, `blue`.
+          minLength: 1
+          maxLength: 65535
+          example: Ronaldo
+        namespace:
+          type: string
+          description: |
+            Namespace for the metafield, for organizational purposes.
+          example: Sales Department
+          minLength: 1
+          maxLength: 64
         permission_set:
           type: string
           description: |
@@ -2900,27 +2921,6 @@ components:
             - write
             - read_and_sf_access
             - write_and_sf_access
-        namespace:
-          type: string
-          description: |
-            Namespace for the metafield, for organizational purposes.
-          example: Sales Department
-          minLength: 1
-          maxLength: 64
-        key:
-          type: string
-          description: |
-            The name of the field, for example: `location_id`, `color`.
-          minLength: 1
-          maxLength: 64
-          example: Staff Name
-        value:
-          type: string
-          description: |
-            The value of the field, for example: `1`, `blue`.
-          minLength: 1
-          maxLength: 65535
-          example: Ronaldo
         description:
           type: string
           description: |

--- a/reference/catalog/product-variants_catalog.v3.yml
+++ b/reference/catalog/product-variants_catalog.v3.yml
@@ -1655,7 +1655,7 @@ paths:
       - $ref: '#/components/parameters/Accept'
   '/catalog/variants/metafields':
     get:
-      summary: Get All Product Variant Metafields
+      summary: Get all product variant metafields
       tags:
         - Batch metafields
       description: Get all variant metafields.
@@ -2509,6 +2509,30 @@ components:
         Common Metafield properties.
       x-internal: false
       properties:
+        id:
+          type: integer
+          description: The unique identifier for the metafield.
+        key:
+          type: string
+          description: |
+            The name of the field, for example: `location_id`, `color`.
+          minLength: 1
+          maxLength: 64
+          example: Staff Name
+        value:
+          type: string
+          description: |
+            The value of the field, for example: `1`, `blue`.
+          minLength: 1
+          maxLength: 65535
+          example: Ronaldo
+        namespace:
+          type: string
+          description: |
+            Namespace for the metafield, for organizational purposes.
+          example: Sales Department
+          minLength: 1
+          maxLength: 64
         permission_set:
           type: string
           description: |
@@ -2526,34 +2550,6 @@ components:
             - write
             - read_and_sf_access
             - write_and_sf_access
-        namespace:
-          type: string
-          description: |
-            Namespace for the metafield, for organizational purposes.
-          example: Sales Department
-          minLength: 1
-          maxLength: 64
-        key:
-          type: string
-          description: |
-            The name of the field, for example: `location_id`, `color`.
-          minLength: 1
-          maxLength: 64
-          example: Staff Name
-        value:
-          type: string
-          description: |
-            The value of the field, for example: `1`, `blue`.
-          minLength: 1
-          maxLength: 65535
-          example: Ronaldo
-        description:
-          type: string
-          description: |
-            Description for the metafields.
-          example: order
-          minLength: 0
-          maxLength: 255
         resource_type:
           type: string
           description: |
@@ -2575,9 +2571,13 @@ components:
             The unique identifier for the resource with which the metafield is associated.
           example: 424242
           readOnly: true
-        id:
-          type: integer
-          description: The unique identifier for the metafield.
+        description:
+          type: string
+          description: |
+            Description for the metafields.
+          example: order
+          minLength: 0
+          maxLength: 255
         date_created:
           type: string
           format: date-time
@@ -2886,10 +2886,10 @@ components:
           maxLength: 255
           example: Name of Staff Member
       required:
-        - permission_set
-        - namespace
         - key
         - value
+        - namespace
+        - permission_set
     MetafieldBase_Put:
       type: object
       description: |


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# ISSUE-280 + ISSUE-281: [update] Product variant metafields, reorder fields + populate response example
* #280
* #281


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Reorder fields in the several product variant metafields responses
* Populate response body by removing required and readOnly fields from response schema

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @atensoftware @bc-tgomez
