### PR TITLE
doc(orders): ORDERS-6364 ORDERS-6365 support new query parameter "tra…

### DIFF
--- a/reference/orders.v3.yml
+++ b/reference/orders.v3.yml
@@ -358,6 +358,11 @@ paths:
     parameters:
       - $ref: '#/components/parameters/Accept'
       - $ref: '#/components/parameters/OrderIdParam'
+      - in: query
+        name: 'transaction_id'
+        description: Filter by refund payment BC transaction_id.
+        schema:
+          type: string
   '/orders/payment_actions/refunds/{refund_id}':
     parameters:
       - $ref: '#/components/parameters/Accept'
@@ -434,6 +439,11 @@ paths:
           schema:
             type: string
             format: date-time
+        - in: query
+          name: 'transaction_id'
+          description: Filter by refund payment BC transaction_id.
+          schema:
+            type: string
         - in: query
           name: page
           description: Specifies the page number in a limited (paginated) list of items.
@@ -2847,6 +2857,10 @@ components:
         declined_message:
           type: string
           description: Message indicate why payment was declined.
+        transaction_id:
+          type: string
+          description: The BC transaction_id.
+          example: '1234'
       x-internal: false
     PaymentOption:
       type: object


### PR DESCRIPTION
…nsaction_id" and also add new field "transaction_id" in the response of the GET Refunds API

# [ORDERS-6364 and ORDERS-6365]

## What changed?
* Support new query parameter `transaction_id` in GET Refunds API endpoints: 
e.g.: 
GET /v3/orders/{id}/payment_actions/refunds?transaction_id=13
GET /v3/orders/payment_actions/refunds?transaction_id=13

* Expose `transaction_id` field to refund.payment on the API:

![image](https://github.com/bigcommerce/docs/assets/63274600/e1059f15-a8ba-4d72-b215-677bddcf62b9)

**Testing proof**:
- The new query param is displayed correctly in the swagger editor: 

<img width="632" alt="image" src="https://github.com/bigcommerce/docs/assets/63274600/29037ec4-7c7c-4680-8bd6-e14ca8ea4f86">

- The new field is displayed correctly in the swagger editor: 

<img width="611" alt="image" src="https://github.com/bigcommerce/docs/assets/63274600/a56a1ff7-ad47-4656-948f-3c3d892382f8">


## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 


ping @bigcommerce/team-orders @slsriehl @bc-tgomez 
