### PR TITLE
SELFDEV-626 Change PUT site's routes body to array

### DIFF
--- a/reference/sites.v3.yml
+++ b/reference/sites.v3.yml
@@ -401,7 +401,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/siteRoute_Full'
+              type: array
+              items:
+                $ref: '#/components/schemas/siteRoute_Full'
         x-examples:
           application/json:
             - id: 1


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [SELFDEV-626]


## What changed?
This PR changes the request body of PUT site's routes to an array of objects, as pointed out by the SELFDEV-626 submitter. 

> Furthermore, the code sample for "Update a Site's Routes" is incorrect. Since it's a bulk update for all possible Routes, it should be wrapped in an array:
> ```
> [{
> "id": 0,
> "type": "product",
> "matching": "5",
> "route": "/my-amazing-product"
> }]
> ```
> Attempting to run the code sample presently documented will result in this error:
> 
> ```
> "status": 422,
> "title": "The request payload has to be a JSON array for the endpoint"
> ```


[SELFDEV-626]: https://bigcommercecloud.atlassian.net/browse/SELFDEV-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ