### PR TITLE
DEVDOCS-5957: Revert Admin GQL API's custom fields

### DIFF
--- a/docs/store-operations/catalog/graphql-admin/product-basic-info.mdx
+++ b/docs/store-operations/catalog/graphql-admin/product-basic-info.mdx
@@ -33,7 +33,6 @@ The following table describes the ID fields that you can use in inputs for mutat
 | | Shared modifier ID | Navigate to **Products <br /> >Product Options <br /> >Shared Modifiers <br /> >_ModifierName_** <br /> in the control panel. <br /><br /> Retrieve the global ID from the URL. | `"bc/store/sharedProductModifier/2"` |
 | `valueId` | Variant option value ID | [Get all product variant option values](/docs/rest-catalog/product-variant-options/values#get-all-product-variant-option-values) | Product variant options: `"bc/store/productOptionValue/68"` <br /><br />Shared variant options: `"bc/store/sharedProductOptionValue/123"` |
 | | Modifier value ID | [Get all modifier values](/docs/rest-catalog/product-modifiers/values#get-all-modifier-values) | Product modifiers: `"bc/store/productModifierValue/107"` <br /><br />Shared modifiers: `"bc/store/sharedProductModifierValue/107"` |
-| `customFieldId` | ID for a product custom field | [Get product custom fields](/docs/rest-catalog/products/custom-fields#get-product-custom-fields) | `"bc/store/productCustomField/1"` |
 
 ## Set basic product information at the global level
 

--- a/docs/store-operations/catalog/msf-international-enhancements.mdx
+++ b/docs/store-operations/catalog/msf-international-enhancements.mdx
@@ -18,7 +18,6 @@ The following pages provide sample queries:
 - [Product modifier options](/docs/store-operations/catalog/graphql-admin/product-modifier-options)
 - [Product URL](/docs/store-operations/catalog/graphql-admin/product-url)
 - [Additional product attributes](/docs/store-operations/catalog/graphql-admin/product-attributes)
-- [Product custom fields](/docs/store-operations/catalog/graphql-admin/product-custom-fields)
 
 You can create webhooks that trigger for the following events:
 - [Product updated](/docs/integrations/webhooks/events#products)


### PR DESCRIPTION
# [DEVDOCS-5957]

P&E team needs the doc changes temporarily  reverted
## What changed?
<!-- Provide a bulleted list in the present tense -->
* Revert Admin GQL API's custom fields, from [PR 347](https://github.com/bigcommerce/docs/pull/347), under P&E's discretion 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

Goes hand in hand with [PR 946](https://github.com/bigcommerce/developer-center/pull/946)


[DEVDOCS-5957]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ