### PR TITLE
CATALOG-10408: [update] Categories: fix of schema

### DIFF
--- a/reference/catalog/category-trees_catalog.v3.yml
+++ b/reference/catalog/category-trees_catalog.v3.yml
@@ -177,7 +177,6 @@ paths:
                       total: 1
                       success: 1
                       failed: 0
-                      
         '207':
           description: Multi-Status
           content:
@@ -206,7 +205,7 @@ paths:
       description: |-
         Updates existing categories. 
 
-         To update a specific category in a tree, provide a category id.
+        To update a specific category in a tree, provide a `category id`.
       parameters:
         - $ref: '#/components/parameters/ContentType'
       tags:
@@ -295,7 +294,7 @@ paths:
           description: List of category trees.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/CategoryTreeList'
               example:
                 data:
@@ -609,7 +608,7 @@ components:
             $ref: '#/components/schemas/GetCategories'
         meta:
           $ref: '#/components/schemas/MetaPagination'
-    CategoryNodeTree: 
+    CategoryNodeTree:
           type: object
           properties:
             data:
@@ -915,8 +914,6 @@ components:
       type: integer
       description: |-
         Unique ID of the *Category*. Increments sequentially.
-        Read-Only.
-      readOnly: true
       example: 36
     parent_id:
       title: Parent ID


### PR DESCRIPTION
# [CATALOG-10408]


## What changed?
* remove "readOnly" property from "category_id" schema

## Release notes draft
* No release note required

## Anything else?

ping @NataliiaNefodova 

[CATALOG-10408]: https://bigcommercecloud.atlassian.net/browse/CATALOG-10408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ