### PR TITLE
DEVDOCS-5929 [new]: Tax Settings API, add document submission strategy field

### DIFF
--- a/docs/api-docs/tax/tax-settings.mdx
+++ b/docs/api-docs/tax/tax-settings.mdx
@@ -36,7 +36,8 @@ To get tax settings, send a request to the [Get tax settings](/docs/rest-managem
       "should_subtract_store_tax": false,
       "should_use_geolocation_to_determine_guest_shopper_tax_zone": true,
       "guest_shopper_tax_zone_id": 1,
-      "store_tax_zone_id": 1
+      "store_tax_zone_id": 1,
+      "document_submission_strategy": "ON_ORDER_CREATION"
     },
     "meta": {}
   }
@@ -83,7 +84,8 @@ Accept: application/json
     "should_subtract_store_tax": false,
     "should_use_geolocation_to_determine_guest_shopper_tax_zone": true,
     "guest_shopper_tax_zone_id": 1,
-    "store_tax_zone_id": 1
+    "store_tax_zone_id": 1,
+    "document_submission_strategy": "ON_ORDER_CREATION"
   },
   "meta": {}
 }

--- a/reference/tax_settings.v3.yml
+++ b/reference/tax_settings.v3.yml
@@ -159,6 +159,13 @@ components:
           default: 1
           type: integer
           description: ID for the tax zone a store uses when subtracting store tax. This setting applies only if a merchant enters tax-inclusive prices and subtracts store tax before tax calculation.
+        document_submission_strategy:
+          default: ON_PAYMENT_CAPTURE
+          type: string
+          description: This setting determines whether BigCommerce submits tax documents to the tax provider when orders are created or when payments are captured online. 
+          enum:
+            - ON_PAYMENT_CAPTURE
+            - ON_ORDER_CREATION
     MetaOpen:
       title: Response meta
       type: object

--- a/reference/tax_settings.v3.yml
+++ b/reference/tax_settings.v3.yml
@@ -162,7 +162,7 @@ components:
         document_submission_strategy:
           default: ON_PAYMENT_CAPTURE
           type: string
-          description: This setting determines whether BigCommerce submits tax documents to the tax provider when orders are created or when payments are captured online. 
+          description: This setting determines whether BigCommerce submits tax documents to third-party tax providers when orders are created or when payments are captured online. 
           enum:
             - ON_PAYMENT_CAPTURE
             - ON_ORDER_CREATION


### PR DESCRIPTION
# [DEVDOCS-5929]


## What changed?
- Add document submission strategy field

## Release notes draft

* We're happy to announce the [Tax Settings API's](https://developer.bigcommerce.com/docs/rest-management/tax-settings) new `document_submission_strategy` field, which lets you choose when tax documents are submitted to third-party tax providers.


[DEVDOCS-5929]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ