### PR TITLE
DEVDOCS-6024 [TEST-SPEC]: updated per review

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -4158,10 +4158,6 @@ paths:
                               type: integer
                               description: |
                                 The unique numeric ID of the product review; increments sequentially.
-                            product_id:
-                              type: integer
-                              description: |
-                                The unique numeric identifier for the product with which the review is associated.
                             date_created:
                               type: string
                               description: |
@@ -4236,6 +4232,7 @@ paths:
                       description: |-
                         The title for the product review.
                         Required in /POST.
+                      example: Great Product
                     text:
                       type: string
                       description: |
@@ -4244,17 +4241,21 @@ paths:
                       type: string
                       description: |
                         The status of the product review. Must be one of `approved`, `disapproved` or `pending`.
+                      example: approved
                     rating:
                       type: integer
                       description: 'The rating of the product review. Must be one of 0, 1, 2, 3, 4, 5.'
+                      example: 5
                     email:
                       type: string
                       description: 'The email of the reviewer. Must be a valid email, or an empty string.'
+                      example: bob@email.com
                     name:
                       maxLength: 255
                       minLength: 0
                       type: string
                       description: The name of the reviewer.
+                      example: Bob S.
                     date_reviewed:
                       type: string
                       description: |
@@ -4318,10 +4319,6 @@ paths:
                             type: integer
                             description: |
                               The unique numeric ID of the product review; increments sequentially.
-                          product_id:
-                            type: integer
-                            description: |
-                              The unique numeric identifier for the product with which the review is associated.
                           date_created:
                             type: string
                             description: |
@@ -4611,10 +4608,6 @@ paths:
                             type: integer
                             description: |
                               The unique numeric ID of the product review; increments sequentially.
-                          product_id:
-                            type: integer
-                            description: |
-                              The unique numeric identifier for the product with which the review is associated.
                           date_created:
                             type: string
                             description: |
@@ -7819,6 +7812,9 @@ components:
               readOnly: true
               format: date-time
               example: '2018-05-07T20:14:17+00:00'
+            owner_client_id: 
+              type: string
+              description: ID of metafield's creator
       x-internal: false
     errorResponse_409:
       title: errorResponse_409


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6024]


## What changed?
- Removed `product _id` from the Product Review response body endpoints. 
- Added `owner_client_id` to the Product Metafield response bodies
- Added examples for the Create Product Review request body endpoint.

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6024]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ