### PR TITLE
Update bulk pricing tiers documentation to cover `null` case

### DIFF
--- a/reference/price_lists.v3.yml
+++ b/reference/price_lists.v3.yml
@@ -1088,12 +1088,13 @@ paths:
                                   quantity_min:
                                     type: integer
                                     description: |
-                                      The minimum quantity of associated variant in the cart needed to qualify for this tiers pricing.
+                                      The minimum quantity of associated variant in the cart needed to qualify for this tier's pricing.
                                     example: 1
                                   quantity_max:
                                     type: integer
+                                    nullable: true
                                     description: |
-                                      The maximum allowed quantity of associated variant in the cart to qualify for this tiers pricing.
+                                      The maximum allowed quantity of associated variant in the cart to qualify for this tier's pricing. `null` indicates that there is no maximum allowed quantity for this tier.
                                     example: 10
                                   type:
                                     type: string


### PR DESCRIPTION
Update schemas for pricelist bulk tiers to cover that `null` may be returned when there is no upper limit on the quantity for a given tier.

## What changed?

* Update schemas for pricelist bulk tiers to cover that `null` may be returned when there is no upper limit on the quantity for a given tier.
* Unrelatedly, add a `'` to "this tiers pricing" since it's a possessive rather than a plural.

## Release notes draft
* Clarified documentation for pricelist bulk tier pricing to explain tiers with no upper quantity limit.

## Anything else?
Nope 😄 
