### PR TITLE
Add copy of order_source for POST/PUT request params

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -3727,6 +3727,17 @@ components:
           description: Amount of discount for this transaction. (Float, Float-As-String, Integer)
           example: '0.0000'
           type: string
+        order_source:
+          description: |-
+            The `order_source` reflects the origin of the order. It will indicate whether the order was created by one of the following:
+            * storefront 
+            * control panel
+            * manual order
+            * /v2/orders API
+            * Checkout API
+            * or by an integration with an external platform such as Facebook by Meta or Amazon.
+          example: 'www'
+          type: string
         ebay_order_id:
           description: If the order was placed through eBay, the eBay order number will be included. Otherwise, the value will be `0`.
           example: '0'
@@ -4405,6 +4416,17 @@ components:
             discount_amount:
               description: Amount of discount for this transaction. (Float, Float-As-String, Integer)
               example: '0.0000'
+              type: string
+            order_source:
+              description: |-
+                The `order_source` reflects the origin of the order. It will indicate whether the order was created by one of the following:
+                * storefront 
+                * control panel
+                * manual order
+                * /v2/orders API
+                * Checkout API
+                * or by an integration with an external platform such as Facebook by Meta or Amazon.
+              example: 'www'
               type: string
             ebay_order_id:
               description: If the order was placed through eBay, the eBay order number will be included. Otherwise, the value will be `0`.


### PR DESCRIPTION
Copied existing content for `order_source` attribute to show as request param for POST/PUT requests.

<!-- Ticket number or summary of work -->
# [DEVDOCS-6008] `order_source` missing from request parameters


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Addition of `order_source` as a request parameter for Order [POST](https://developer.bigcommerce.com/docs/rest-management/orders#create-an-order)/[PUT ](https://developer.bigcommerce.com/docs/rest-management/orders#update-an-order) requests.
* Added in order_Put an order_Shared YAML objects.

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* Addition of `order_source` as a request parameter for Order [POST](https://developer.bigcommerce.com/docs/rest-management/orders#create-an-order)/[PUT ](https://developer.bigcommerce.com/docs/rest-management/orders#update-an-order) requests.


## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->
* Twined with DEVDOCS-6009: Re-work of order_source parameter description



[DEVDOCS-6008]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ