### PR TITLE
[No ticket]: fix URL for site certificates

### DIFF
--- a/reference/sites.v3.yml
+++ b/reference/sites.v3.yml
@@ -497,7 +497,7 @@ paths:
           type: integer
         required: true
     get:
-      summary: Get a Site’s SSL/TLS Certificate Information
+      summary: Get a Site’s SSL TLS Certificate Information
       description: Obtain information about a site’s SSL/TLS certificate.
       tags:
         - Site Certificate
@@ -511,7 +511,7 @@ paths:
                 $ref: '#/components/schemas/CertificateResponse'
               examples: {}
     put:
-      summary: Upsert a Site’s SSL/TLS Certificate Information
+      summary: Upsert a Site’s SSL TLS Certificate Information
       operationId: upsertSiteCertificate
       parameters:
         - $ref: '#/components/parameters/ContentType'


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
[No ticket]

Currently, the URLs for Get a Site Certificate & Upsert a Site Certificate don't work in the browser (due to the slash in the URL) (e.g. clicking on the sidebar menu doesn't help you navigate the page) 
1. `/docs/rest-management/sites/site-certificate#get-a-sites-ssl/tls-certificate-information` 
2. `/docs/rest-management/sites/site-certificate#upsert-a-sites-ssl/tls-certificate-information`

This PR changes the URLs:
1. `#get-a-sites-ssl/tls-certificate-information` becomes `#get-a-sites-ssl-tls-certificate-information`
2. `#upsert-a-sites-ssl/tls-certificate-information` becomes `#upsert-a-sites-ssl-tls-certificate-information`

## What changed?

## Release notes draft
N / A

## Anything else?
N / A
