### PR TITLE
DEVDOCS-5890 [new]: Stencil theme, add Japanese language

### DIFF
--- a/docs/stencil-docs/localization/localizing-stores.mdx
+++ b/docs/stencil-docs/localization/localizing-stores.mdx
@@ -38,6 +38,7 @@ BigCommerce's Cornerstone Stencil theme supports these uneditable strings in the
 * French
 * German
 * Italian
+* Japanese
 * Norwegian
 * Polish
 * Portuguese

--- a/docs/stencil-docs/localization/multi-language-checkout.mdx
+++ b/docs/stencil-docs/localization/multi-language-checkout.mdx
@@ -70,6 +70,7 @@ You can provide values for all of the checkout's supported translation keys even
 | French | `fr.json` |
 | German | `de.json` |
 | Italian | `it.json` |
+| Japanese | `ja-JP.json` |
 | Norwegian| `no.json`|
 | Polish   | `pl.json` |
 | Portuguese| `pt.json`|

--- a/docs/stencil-docs/localization/multi-language-checkout.mdx
+++ b/docs/stencil-docs/localization/multi-language-checkout.mdx
@@ -70,7 +70,7 @@ You can provide values for all of the checkout's supported translation keys even
 | French | `fr.json` |
 | German | `de.json` |
 | Italian | `it.json` |
-| Japanese | `ja-JP.json` |
+| Japanese | `ja.json` |
 | Norwegian| `no.json`|
 | Polish   | `pl.json` |
 | Portuguese| `pt.json`|


### PR DESCRIPTION
# [DEVDOCS-5890]


## What changed?
- Add Japanese as a supported language for your Stencil storefront content. 

## Release notes draft

We are excited to announce Japanese language support. Now, BigCommerce's Cornerstone Stencil theme supports uneditable strings in Japanese.

## Anything else?

@bigcommerce/team-localization 


[DEVDOCS-5890]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ