### PR TITLE
DEVDOCS-5999 [new]: GQL SF API, GQL token multiple channels

### DIFF
--- a/docs/start/authentication/graphql-storefront.mdx
+++ b/docs/start/authentication/graphql-storefront.mdx
@@ -45,7 +45,7 @@ accept: application/json
 content-type: application/json
 
 {
-  "channel_id": 1,            // integer (must be a valid channel ID on the store)
+  "channel_ids": [1, 2, 3],            // array of integers (must be a valid channel IDs on the store)
   "expires_at": 1602288000,   // when the token will expire, as an integer unix timestamp (in seconds)
   "allowed_cors_origins": [   // array of origins (up to 2 origins per token)
     "https://example.com"
@@ -94,7 +94,7 @@ Accept: application/json
 Content-Type: application/json
 
 {
-  "channel_id": 1, // integer (must be a valid channel ID on the store)
+  "channel_ids": [1, 2, 3] // array of integers (must be a valid channel IDs on the store)
   "expires_at": 1602288000 // when the token will expire, as an integer unix timestamp (in seconds)
 }
 ```

--- a/docs/storefront/graphql/index.mdx
+++ b/docs/storefront/graphql/index.mdx
@@ -576,7 +576,7 @@ For example, if your store hash is `abc123` and your channel ID is `456`, the ch
 For a channel's permanent URL to respond to requests, you must first [create a site](/docs/rest-management/sites#create-a-site) for the channel.
 
 <Callout type="info">
-  When you create a GraphQL Storefront API token, include the channel ID of the channel on which you wish to use the token. Otherwise, the server will reject your requests. See the section on [Creating a token](/docs/start/authentication/graphql-storefront#creating-a-token) in the GraphQL Storefront authentication article.
+  When you create a GraphQL Storefront API token, include the channel IDs of the channels on which you wish to use the token. Otherwise, the server will reject your requests. See the section on [Creating a token](/docs/start/authentication/graphql-storefront#creating-a-token) in the GraphQL Storefront authentication article.
 </Callout>
 
 ### I want to run requests from a front-end application or browser. I only show anonymous information, or I do not support signing in as a customer

--- a/reference/storefront_tokens.v3.yml
+++ b/reference/storefront_tokens.v3.yml
@@ -62,8 +62,8 @@ paths:
           application/json:
             schema:
               allOf:
-              - $ref: '#/components/schemas/TokenPostSimple'
-              - $ref: '#/components/schemas/TokenPostImpersonation'
+                - $ref: '#/components/schemas/TokenPostSimple'
+                - $ref: '#/components/schemas/TokenPostImpersonation'
         required: false
       responses:
         '200':

--- a/reference/storefront_tokens.v3.yml
+++ b/reference/storefront_tokens.v3.yml
@@ -168,10 +168,18 @@ components:
       type: object
       x-internal: false
       properties:
+        channel_ids:
+          type: array
+          description: A list of channel IDs for the requested token.
+          items:
+            type: integer
+          example: 
+          - 1
+          - 2
         channel_id:
           type: integer
           minimum: 1
-          description: Channel ID for requested token
+          description: Channel ID for requested token.
           example: 1
         expires_at:
           type: integer
@@ -179,8 +187,10 @@ components:
           example: 1885635176
           minimum: 0
       required:
-        - channel_id
         - expires_at
+      oneOf:
+        - required: ["channel_id"]
+        - required: ["channel_ids"]
     TokenPostSimple:
       type: object
       properties:

--- a/reference/storefront_tokens.v3.yml
+++ b/reference/storefront_tokens.v3.yml
@@ -223,7 +223,7 @@ components:
         channel_id:
           type: integer
           minimum: 1
-          description: Channel ID that is valid for the requested token. We support this field for backwards compatibility, but `channel_ids` is preferred.
+          description: Channel ID that is valid for the requested token. Use this field to enter a channel ID. Do not use this field if you have more than one channel. We support this field for backwards compatibility, but `channel_ids` is preferred. You can not use both `channel_id` and `channel_ids` in your request.
           example: 1
       required:
         - channel_id
@@ -234,12 +234,10 @@ components:
       properties:
         channel_ids:
           type: array
-          description: A list of channel IDs that are valid for the requested token.
+          description: A list of channel IDs that are valid for the requested token. Use this field if you have more than one channel ID. You can not use both `channel_id` and `channel_ids` in your request.
           items:
             type: integer
-          example: 
-          - 1
-          - 2
+          example: [667251, 1]
       required:
         - channel_ids
     ErrorResponse:

--- a/reference/storefront_tokens.v3.yml
+++ b/reference/storefront_tokens.v3.yml
@@ -62,8 +62,8 @@ paths:
           application/json:
             schema:
               allOf:
-                - $ref: '#/components/schemas/TokenPostSimple'
-                - $ref: '#/components/schemas/TokenPostImpersonation'
+              - $ref: '#/components/schemas/TokenPostSimple'
+              - $ref: '#/components/schemas/TokenPostImpersonation'
         required: false
       responses:
         '200':
@@ -165,32 +165,22 @@ components:
         default: 'application/json'
   schemas:
     TokenPostImpersonation:
-      type: object
       x-internal: false
-      properties:
-        channel_ids:
-          type: array
-          description: A list of channel IDs for the requested token.
-          items:
-            type: integer
-          example: 
-          - 1
-          - 2
-        channel_id:
-          type: integer
-          minimum: 1
-          description: Channel ID for requested token.
-          example: 1
-        expires_at:
-          type: integer
-          description: Unix timestamp (UTC time) defining when the token should expire. Supports seconds, but does not support milliseconds, microseconds, or nanoseconds.
-          example: 1885635176
-          minimum: 0
+      allOf:
+        - type: object
+          properties:
+            expires_at:
+              type: integer
+              description: Unix timestamp (UTC time) defining when the token should expire. Supports seconds, but does not support milliseconds, microseconds, or nanoseconds.
+              example: 1885635176
+              minimum: 0
+          required:
+            - expires_at
+        - oneOf:
+          - $ref: "#/components/schemas/Channels"
+          - $ref: "#/components/schemas/Channel"
       required:
         - expires_at
-      oneOf:
-        - required: ["channel_id"]
-        - required: ["channel_ids"]
     TokenPostSimple:
       type: object
       properties:
@@ -226,6 +216,33 @@ components:
           type: string
           description: JWT Token for accessing the Storefront API
       x-internal: false
+    Channel:
+      title: channel_id
+      type: object
+      x-internal: false
+      properties:
+        channel_id:
+          type: integer
+          minimum: 1
+          description: Channel ID that is valid for the requested token. We support this field for backwards compatibility, but `channel_ids` is preferred.
+          example: 1
+      required:
+        - channel_id
+    Channels:
+      title: channel_ids
+      type: object
+      x-internal: false
+      properties:
+        channel_ids:
+          type: array
+          description: A list of channel IDs that are valid for the requested token.
+          items:
+            type: integer
+          example: 
+          - 1
+          - 2
+      required:
+        - channel_ids
     ErrorResponse:
       allOf:
         - $ref: '#/components/schemas/BaseError'


### PR DESCRIPTION
# [DEVDOCS-5999]

## What changed?
* Update reference & docs to mention that GQL Storefront API token & Customer Impersonation Tokens can be created for multiple channels

## Release notes draft

* We're happy to announce that you can now create [GraphQL Storefront API Tokens](https://developer.bigcommerce.com/docs/rest-authentication/tokens) that are valid for multiple channels. For more information, see [Create a Storefront API token](https://developer.bigcommerce.com/docs/rest-authentication/tokens#create-a-token) and [Create a Customer Impersonation Token](https://developer.bigcommerce.com/docs/rest-authentication/tokens/customer-impersonation-token#create-a-token).

[DEVDOCS-5999]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ