### PR TITLE
Update description of TaxQuote::id

### DIFF
--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -1120,7 +1120,7 @@ components:
       properties:
         code:
           type: string
-          description: 'The provider-specific tax code for this item. Items can be classified with tax codes relevant to each Tax Provider, configured by the merchant, and assigned to their products within BigCommerce. A tax code is intended to apply to multiple products. This code should match the tax codes provided by the third-party integration.'
+          description: 'The provider-specific tax code for this item. Items can be classified with tax codes relevant to each tax provider, configured by the merchant, and assigned to their products within BigCommerce. A tax code is intended to apply to multiple products. This code should match the tax codes provided by the third-party integration.'
         class_id:
           type: string
           description: The ID of the tax class defined in the merchant’s BigCommerce store. May have a UUID value.
@@ -1137,7 +1137,7 @@ components:
       properties:
         id:
           type: string
-          description: The unique identifier of the tax quote that was requested. This must match the ID of the requested quote.
+          description: The unique identifier of the tax quote that was requested. This value must either match the ID of the requested quote or be an external ID on the tax provider’s system. This value will be used for future adjust and void operations.
         documents:
           type: array
           description: 'Represents an order quote or part of an order quote of tax-relevant items fulfilled from a single origin address to a single destination address, including arrays of shipping and handling fee objects for each item. Most order quotes contain a single document; however, BigCommerce supports "multi-address orders", which may come from or go to distinct sets of addresses and thus require multiple documents per quote.'
@@ -1273,11 +1273,11 @@ components:
         id:
           type: string
           description: |-
-            Optional unique identifier for this sales tax, describing the relevant tax classification rule on the Tax Provider platform.
+            Optional unique identifier for this sales tax, describing the relevant tax classification rule on the tax provider platform.
 
             Supplying an identifier allows BigCommerce to group related taxes together from all items in the order.
 
-            This identifier is persisted by BigCommerce and may be desirable for auditing purposes between BigCommerce and the Tax Provider. Currently supports persisting integer values only (the string type indicates we may support UUID values in the future).
+            This identifier is persisted by BigCommerce and may be desirable for auditing purposes between BigCommerce and the tax provider. Currently supports persisting integer values only (the string type indicates we may support UUID values in the future).
           example: '1701'
       required:
         - name
@@ -1317,7 +1317,7 @@ components:
       type: http
       scheme: basic
       description: |-
-        The [HTTP Basic Authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication) (developer.mozilla.org) credentials used to authenticate each API request to the Tax Provider from the associated store; set and update `username`, `password`, and optionally `profile`, using the [Update a Connection](/docs/rest-contracts/tax-app-connection#update-a-connection) request. `profile` is an optional field and will be used with supporting providers only.
+        The [HTTP Basic Authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication) (developer.mozilla.org) credentials used to authenticate each API request to the tax provider from the associated store; set and update `username`, `password`, and optionally `profile`, using the [Update a Connection](/docs/rest-contracts/tax-app-connection#update-a-connection) request. `profile` is an optional field and will be used with supporting providers only.
         
         For more, see [developer-configured authentication](/docs/start/authentication#developer-configured-authentication) for Provider APIs.
 


### PR DESCRIPTION
## What changed?
* Adjust description of the `TaxQuote::id` field to describe that we also accept external ID values.
* Also describe how this value is used with adjust and void requests.
* Bonus: adjust remaining outlier casing concerns for "Tax Provider" => "tax provider".

Based on tax partner feedback and a significant confusion internally.

## Release notes draft
* Clarify accepted Tax Provider API quote ID values and usages.