### PR TITLE
DEVDOCS-5996: [Update] channel ID is no longer a requirement for toke…

### DIFF
--- a/docs/storefront/graphql/index.mdx
+++ b/docs/storefront/graphql/index.mdx
@@ -576,7 +576,7 @@ For example, if your store hash is `abc123` and your channel ID is `456`, the ch
 For a channel's permanent URL to respond to requests, you must first [create a site](/docs/rest-management/sites#create-a-site) for the channel.
 
 <Callout type="info">
-  When you create a GraphQL Storefront API token, include the channel ID of the channel on which you wish to use the token. Otherwise, the server will reject your requests. See the section on [Creating a token](/docs/start/authentication/graphql-storefront#creating-a-token) in the GraphQL Storefront authentication article.
+  When you create a GraphQL Storefront API token, you can include the channel ID of the channel on which you wish to use the token. See the section on [Creating a token](/docs/start/authentication/graphql-storefront#creating-a-token) in the GraphQL Storefront authentication article.
 </Callout>
 
 ### I want to run requests from a front-end application or browser. I only show anonymous information, or I do not support signing in as a customer

--- a/reference/storefront_tokens.v3.yml
+++ b/reference/storefront_tokens.v3.yml
@@ -64,6 +64,11 @@ paths:
               allOf:
                 - $ref: '#/components/schemas/TokenPostSimple'
                 - $ref: '#/components/schemas/TokenPostImpersonation'
+            example:
+              allowed_cors_origins:
+                -  'https://www.yourstorefront.com/'
+              channel_id: 1
+              expires_at: 1885635176
         required: false
       responses:
         '200':
@@ -179,7 +184,6 @@ components:
           example: 1885635176
           minimum: 0
       required:
-        - channel_id
         - expires_at
     TokenPostSimple:
       type: object
@@ -190,15 +194,8 @@ components:
           type: array
           description: List of allowed domains for Cross-Origin Request Sharing. Currently accepts a maximum of two domains per created token.
           items:
-            maxLength: 1
-            minLength: 1
-            pattern: '/^https?:\/\/(?=.{1,254}(?::|$))(?:(?!\d|-)(?![a-z0-9\-]{1,62}-(?:\.|:|$))[a-z0-9\-]{1,63}\b(?!\.$)\.?)+(:\d+)?$/i;'
             type: string
       x-internal: false
-      x-examples:
-        example-1:
-          allowed_cors_origins:
-            - 'https://www.yourstorefront.com/'
     Token_Full:
       type: object
       properties:

--- a/reference/storefront_tokens.v3.yml
+++ b/reference/storefront_tokens.v3.yml
@@ -174,14 +174,15 @@ components:
       x-internal: false
       properties:
         channel_id:
-          oneOf:
-           - type: integer
-             example: 1
-           - type: array
-             items:
-               type: integer
+           type: integer
+           example: 1
+           description: Channel ID for a requested token. Use this field to enter a channel ID. Do not use this field if you have more than one channel. You can not use both `channel_id` and `channel_ids` in your request.
+        channel_ids:
+           type: array
+           items:
+             type: integer
              example: [667251, 1]
-          description: Channel ID or list of channel IDs for requested token
+             description: List of channel IDs for a requested token. Use this field if you have more than one channel ID. You can not use both `channel_id` and `channel_ids` in your request.
         expires_at:
           type: integer
           description: Unix timestamp (UTC time) defining when the token should expire. Supports seconds, but does not support milliseconds, microseconds, or nanoseconds.

--- a/reference/storefront_tokens.v3.yml
+++ b/reference/storefront_tokens.v3.yml
@@ -200,7 +200,6 @@ components:
           description: List of allowed domains for Cross-Origin Request Sharing. Currently accepts a maximum of two domains per created token.
           items:
             minLength: 1
-            maxLength: 1
             type: string
       x-internal: false
     Token_Full:

--- a/reference/storefront_tokens.v3.yml
+++ b/reference/storefront_tokens.v3.yml
@@ -174,10 +174,14 @@ components:
       x-internal: false
       properties:
         channel_id:
-          type: integer
-          minimum: 1
-          description: Channel ID for requested token
-          example: 1
+          oneOf:
+           - type: integer
+             example: 1
+           - type: array
+             items:
+               type: integer
+             example: [667251, 1]
+          description: Channel ID or list of channel IDs for requested token
         expires_at:
           type: integer
           description: Unix timestamp (UTC time) defining when the token should expire. Supports seconds, but does not support milliseconds, microseconds, or nanoseconds.
@@ -185,6 +189,7 @@ components:
           minimum: 0
       required:
         - expires_at
+        - channel_id
     TokenPostSimple:
       type: object
       properties:
@@ -194,6 +199,8 @@ components:
           type: array
           description: List of allowed domains for Cross-Origin Request Sharing. Currently accepts a maximum of two domains per created token.
           items:
+            minLength: 1
+            maxLength: 1
             type: string
       x-internal: false
     Token_Full:

--- a/reference/storefront_tokens.v3.yml
+++ b/reference/storefront_tokens.v3.yml
@@ -181,8 +181,8 @@ components:
            type: array
            items:
              type: integer
-             example: [667251, 1]
-             description: List of channel IDs for a requested token. Use this field if you have more than one channel ID. You can not use both `channel_id` and `channel_ids` in your request.
+           example: [667251, 1]
+           description: List of channel IDs for a requested token. Use this field if you have more than one channel ID. You can not use both `channel_id` and `channel_ids` in your request.
         expires_at:
           type: integer
           description: Unix timestamp (UTC time) defining when the token should expire. Supports seconds, but does not support milliseconds, microseconds, or nanoseconds.


### PR DESCRIPTION
…n creation

<!-- Ticket number or summary of work -->
# [DEVDOCS-5996]


## What changed?

* removed text regarding the requirement to enter a channel ID when creating a Storefront token
* Fixed incorrect example
* Created a ticket to remove duplicated request fields.

## Release notes draft

We're happy to announce that you can use a channel ID or channel IDs  when creating a Storefront token. (needs review)

<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-5996]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ