### PR TITLE
[DEVDOCS-5715]: [revise] Customers V3, Add origin_channel_id to the list of read only fields

### DIFF
--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -323,7 +323,7 @@ paths:
 
         * Attributes Values can not be updated using Update a Customer. Use the [Update customer attribute values](/docs/rest-management/customers/customer-attribute-values#upsert-customer-attribute-values) endpoint.
         * channel_ids -- Updating the list of channels a customer can access may create some side effects in a multi-storefront situation. This list determines which customer account we will use to authenticate a shopper given a channel.
-        * origin_channel_id -- Updating the string value doesn't return an error, nor does it update the value. This value is set when you create a customer.
+        * origin_channel_id -- This is an immutable value set as a reference to the channel of origin when a customer is created.
       summary: Update Customers
       tags:
         - Customers

--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -316,12 +316,14 @@ paths:
         * registration_ip_address
         * date_created
         * date_modified
+        * origin_channel_id
 
 
         **Notes**
 
         * Attributes Values can not be updated using Update a Customer. Use the [Update customer attribute values](/docs/rest-management/customers/customer-attribute-values#upsert-customer-attribute-values) endpoint.
         * channel_ids -- Updating the list of channels a customer can access may create some side effects in a multi-storefront situation. This list determines which customer account we will use to authenticate a shopper given a channel.
+        * origin_channel_id -- Updating the string value doesn't return an error, nor does it update the value. This value is set when you create a customer.
       summary: Update Customers
       tags:
         - Customers


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-5715]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Add `origin_channel_ids` to the list of read only fields

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* Added origin_channel_id to the list of read-only fields in the Customers V3 API. This field is set upon customer creation and cannot be updated afterward.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @


[DEVDOCS-5715]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ