### PR TITLE
[DEVDOCS-6033] - Arrange callback attributes in correct order

### DIFF
--- a/docs/webhooks/callbacks/store_cart_abandoned.yml
+++ b/docs/webhooks/callbacks/store_cart_abandoned.yml
@@ -4,9 +4,15 @@ properties:
     description: Fires when a cart is abandoned. A cart is considered abandoned when no changes have been made to its properties or contents for one hour. This webhook is available for all store plans, regardless of whether the Abandoned Cart Saver feature is enabled.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -17,10 +23,3 @@ properties:
             type: string
           token:
             type: string
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_cart_converted.yml
+++ b/docs/webhooks/callbacks/store_cart_converted.yml
@@ -4,9 +4,15 @@ properties:
     description: Fires when a cart is converted into an order, which typically follows the payment step of checkout. At this point, the cart is no longer accessible and has been deleted. This webhook returns both the cart ID and the order ID for correlation purposes.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -17,10 +23,3 @@ properties:
             type: string
           orderId:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_cart_couponApplied.yml
+++ b/docs/webhooks/callbacks/store_cart_couponApplied.yml
@@ -4,9 +4,15 @@ properties:
     description: Fires when a new coupon code is applied to a cart. The payload includes the ID of the coupon code.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -17,10 +23,3 @@ properties:
             type: string
           couponId:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_cart_created.yml
+++ b/docs/webhooks/callbacks/store_cart_created.yml
@@ -10,9 +10,15 @@ properties:
       The store/cart/updated webhook fires simultaneously with store/cart/created.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -21,10 +27,3 @@ properties:
             type: string
           id:
             type: string
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_cart_deleted.yml
+++ b/docs/webhooks/callbacks/store_cart_deleted.yml
@@ -10,9 +10,15 @@ properties:
       The store/cart/updated webhook fires simultaneously with store/cart/deleted.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -21,10 +27,3 @@ properties:
             type: string
           id:
             type: string
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_cart_lineItem_created.yml
+++ b/docs/webhooks/callbacks/store_cart_lineItem_created.yml
@@ -4,9 +4,15 @@ properties:
     description: Fires when a new item is added to a cart.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -17,10 +23,3 @@ properties:
             type: string
           cartId:
             type: string
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_cart_lineItem_deleted.yml
+++ b/docs/webhooks/callbacks/store_cart_lineItem_deleted.yml
@@ -4,9 +4,15 @@ properties:
     description: Fires when an item is deleted from a cart.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -17,10 +23,3 @@ properties:
             type: string
           cartId:
             type: string
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_cart_lineItem_updated.yml
+++ b/docs/webhooks/callbacks/store_cart_lineItem_updated.yml
@@ -4,9 +4,15 @@ properties:
     description: Fires when a line item’s quantity or product options change.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -17,10 +23,3 @@ properties:
             type: string
           cartId:
             type: string
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_cart_updated.yml
+++ b/docs/webhooks/callbacks/store_cart_updated.yml
@@ -14,9 +14,15 @@ properties:
       The payload includes the ID of the cart being updated.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -25,10 +31,3 @@ properties:
             type: string
           id:
             type: string
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_category_created.yml
+++ b/docs/webhooks/callbacks/store_category_created.yml
@@ -4,9 +4,15 @@ properties:
     description: Fires when a category is created.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -15,10 +21,3 @@ properties:
             type: string
           id:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_category_deleted.yml
+++ b/docs/webhooks/callbacks/store_category_deleted.yml
@@ -4,9 +4,15 @@ properties:
     description: Fires when a category is deleted
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -15,10 +21,3 @@ properties:
             type: string
           id:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_customer_address_created.yml
+++ b/docs/webhooks/callbacks/store_customer_address_created.yml
@@ -4,9 +4,15 @@ properties:
     description: Fires when a customer address is created
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -20,10 +26,3 @@ properties:
             properties:
               customer_id:
                 type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_customer_address_deleted.yml
+++ b/docs/webhooks/callbacks/store_customer_address_deleted.yml
@@ -4,9 +4,15 @@ properties:
     description: Fires when a customer address is deleted
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -20,10 +26,3 @@ properties:
             properties:
               customer_id:
                 type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_customer_address_updated.yml
+++ b/docs/webhooks/callbacks/store_customer_address_updated.yml
@@ -4,9 +4,15 @@ properties:
     description: Fires when a customer address is updated
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -20,10 +26,3 @@ properties:
             properties:
               customer_id:
                 type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_customer_deleted.yml
+++ b/docs/webhooks/callbacks/store_customer_deleted.yml
@@ -4,9 +4,15 @@ properties:
     description: Fires when a customer is deleted
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -15,10 +21,3 @@ properties:
             type: string
           id:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_customer_payment_instrument_default_updated.yml
+++ b/docs/webhooks/callbacks/store_customer_payment_instrument_default_updated.yml
@@ -4,9 +4,15 @@ properties:
     description: Fires when a customer default payment instrument is updated
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -15,10 +21,3 @@ properties:
             type: string
           id:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_customer_payment_instrument_default_updated.yml
+++ b/docs/webhooks/callbacks/store_customer_payment_instrument_default_updated.yml
@@ -17,7 +17,7 @@ properties:
       data:
         type: object
         properties:
-          type:
-            type: string
           id:
             type: integer
+          type:
+            type: string

--- a/docs/webhooks/callbacks/store_information_updated.yml
+++ b/docs/webhooks/callbacks/store_information_updated.yml
@@ -19,5 +19,3 @@ properties:
         properties:
           type:
             type: string
-              customer_id:
-                type: integer

--- a/docs/webhooks/callbacks/store_information_updated.yml
+++ b/docs/webhooks/callbacks/store_information_updated.yml
@@ -4,19 +4,20 @@ properties:
     description: Fires when changes are made to store settings. For a full list of fields that can trigger this event, see the store information updated events that follow.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
         properties:
           type:
             type: string
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-
+              customer_id:
+                type: integer

--- a/docs/webhooks/callbacks/store_modifier_updated.yml
+++ b/docs/webhooks/callbacks/store_modifier_updated.yml
@@ -7,9 +7,15 @@ properties:
       For shared modifiers, the maximum number of product IDs in a payload is 100. If a shared modifier is assigned to more than 100 products, the payload includes a link to the API so you can query all the event data.  
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -34,9 +40,3 @@ properties:
               locale:
                 type: string
                 description: '`null` if the attribute that was overridden applies to the entire channel.'
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string

--- a/docs/webhooks/callbacks/store_option_updated.yml
+++ b/docs/webhooks/callbacks/store_option_updated.yml
@@ -7,9 +7,15 @@ properties:
       For shared options, the maximum number of product IDs in a payload is 100. If a shared modifier is assigned to more than 100 products, the payload includes a link to the API so you can query all the event data.  
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -33,9 +39,3 @@ properties:
                 type: integer
               locale:
                 type: string
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string

--- a/docs/webhooks/callbacks/store_order_archived.yml
+++ b/docs/webhooks/callbacks/store_order_archived.yml
@@ -4,9 +4,15 @@ properties:
     description: Order is archived
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -15,10 +21,3 @@ properties:
             type: string
           id:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_order_created.yml
+++ b/docs/webhooks/callbacks/store_order_created.yml
@@ -4,9 +4,15 @@ properties:
     description: Fires when an order is created either in the control panel or by API.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -15,10 +21,3 @@ properties:
             type: string
           id:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_order_message_created.yml
+++ b/docs/webhooks/callbacks/store_order_message_created.yml
@@ -4,9 +4,15 @@ properties:
     description: Order message is created by customer or in control panel
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -20,10 +26,3 @@ properties:
             properties:
               order_message_id:
                 type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_order_refund_created.yml
+++ b/docs/webhooks/callbacks/store_order_refund_created.yml
@@ -4,9 +4,15 @@ properties:
     description: A refund has been submitted against an order
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -20,10 +26,3 @@ properties:
             properties:
               refund_id:
                 type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_order_statusUpdated.yml
+++ b/docs/webhooks/callbacks/store_order_statusUpdated.yml
@@ -4,9 +4,15 @@ properties:
     description: Fires when the order status has changed, such as from Pending to Awaiting Payment.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -22,10 +28,3 @@ properties:
                 type: integer
               new_status_id:
                 type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_product_created.yml
+++ b/docs/webhooks/callbacks/store_product_created.yml
@@ -4,9 +4,15 @@ properties:
     description: A new product is created
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -15,10 +21,3 @@ properties:
             type: string
           id:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_product_deleted.yml
+++ b/docs/webhooks/callbacks/store_product_deleted.yml
@@ -4,9 +4,15 @@ properties:
     description: Product is deleted
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -15,10 +21,3 @@ properties:
             type: string
           id:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_product_inventory_order_updated.yml
+++ b/docs/webhooks/callbacks/store_product_inventory_order_updated.yml
@@ -7,9 +7,15 @@ properties:
       The webhook always fires for products without variants. For products with variants, the webhook only fires when the product's inventory properties are configured to track by _product_.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -27,10 +33,3 @@ properties:
                 type: string
               value:
                 type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_product_inventory_updated.yml
+++ b/docs/webhooks/callbacks/store_product_inventory_updated.yml
@@ -9,9 +9,15 @@ properties:
       Inventory updates made in the control panel and by API trigger the webhook. This includes changes made by apps. In the control panel, you can bulk import inventory updates or make inventory updates to single products on the **Products > View** page.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -29,10 +35,3 @@ properties:
                 type: string
               value:
                 type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_shipment_created.yml
+++ b/docs/webhooks/callbacks/store_shipment_created.yml
@@ -4,9 +4,15 @@ properties:
     description: Shipment is created
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -17,10 +23,3 @@ properties:
             type: integer
           orderId:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_shipment_deleted.yml
+++ b/docs/webhooks/callbacks/store_shipment_deleted.yml
@@ -4,9 +4,15 @@ properties:
     description: Shipment is deleted
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -17,10 +23,3 @@ properties:
             type: integer
           orderId:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_shipment_updated.yml
+++ b/docs/webhooks/callbacks/store_shipment_updated.yml
@@ -4,9 +4,15 @@ properties:
     description: Shipment is updated
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -17,10 +23,3 @@ properties:
             type: integer
           orderId:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_sku_created.yml
+++ b/docs/webhooks/callbacks/store_sku_created.yml
@@ -4,9 +4,15 @@ properties:
     description: A new sku is created
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -22,10 +28,3 @@ properties:
                 type: integer
               variant_id:
                 type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_sku_deleted.yml
+++ b/docs/webhooks/callbacks/store_sku_deleted.yml
@@ -4,9 +4,15 @@ properties:
     description: SKU is deleted
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -22,10 +28,3 @@ properties:
                 type: integer
               variant_id:
                 type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_sku_inventory_order_updated.yml
+++ b/docs/webhooks/callbacks/store_sku_inventory_order_updated.yml
@@ -7,9 +7,15 @@ properties:
       The webhook does not fire for products without variants. For products with variants, the webhook only fires when the product's inventory properties are configured to track by _variant_.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -29,10 +35,3 @@ properties:
                 type: integer
               variant_id:
                 type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_sku_inventory_updated.yml
+++ b/docs/webhooks/callbacks/store_sku_inventory_updated.yml
@@ -9,9 +9,15 @@ properties:
       Inventory updates made in the control panel and by API trigger the webhook. This includes changes made by apps. In the control panel, you can bulk import inventory updates or make inventory updates to single products on the **Products > View** page.
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -31,10 +37,3 @@ properties:
                 type: integer
               variant_id:
                 type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_sku_updated.yml
+++ b/docs/webhooks/callbacks/store_sku_updated.yml
@@ -4,9 +4,15 @@ properties:
     description: SKU is updated
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -22,10 +28,3 @@ properties:
                 type: integer
               variant_id:
                 type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_subscriber_created.yml
+++ b/docs/webhooks/callbacks/store_subscriber_created.yml
@@ -4,9 +4,15 @@ properties:
     description: Subscriber is created
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -15,10 +21,3 @@ properties:
             type: string
           id:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_subscriber_deleted.yml
+++ b/docs/webhooks/callbacks/store_subscriber_deleted.yml
@@ -4,9 +4,15 @@ properties:
     description: Subscriber is deleted
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -15,10 +21,3 @@ properties:
             type: string
           id:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-

--- a/docs/webhooks/callbacks/store_subscriber_updated.yml
+++ b/docs/webhooks/callbacks/store_subscriber_updated.yml
@@ -4,9 +4,15 @@ properties:
     description: Subscriber is updated
     type: object
     properties:
-      scope:
+      producer:
         type: string
+      hash:
+        type: string
+      created_at:
+        type: integer
       store_id:
+        type: string
+      scope:
         type: string
       data:
         type: object
@@ -15,10 +21,3 @@ properties:
             type: string
           id:
             type: integer
-      hash:
-        type: string
-      created_at:
-        type: integer
-      producer:
-        type: string
-


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6033] Webhooks reference overhaul - Arrange callback attributes in correct order


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Arranged the order of attributes to be accurate with our payload format for the following events:
store/cart/abandoned
store/cart/converted
store/cart/couponApplied
store/cart/created
store/cart/deleted
store/cart/lineItem/created
store/cart/lineItem/updated
store/cart/lineItem/deleted
store/cart/updated
store/category/created
store/category/updated
store/category/deleted
store/customer/deleted
store/customer/address/created
store/customer/address/updated
store/customer/address/deleted
store/customer/payment/instrument/default/updated
store/information/updated
store/inventory/location/created
store/inventory/location/updated
store/modifier/updated
store/option/updated
store/order/archived
store/order/created
store/order/updated
store/order/message/created
store/order/refund/created
store/order/statusUpdated
store/product/created
store/product/updated
store/product/deleted
store/product/inventory/order/updated
store/product/inventory/updated
store/shipment/created
store/shipment/updated
store/shipment/deleted
store/sku/created
store/sku/updated
store/sku/deleted
store/sku/inventory/order/updated
store/sku/inventory/updated
store/subscriber/created
store/subscriber/updated
store/subscriber/deleted
* Note that other callbacks would have their order re-arranged by pull request for DEVDOCS-6029:
https://github.com/bigcommerce/docs/pull/380

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* Re-ordered the attributes of callbacks in our documentation so they match the order of webhook payloads.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {@bc-traciporter}


[DEVDOCS-6033]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ