### PR TITLE
[DEVDOCS-6006] Document is_deleted flag for Orders

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -4078,7 +4078,7 @@ components:
           type: number
           description: The number of shipping addresses associated with this transaction. A read-only value. Do not pass in a POST or PUT.
         is_deleted:
-          description: Indicates whether the order is deleted/archived. When set to true in a PUT, has the same result as the DELETE an order call.
+          description: Indicates whether the order is deleted/archived. When set to true in a PUT request, it has the same result as the DELETE an order request.
           example: false
           type: boolean
         is_email_opt_in:

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -4077,6 +4077,10 @@ components:
         shipping_address_count:
           type: number
           description: The number of shipping addresses associated with this transaction. A read-only value. Do not pass in a POST or PUT.
+        is_deleted:
+          description: Indicates whether the order is deleted/archived. When set to true in a PUT, has the same result as the DELETE an order call.
+          example: false
+          type: boolean
         is_email_opt_in:
           description: Indicates whether the shopper has selected an opt-in check box (on the checkout page) to receive emails. A read-only value. Do not pass in a POST or PUT.
           example: false


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6006]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Added `is_deleted` flag to order response attributes for [POST](https://developer.bigcommerce.com/docs/rest-management/orders#create-an-order), [PUT](https://developer.bigcommerce.com/docs/rest-management/orders#update-an-order), [GET ](https://developer.bigcommerce.com/docs/rest-management/orders#get-an-order)and[ GET all](https://developer.bigcommerce.com/docs/rest-management/orders#get-all-orders) calls
* Response body attributes map to order_RespOnly YAML object

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* Documentation for `is_deleted` flag in V2 Orders API

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->
*Twined with DEVDOCS-6007 - Investigate missing `is_deleted` parameter/attribute in Orders documentation



[DEVDOCS-6006]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ