### PR TITLE
[DEVDOCS-6010] Remove pagination object for Themes API

### DIFF
--- a/reference/themes.v3.yml
+++ b/reference/themes.v3.yml
@@ -708,13 +708,7 @@ components:
                     settings: {}
                     date_created: ei
                     site_id: 52736226
-                meta:
-                  pagination:
-                    total: 36
-                    count: 36
-                    per_page: 50
-                    current_page: 1
-                    total_pages: 1
+                meta: {}
   securitySchemes:
     X-Auth-Token:
       name: X-Auth-Token
@@ -743,196 +737,23 @@ components:
   schemas:
     CollectionMeta:
       type: object
-      description: 'Data about the response, including pagination and collection totals.'
-      properties:
-        pagination:
-          type: object
-          description: 'Data about the response, including pagination and collection totals.'
-          title: Pagination
-          properties:
-            total:
-              type: integer
-              description: |
-                Total number of items in the result set.
-              example: 36
-            count:
-              type: integer
-              description: |
-                Total number of items in the collection response.
-              example: 36
-            per_page:
-              type: integer
-              description: |
-                The amount of items returned in the collection per page, controlled by the limit parameter.
-              example: 50
-            current_page:
-              type: integer
-              description: |
-                The page you are currently on within the collection.
-              example: 1
-            total_pages:
-              type: integer
-              description: |
-                The total number of pages in the collection.
-              example: 1
-            links:
-              type: object
-              description: |
-                Pagination links for the previous and next parts of the whole collection.
-              properties:
-                previous:
-                  type: string
-                  description: |
-                    Link to the previous page returned in the response.
-                current:
-                  type: string
-                  description: |
-                    Link to the current page returned in the response.
-                  example: '?page=1&limit=50'
-                next:
-                  type: string
-                  description: |
-                    Link to the next page returned in the response.
+      properties: {}
+      additionalProperties: true
+      description: Response metadata.
       title: Collection Meta
       x-internal: false
     ThemesCollectionMeta:
       type: object
-      description: 'Data about the response, including pagination and collection totals.'
-      properties:
-        pagination:
-          type: object
-          description: 'Data about the response, including pagination and collection totals.'
-          title: Pagination
-          properties:
-            total:
-              type: integer
-              description: |
-                Total number of items in the result set.
-              example: 36
-            count:
-              type: integer
-              description: |
-                Total number of items in the collection response.
-              example: 36
-            per_page:
-              type: integer
-              description: |
-                The amount of items returned in the collection per page, controlled by the limit parameter.
-              example: 50
-            current_page:
-              type: integer
-              description: |
-                The page you are currently on within the collection.
-              example: 1
-            total_pages:
-              type: integer
-              description: |
-                The total number of pages in the collection.
-              example: 1
+      properties: {}
+      additionalProperties: true
+      description: Response metadata.
       title: Themes Collection Meta
-      x-internal: false
-    Pagination:
-      type: object
-      description: 'Data about the response, including pagination and collection totals.'
-      title: Pagination
-      properties:
-        total:
-          type: integer
-          description: |
-            Total number of items in the result set.
-          example: 36
-        count:
-          type: integer
-          description: |
-            Total number of items in the collection response.
-          example: 36
-        per_page:
-          type: integer
-          description: |
-            The amount of items returned in the collection per page, controlled by the limit parameter.
-          example: 50
-        current_page:
-          type: integer
-          description: |
-            The page you are currently on within the collection.
-          example: 1
-        total_pages:
-          type: integer
-          description: |
-            The total number of pages in the collection.
-          example: 1
-        links:
-          type: object
-          description: |
-            Pagination links for the previous and next parts of the whole collection.
-          properties:
-            previous:
-              type: string
-              description: |
-                Link to the previous page returned in the response.
-            current:
-              type: string
-              description: |
-                Link to the current page returned in the response.
-              example: '?page=1&limit=50'
-            next:
-              type: string
-              description: |
-                Link to the next page returned in the response.
       x-internal: false
     Meta:
       type: object
-      description: 'Data about the response, including pagination and collection totals.'
-      title: Collection Meta
-      properties:
-        pagination:
-          type: object
-          description: 'Data about the response, including pagination and collection totals.'
-          title: Pagination
-          properties:
-            total:
-              type: integer
-              description: |
-                Total number of items in the result set.
-              example: 36
-            count:
-              type: integer
-              description: |
-                Total number of items in the collection response.
-              example: 36
-            per_page:
-              type: integer
-              description: |
-                The amount of items returned in the collection per page, controlled by the limit parameter.
-              example: 50
-            current_page:
-              type: integer
-              description: |
-                The page you are currently on within the collection.
-              example: 1
-            total_pages:
-              type: integer
-              description: |
-                The total number of pages in the collection.
-              example: 1
-            links:
-              type: object
-              description: |
-                Pagination links for the previous and next parts of the whole collection.
-              properties:
-                previous:
-                  type: string
-                  description: |
-                    Link to the previous page returned in the response.
-                current:
-                  type: string
-                  description: |
-                    Link to the current page returned in the response.
-                  example: '?page=1&limit=50'
-                next:
-                  type: string
-                  description: |
-                    Link to the next page returned in the response.
+      properties: {}
+      additionalProperties: true
+      description: Response metadata.
       x-internal: false
     ErrorResponse:
       allOf:
@@ -1204,56 +1025,9 @@ components:
                 type: string
         meta:
           type: object
-          description: 'Data about the response, including pagination and collection totals.'
-          properties:
-            pagination:
-              type: object
-              description: 'Data about the response, including pagination and collection totals.'
-              title: Pagination
-              properties:
-                total:
-                  type: integer
-                  description: |
-                    Total number of items in the result set.
-                  example: 36
-                count:
-                  type: integer
-                  description: |
-                    Total number of items in the collection response.
-                  example: 36
-                per_page:
-                  type: integer
-                  description: |
-                    The amount of items returned in the collection per page, controlled by the limit parameter.
-                  example: 50
-                current_page:
-                  type: integer
-                  description: |
-                    The page you are currently on within the collection.
-                  example: 1
-                total_pages:
-                  type: integer
-                  description: |
-                    The total number of pages in the collection.
-                  example: 1
-                links:
-                  type: object
-                  description: |
-                    Pagination links for the previous and next parts of the whole collection.
-                  properties:
-                    previous:
-                      type: string
-                      description: |
-                        Link to the previous page returned in the response.
-                    current:
-                      type: string
-                      description: |
-                        Link to the current page returned in the response.
-                      example: '?page=1&limit=50'
-                    next:
-                      type: string
-                      description: |
-                        Link to the next page returned in the response.
+          properties: {}
+          additionalProperties: true
+          description: Response metadata.
           title: Collection Meta
       title: Themes Collection Response
       x-internal: false


### PR DESCRIPTION
Replacing all pagination objects with empty meta object (copied from email_templates.v3.yml)

<!-- Ticket number or summary of work -->
# [DEVDOCS-6010] Remove pagination object for Themes API


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Removed all pagination objects and replaced them with empty meta object (copied from email_templates.v3.yml)

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* Removed pagination object from [GET All Themes API call](https://developer.bigcommerce.com/docs/rest-content/themes#get-all-themes)

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->




[DEVDOCS-6010]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ