### PR TITLE
TAX-2153 [new]: Tax Provider API, add performance guidance

### DIFF
--- a/docs/integrations/tax.mdx
+++ b/docs/integrations/tax.mdx
@@ -26,7 +26,7 @@ Once your tax provider configuration is ready, we'll let you know through email.
 | Tax Provider Details | Required / Optional | Value(s) | Description | Example |
 | :--- | :--- | :--- | :--- | :--- |
 | App ID | Required | Integer | Tells us which tax provider configuration to use after the app is installed. | `123456` |
-| Tax provider name | Required | String | Displayed in the control panel (e.g. **Settings > Setup > Tax > Add tax service**). | `Sample Tax` |
+| Tax provider name | Required | String | Displayed in the control panel (e.g., **Settings > Setup > Tax > Add tax service**). | `Sample Tax` |
 | Transaction type | Required | Production, Test | Whether your tax provider will be handling production traffic or conducting test transactions. | `Production` |
 | Partner support email | Required | Email | Contact email that BigCommerce uses to send merchant support requests or discuss integration improvements with you. | `support@sampletax.example.com` |
 **Coverage** | | | | |
@@ -147,7 +147,7 @@ BigCommerce sends requests for tax estimates on product item, shipping, and hand
 
 Merchants expect fast tax estimate responses to facilitate a streamlined checkout experience for their shoppers. Hence performance is an essential consideration for a tax provider.
 
-To protect the shopper checkout experience from overly slow tax responses, tax estimate requests will time out after a set period of time. The default timeout threshold of four seconds is intended to support a wide variety of use cases (e.g. large tax estimate requests).
+To protect the shopper checkout experience from overly slow tax responses, tax estimate requests will time out after a set period of time. The default timeout threshold of four seconds is intended to support a wide variety of use cases (e.g., large tax estimate requests).
 
 <Callout type="info">
   You may request a lower timeout threshold to provide a better service to merchants.
@@ -155,11 +155,11 @@ To protect the shopper checkout experience from overly slow tax responses, tax e
 
 #### Handling additional inputs
 
-The Tax Provider API's request specification has been designed to include all necessary inputs required to perform a standard tax estimation. If your solution requires additional inputs beyond what the request model offers, then this additional data should be accessible on your system in a performant manner.
+The Tax Provider API's request specification includes all necessary inputs for a standard tax estimation. If your solution needs extra inputs beyond what the request model, ensure this data is readily accessible on your system.
 
-In particular this means avoiding synchronous calls to external systems while preparing your tax estimate response. A recommended performant implementation strategy is to maintain a projection of external data on your system, performing updates asynchronously through background jobs or queues as required (e.g. [subscribing to BigCommerce webhooks](https://developer.bigcommerce.com/docs/integrations/webhooks)).
+Avoid synchronous calls to external systems when preparing your tax estimate response. We recommend you keep a copy of external data on your system and update it asynchronously through background jobs or queues as required (e.g., [subscribing to BigCommerce webhooks](https://developer.bigcommerce.com/docs/integrations/webhooks)).
 
-Leaning on the capabilities of [Tax Properties](/docs/store-operations/tax/tax-properties) to enhance the initial Tax Provider API request is another available approach for avoiding the need to look up additional tax estimate inputs on external systems.
+Using [Tax Properties](/docs/store-operations/tax/tax-properties) to enhance the initial Tax Provider API request can help you avoid looking up additional tax estimate inputs on external systems.
 
 ## Document submission
 

--- a/docs/integrations/tax.mdx
+++ b/docs/integrations/tax.mdx
@@ -153,6 +153,14 @@ To protect the shopper checkout experience from overly slow tax responses, tax e
   You may request a lower timeout threshold to provide a better service to merchants.
 </Callout>
 
+#### Handling additional inputs
+
+The Tax Provider API's request specification has been designed to include all necessary inputs required to perform a standard tax estimation. If your solution requires additional inputs beyond what the request model offers, then this additional data should be accessible on your system in a performant manner.
+
+In particular this means avoiding synchronous calls to external systems while preparing your tax estimate response. A recommended performant implementation strategy is to maintain a projection of external data on your system, performing updates asynchronously through background jobs or queues as required (e.g. [subscribing to BigCommerce webhooks](https://developer.bigcommerce.com/docs/integrations/webhooks)).
+
+Leaning on the capabilities of [Tax Properties](/docs/store-operations/tax/tax-properties) to enhance the initial Tax Provider API request is another available approach for avoiding the need to look up additional tax estimate inputs on external systems.
+
 ## Document submission
 
 Document submission enables you to persist a tax quote request, replace it with another one, or invalidate it if necessary.


### PR DESCRIPTION
# [TAX-2153]

## What changed?
* Set context of the intention of the Tax Provider API request model supporting required inputs for standard tax requests.
* Add advice on obtaining additional data that is not part of the Tax Provider API request model.
* Add guidance on Tax Properties, relating to performance and the topic of "additional data".
* Adjust `e.g.` to `e.g.,` as advised.

## Release notes draft
* Added guidance on how to best achieve a performant solution with the Tax Provider API.

[TAX-2153]: https://bigcommercecloud.atlassian.net/browse/TAX-2153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ