### PR TITLE
Fix response code for createShippingZones operation

### DIFF
--- a/reference/shipping.v2.yml
+++ b/reference/shipping.v2.yml
@@ -305,7 +305,7 @@ paths:
                   name: Global
                   type: global
       responses:
-        '200':
+        '201':
           description: ''
           content:
             application/json:


### PR DESCRIPTION
## What changed?
Change response code
![image](https://github.com/bigcommerce/docs/assets/425208/d4b71d0d-2453-4494-b52c-2683d2fb79e5)

## Release notes draft

Fixed a bug in the /v2/shipping/zones. Now the response code is 201 instead of 200

## Anything else?
-