### PR TITLE
Remove inaccurate note about deleting consignment unassociated a cart from a customer

### DIFF
--- a/reference/checkouts.v3.yml
+++ b/reference/checkouts.v3.yml
@@ -5608,8 +5608,6 @@ paths:
       summary: Delete Checkout Consignment
       description: |-
         Removes an existing consignment from a checkout.
-
-        Removing the last consignment will remove the cart from the customer it is assigned to. Create a new redirect URL for the customer so they can access the cart again.
       operationId: deleteCheckoutConsignment
       responses:
         '200':


### PR DESCRIPTION
The API reference for deleting a Consignment contains a note that deleting a checkout's last consignment removes the cart from its assigned customer.  This has been tested and found to be inaccurate, and Valentin Dellangela verified it should be removed.