### PR TITLE
DEVDOCS-6045: [update]added comparison_price and extended_comparison_price

### DIFF
--- a/reference/checkouts.v3.yml
+++ b/reference/checkouts.v3.yml
@@ -1707,6 +1707,8 @@ paths:
                           sale_price: 33.23
                           extended_list_price: 31.95
                           extended_sale_price: 33.23
+                          comparison_price: 33.23
+                          extended_comparison_price: 33.23
                           is_require_shipping: true
                           gift_wrapping: {}
                           is_mutable: true
@@ -8091,6 +8093,14 @@ components:
                         type: number
                         description: Sale price of the item multiplied by the quantity.
                         format: double
+                      comparison_price:
+                        type: number
+                        description: The price of a single product used for strike-through.
+                        format: double
+                      extended_comparison_price:
+                        type: number
+                        description: The price of a line item (product * quantity) used for strike-through.
+                        format: double
                       is_require_shipping:
                         type: boolean
                         description: ''
@@ -8210,6 +8220,14 @@ components:
                       extended_sale_price:
                         type: number
                         description: Sale price of the item multiplied by the quantity.
+                        format: double
+                      comparison_price:
+                        type: number
+                        description: The price of a single product used for strike-through.
+                        format: double
+                      extended_comparison_price:
+                        type: number
+                        description: The price of a line item (product * quantity) used for strike-through.
                         format: double
                     required:
                       - quantity


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6045]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* 

## Release notes draft

* The newly-released `comparison_price` and `extended_comparison_price` fields are now available to use. Now, you’ll be able to identify the price of a single or line item (product x quantity) used for strike-through.

<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6045]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ