### PR TITLE
DEVDOCS-5971 [new]: GQL Storefront API / Customers, add password complexity requirements

### DIFF
--- a/docs/storefront/graphql/customers.mdx
+++ b/docs/storefront/graphql/customers.mdx
@@ -18,6 +18,8 @@ Customer mutations and queries can do the following:
 * Reset a password
 * Get a customer address book
 
+When you register a customer, change a password, or reset a password, you can validate the password using [complexity requirements]() before submitting the desired password to the BigCommerce platform.
+
 ## Tokens
 
 To make requests, create a [store-level](/docs/start/authentication/api-accounts#store-level-api-accounts) or [app-level](/docs/start/authentication/api-accounts#app-level-api-accounts) API account with one or more of the following token creation OAuth scopes:

--- a/docs/storefront/graphql/customers.mdx
+++ b/docs/storefront/graphql/customers.mdx
@@ -18,7 +18,7 @@ Customer mutations and queries can do the following:
 * Reset a password
 * Get a customer address book
 
-When you register, change, or reset a password, you can validate it using the password complexity requirements under the [CustomerSettings node](/graphql-storefront/reference#definition-CustomersSettings) before submitting the desired password to the BigCommerce platform.
+When you register, change, or reset a password, you can validate it using the password complexity requirements under the [CustomersSettings node](/graphql-storefront/reference#definition-CustomersSettings) before submitting the desired password to the BigCommerce platform.
 
 ## Tokens
 

--- a/docs/storefront/graphql/customers.mdx
+++ b/docs/storefront/graphql/customers.mdx
@@ -18,7 +18,7 @@ Customer mutations and queries can do the following:
 * Reset a password
 * Get a customer address book
 
-When you register, change, or reset a password, you can validate the password using [complexity requirements](/graphql-storefront/reference#definition-CustomersSettings) before submitting the desired password to the BigCommerce platform.
+When you register, change, or reset a password, you can validate it using the password complexity requirements under the [CustomerSettings node](/graphql-storefront/reference#definition-CustomersSettings) before submitting the desired password to the BigCommerce platform.
 
 ## Tokens
 

--- a/docs/storefront/graphql/customers.mdx
+++ b/docs/storefront/graphql/customers.mdx
@@ -18,7 +18,7 @@ Customer mutations and queries can do the following:
 * Reset a password
 * Get a customer address book
 
-When you register a customer, change a password, or reset a password, you can validate the password using [complexity requirements]() before submitting the desired password to the BigCommerce platform.
+When you register, change, or reset a password, you can validate the password using [complexity requirements](/graphql-storefront/reference#definition-CustomersSettings) before submitting the desired password to the BigCommerce platform.
 
 ## Tokens
 


### PR DESCRIPTION
# [DEVDOCS-5971]

## What changed?
<!-- Provide a bulleted list in the present tense -->
* Mention password complexity requirements that developers can use to validate passwords when registering / changing / resetting a customer's password

## Release notes draft

* The GraphQL Storefront API's newly-released [`CustomersSettings` node](https://developer.bigcommerce.com/graphql-storefront/reference#definition-CustomersSettings) has password complexity requirements that are now available. Now, when you register, update, or reset a customer's password, you’ll be able to validate it before submitting the customer's desired password to the BigCommerce Platform.

## Anything else?

This PR relates to [PR 3054](https://github.com/bigcommerce/storefront/pull/3054) (editing schema descriptions)

To prevent broken links, this PR should be merged only after the node shows up on https://developer.bigcommerce.com/graphql-storefront/reference 

@bigcommerce/team-storefront 


[DEVDOCS-5971]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ