### PR TITLE
DEVDOCS-4695 [new]: Store-level API accounts, add authorized users

### DIFF
--- a/docs/integrations/apps/guide/auth.mdx
+++ b/docs/integrations/apps/guide/auth.mdx
@@ -7,7 +7,7 @@ It may be more appropriate for your application to use an API client to handle t
 
 <Callout type="info">
   #### Store owner access_token constraint
-  Typically, only [store owners](https://support.bigcommerce.com/s/article/Store-API-Accounts#creating) and authorized users can create API accounts and `access_token`s for a store. However, when an app is approved to be publicly available for additional stores to install, it can generate `access_token`s *on behalf* of store owners. 
+  Typically, only [store owners](https://support.bigcommerce.com/s/article/Store-API-Accounts#creating) and authorized users can create API accounts and `access_token`s for a store. However, when an app is approved to be publicly available for additional stores to install, it can generate `access_token`s *on behalf* of store owners and authorized users. 
 </Callout>
 
 ## Overview

--- a/docs/integrations/apps/guide/types.mdx
+++ b/docs/integrations/apps/guide/types.mdx
@@ -22,7 +22,7 @@ Once granted, the app can request a permanent `access_token` for making REST API
 Single-click apps can use [App Extensions](/docs/integrations/apps/app-extensions).
 
 ## Connector
-Connector apps use manual OAuth token creation instead of the single-click app flow. Store owners and authorized users manually generate [store-level API credentials](/docs/start/authentication/api-accounts#revoking-store-level-api-credentials) and enter them into the app's configuration. While single-click apps are recommended, the following use cases might not be compatible:
+Connector apps use manual OAuth token creation instead of the single-click app flow. Store owners and authorized users manually generate [store-level API credentials](/docs/start/authentication/api-accounts#revoking-store-level-api-credentials) and enter them into the app's configuration. While we recommend single-click apps, the following use cases might not be compatible:
 
 - Customized integrations that vary per store.
 - Integrations that do not provide any content for an iFrame.

--- a/docs/integrations/apps/guide/types.mdx
+++ b/docs/integrations/apps/guide/types.mdx
@@ -5,7 +5,7 @@ keywords: app extensions
 
 # Types of Apps
 
-The first step when developing an app is deciding which type of app to develop. The two types of apps, single-click and connector, are defined by the method of authentication. [Single-click](#single-click) apps use an OAuth Authorization Code Grant flow. [Connector apps](#connector) require store owners to manually generate and configure store API credentials. In addition to the authentication method, apps can differ by [visibility](#visibility).
+The first step when developing an app is deciding which type of app to develop. The two types of apps, single-click and connector, are defined by the method of authentication. [Single-click](#single-click) apps use an OAuth Authorization Code Grant flow. [Connector apps](#connector) require store owners or authorized users to manually generate and configure store API credentials. In addition to the authentication method, apps can differ by [visibility](#visibility).
 
 ## Single-Click
 
@@ -22,7 +22,7 @@ Once granted, the app can request a permanent `access_token` for making REST API
 Single-click apps can use [App Extensions](/docs/integrations/apps/app-extensions).
 
 ## Connector
-Connector apps use manual OAuth token creation instead of the single-click app flow. Store owners manually generate [store-level API credentials](/docs/start/authentication/api-accounts#revoking-store-level-api-credentials) and enter them into the app's configuration. While single-click apps are recommended, the following use cases might not be compatible:
+Connector apps use manual OAuth token creation instead of the single-click app flow. Store owners and authorized users manually generate [store-level API credentials](/docs/start/authentication/api-accounts#revoking-store-level-api-credentials) and enter them into the app's configuration. While single-click apps are recommended, the following use cases might not be compatible:
 
 - Customized integrations that vary per store.
 - Integrations that do not provide any content for an iFrame.

--- a/docs/start/authentication/api-accounts.mdx
+++ b/docs/start/authentication/api-accounts.mdx
@@ -79,10 +79,10 @@ App-level API accounts do not come pre-configured with an access token. Each tim
 
 There is no way to manually revoke or force-regenerate app-level API account access tokens. However, either of the following actions triggers a token refresh:
 
-* When the store owner's email address changes
+* When the store owner's email address changes 
 * When you modify the app API account's OAuth scopes
 
-After one of these changes, the store owner will be prompted to review the change and reauthorize the app the next time they click the app icon in the store control panel.
+After one of these changes, the store owner will be prompted to review the change and reauthorize the app the next time they click the app icon in the store control panel. 
 
 <Callout type="error">
   #### Delete apps carefully

--- a/docs/start/authentication/api-accounts.mdx
+++ b/docs/start/authentication/api-accounts.mdx
@@ -79,10 +79,10 @@ App-level API accounts do not come pre-configured with an access token. Each tim
 
 There is no way to manually revoke or force-regenerate app-level API account access tokens. However, either of the following actions triggers a token refresh:
 
-* When the store owner's email address changes 
+* When the store owner's email address changes
 * When you modify the app API account's OAuth scopes
 
-After one of these changes, the store owner will be prompted to review the change and reauthorize the app the next time they click the app icon in the store control panel. 
+After one of these changes, the store owner will be prompted to review the change and reauthorize the app the next time they click the app icon in the store control panel.
 
 <Callout type="error">
   #### Delete apps carefully


### PR DESCRIPTION
# [DEVDOCS-4695]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Edit wording to include that authorized users (not just store owners) can manage API accounts

## Release notes draft

* We're happy to announce [X feature], which can help you  [perform Y action].


## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->




[DEVDOCS-4695]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ