### PR TITLE
(no ticket): Channels feature, update allowed PUT statuses

### DIFF
--- a/reference/channels.v3.yml
+++ b/reference/channels.v3.yml
@@ -3024,7 +3024,7 @@ components:
       x-internal: false
     ChannelStatus:
       type: string
-      description: 'The status of the channel; channel `type`, `platform`, and `status` must be a [valid combination](/docs/rest-management/channels#status). `terminated` is not valid for `PUT` or `POST` requests. `deleted` is not valid for `POST` requests.'
+      description: 'The status of the channel; channel `type`, `platform`, and `status` must be a [valid combination](/docs/rest-management/channels#status). `terminated` is not valid for `PUT` or `POST` requests. `deleted` is not valid for `POST` requests. `prelaunch` is not valid for `PUT` requests.'
       enum:
         - active
         - prelaunch


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# (no ticket): Channels feature, update allowed PUT statuses


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Indicate that Update a channel does not support restoring a channel to `prelaunch` status.

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* Fixed a bug to indicate that the Update a channel endpoint does not support restoring a channel to `prelaunch` status.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping FYI @bc-tgomez
thanks @mattcoy-arcticleaf!