### PR TITLE
DEVDOCS-6022: Update cart/checkout API with information on concurrency control

### DIFF
--- a/reference/carts.sf.yml
+++ b/reference/carts.sf.yml
@@ -124,11 +124,13 @@ paths:
         > #### Notes
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-        > * Please note that this API endpoint is not concurrent safe, meaning multiple simultaneous requests could result in unexpected and inconsistent results.
+        > * To prevent lost updates due to concurrent requests overriding changes made by others, it is recommended to enable optimistic concurrency control by including the `version` field in the request payload. If the provided version does not match the version on the server, a conflict error will be returned, which the client can handle accordingly.
       operationId: addCartLineItem
       responses:
         '200':
           $ref: '#/components/responses/postCartsItems'
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
       requestBody:
         content:
           application/json:
@@ -146,6 +148,7 @@ paths:
                           optionValue: 117
                         - optionId: 11
                           optionValue: 125
+                  version: 1
               With Gift Wrapping:
                 value:
                   lineItems:
@@ -156,7 +159,8 @@ paths:
                           wrapTogether: true
                           wrapDetails:
                             - id: 1
-                              message: "Happy Birthday"                 
+                              message: "Happy Birthday"
+                  version: 1
         description: ''
   '/carts/{cartId}/items/{itemId}':
     parameters:
@@ -177,7 +181,7 @@ paths:
         > #### Notes
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint. 
-        > * Please note that this API endpoint is not concurrent safe, meaning multiple simultaneous requests could result in unexpected and inconsistent results.
+        > * To prevent lost updates due to concurrent requests overriding changes made by others, it is recommended to enable optimistic concurrency control by including the `version` field in the request payload. If the provided version does not match the version on the server, a conflict error will be returned, which the client can handle accordingly.
       operationId: updateCartLineItem
       parameters:
         - $ref: '#/components/parameters/ContentType'
@@ -194,6 +198,7 @@ paths:
                     variantId: 191
                     quantity: 10
                   locale: en
+                  version: 1
               Custom Item:
                 value:
                   lineItem:
@@ -204,6 +209,7 @@ paths:
                       - optionId: 125
                         optionValue: 127
                   locale: en
+                  version: 1
               With Gift Wrapping:
                 value:
                   lineItem:
@@ -215,6 +221,7 @@ paths:
                         wrapDetails:
                           - id: 1
                             message: "Happy Birthday"
+                  version: 1
               With null Gift Wrapping (will delete current gift wrapping):
                 value:
                   lineItem:
@@ -222,12 +229,20 @@ paths:
                     productId: 230
                     variantId: 124
                     giftWrapping: null
+                  version: 1
         required: true
       responses:
         '200':
           $ref: '#/components/responses/putCartsItems'
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
       x-codegen-request-body-name: lineItem
     delete:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/requestLineItemDelete'
       tags:
         - Cart Items
       summary: Delete Cart Line Item
@@ -239,10 +254,13 @@ paths:
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
+        > * To prevent lost updates due to concurrent requests overriding changes made by others, it is recommended to enable optimistic concurrency control by including the `version` field in the request payload. If the provided version does not match the version on the server, a conflict error will be returned, which the client can handle accordingly.
       operationId: deleteCartLineItem
       responses:
         '200':
           $ref: '#/components/responses/deleteCartsItems'
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
   '/carts/{cartId}/currency':
     parameters:
       - $ref: '#/components/parameters/CartIdPath'
@@ -377,6 +395,10 @@ components:
         locale:
           type: string
           description: Locale of the cart.
+        version:
+          type: integer
+          description: The current version of the cart.
+          example: 1
       x-internal: false
     requestCart:
       title: Create Cart Request Object
@@ -506,6 +528,9 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/requestCartPostLineItem'
+            version:
+              type: integer
+              description: The expected version of the cart.
           required:
             - lineItems
         - type: object
@@ -514,6 +539,9 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/requestLineItemGiftCertificate'
+            version:
+              type: integer
+              description: The expected version of the cart.
           required:
             - giftCertificates
         - type: object
@@ -524,6 +552,9 @@ components:
                 $ref: '#/components/schemas/requestCartPostLineItem'
             giftCertificates:
               $ref: '#/components/schemas/requestLineItemGiftCertificate'
+            version:
+              type: integer
+              description: The expected version of the cart.
           required:
             - lineItems
             - giftCertificates
@@ -536,6 +567,9 @@ components:
           properties:
             lineItem:
               $ref: '#/components/schemas/requestCartPostLineItem'
+            version:
+              type: integer
+              description: The expected version of the cart.
           required:
             - lineItem
           title: Line item
@@ -543,6 +577,9 @@ components:
           properties:
             giftCertificates:
               $ref: '#/components/schemas/requestLineItemGiftCertificate'
+            version:
+              type: integer
+              description: The expected version of the cart.
           required:
             - giftCertificates
           title: Gift certificate item
@@ -552,11 +589,20 @@ components:
               $ref: '#/components/schemas/requestCartPostLineItem'
             giftCertificates:
               $ref: '#/components/schemas/requestLineItemGiftCertificate'
+            version:
+              type: integer
+              description: The expected version of the cart.
           required:
             - lineItem
             - giftCertificates
           title: line & gift certificate items
       description: ''
+    requestLineItemDelete:
+      type: object
+      properties:
+        version:
+          type: integer
+          description: The expected version of the cart.
     responseCartCurrency:
       title: Currency
       type: object
@@ -1339,6 +1385,7 @@ components:
                   createdTime: '2021-03-04T14:17:50+00:00'
                   updatedTime: '2021-03-04T14:17:50+00:00'
                   locale: en
+                  version: 1
     deleteCartsItems:
       description: 'NOTE: Discounted line items are re-evaluated on cart actions and may be automatically added back to your cart with a new line item ID to satisfy promotional requirements.'
       content:
@@ -1439,6 +1486,23 @@ components:
                 createdTime: string
                 updatedTime: string
                 locale: string
+    CartConflictErrorResponse:
+      description: 'Cart conflict'
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+              title:
+                type: string
+              type:
+                type: string
+          example:
+            status: 409
+            title: The request cannot be processed due to a possible conflict. Please review the changes and try again.
+            type: https://developer.bigcommerce.com/api-docs/getting-started/api-status-codes
   parameters:
     Accept:
       name: Accept

--- a/reference/carts.v3.yml
+++ b/reference/carts.v3.yml
@@ -278,7 +278,8 @@ paths:
 
         If a product has modifiers, omit the `variant_id` and instead use the `option_selections` array to describe both the **variant** and the **modifier** selections.
 
-        Please note that this API endpoint is not concurrent safe, meaning multiple simultaneous requests could result in unexpected and inconsistent results.
+        To prevent lost updates due to concurrent requests overriding changes made by others, it is recommended to enable optimistic concurrency control by including the `version` field in the request payload. If the provided version does not match the version on the server, a conflict error will be returned, which the client can handle accordingly.
+
       parameters:
         - name: include
           in: query
@@ -325,6 +326,7 @@ paths:
                         name: Jane Does
                         email: janedoe@example.com
                       message: Happy Birthday Jane!
+                  version: 1
               'Example 2: Custom Item':
                 value:
                   custom_items:
@@ -400,7 +402,7 @@ paths:
 
         Deleting all line items from the cart will invalidate the cart. 
 
-        Please note that this API endpoint is not concurrent safe, meaning multiple simultaneous requests could result in unexpected and inconsistent results.
+        To prevent lost updates due to concurrent requests overriding changes made by others, it is recommended to enable optimistic concurrency control by including the `version` field in the request payload. If the provided version does not match the version on the server, a conflict error will be returned, which the client can handle accordingly.
       parameters:
         - name: include
           in: query
@@ -432,6 +434,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/CartResponse'
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
       summary: Update Cart Line Item
       operationId: updateCartLineItem
     delete:
@@ -441,6 +445,8 @@ paths:
         **Notes**
 
         Removing the last `line_item` in the *Cart* deletes the *Cart*.
+
+        To prevent lost updates due to concurrent requests overriding changes made by others, it is recommended to enable optimistic concurrency control by including the `version` field in the request payload. If the provided version does not match the version on the server, a conflict error will be returned, which the client can handle accordingly.
       parameters:
         - name: include
           in: query
@@ -460,6 +466,11 @@ paths:
                 - line_items.physical_items.options
                 - line_items.digital_items.options
                 - promotions.banners
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CartLineItemDelete'
       tags:
         - Items
       responses:
@@ -537,6 +548,8 @@ paths:
                       meta: {}
         '204':
           description: 'If the action’s result is an empty cart, the cart is automatically deleted.'
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
       summary: Delete Cart Line Item
       operationId: deleteCartLineItem
   '/carts/{cartId}':
@@ -580,6 +593,8 @@ paths:
         **Notes**
 
         Changing the *Cart* `customer_id` will remove any promotions or shipping calculations on the *Cart*. These are tied to the customer depending on cart conditions and any customer groups. 
+
+        To prevent lost updates due to concurrent requests overriding changes made by others, it is recommended to enable optimistic concurrency control by including the `version` field in the request payload. If the provided version does not match the version on the server, a conflict error will be returned, which the client can handle accordingly.
       parameters:
         - name: include
           in: query
@@ -607,12 +622,15 @@ paths:
               $ref: '#/components/schemas/CartUpdatePutRequestData'
             example:
               customer_id: 5
+              version: 1
         required: true
       tags:
         - Carts (Single)
       responses:
         '201':
           $ref: '#/components/responses/CartResponse'
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
       summary: Update Customer ID
       operationId: updateCart
     delete:
@@ -1504,6 +1522,9 @@ components:
       properties:
         customer_id:
           type: integer
+        version:
+          type: integer
+          description: The expected version of the cart.
       title: Cart Update Put Request Data
       x-internal: false
     LineItemRequestData:
@@ -1706,6 +1727,10 @@ components:
                 text:
                   description: Text of the banner.
                   type: string
+        version:
+          type: integer
+          description: The current version of the cart.
+          example: 1
     Currency:
       type: object
       description: The currency. This is the same for both the cart and its subsequent checkout.
@@ -2865,6 +2890,15 @@ components:
               - recipient
         custom_items:
           $ref: '#/components/schemas/cart_PostCustomItem'
+        version:
+          type: integer
+          description: The expected version of the cart.
+    CartLineItemDelete:
+      type: object
+      properties:
+        version:
+          type: integer
+          description: The expected version of the cart.
     Redirect_urls_Post:
       type: object
       title: Redirect_urls_Post
@@ -2944,6 +2978,9 @@ components:
               - recipient
         custom_items:
           $ref: '#/components/schemas/cart_PostCustomItem'
+        version:
+          type: integer
+          description: The expected version of the cart.
     cart_PostCustomItem:
       type: array
       title: Custom item
@@ -3679,6 +3716,16 @@ components:
           schema:
             $ref: '#/components/schemas/Cart_Full'
           examples: {}
+    CartConflictErrorResponse:
+      description: 'Cart conflict'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            status: 409
+            title: The request cannot be processed due to a possible conflict. Please review the changes and try again.
+            type: https://developer.bigcommerce.com/api-docs/getting-started/api-status-codes
     CartRedirectResponse:
       description: ''
       content:

--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -165,6 +165,7 @@ paths:
                 createdTime: '2019-01-10T17:18:00+00:00'
                 updatedTime: '2019-01-10T17:19:47+00:00'
                 customerMessage: ''
+                version: 1
         '400':
           description: When a problem arises, returns a generic response.
           content:
@@ -333,6 +334,9 @@ paths:
                 createdTime: '2019-01-10T17:18:00+00:00'
                 updatedTime: '2019-01-10T17:19:47+00:00'
                 customerMessage: ''
+                version: 1
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
       x-codegen-request-body-name: body
   '/checkouts/{checkoutId}/carts/{cartId}/items/{itemId}':
     parameters:
@@ -479,6 +483,7 @@ paths:
                 createdTime: '2019-01-10T17:18:00+00:00'
                 updatedTime: '2019-01-10T17:19:47+00:00'
                 customerMessage: ''
+                version: 1
       x-codegen-request-body-name: body
     delete:
       tags:
@@ -741,7 +746,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/address_Base'
+              $ref: '#/components/schemas/BillingAddressRequest'
         required: true
       responses:
         '200':
@@ -859,9 +864,12 @@ paths:
                 createdTime: '2019-01-10T17:18:00+00:00'
                 updatedTime: '2019-01-10T17:19:47+00:00'
                 customerMessage: ''
+                version: 1
         '403':
           description: The email trying to be set for the guest is associated with an account. The customer must sign in.
           content: {}
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
         '429':
           description: Unable to determine if provided email is associated with an account. The customer must sign in.
           content: {}
@@ -887,7 +895,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/address_Base'
+              $ref: '#/components/schemas/BillingAddressRequest'
         required: true
       responses:
         '200':
@@ -1114,6 +1122,8 @@ paths:
         '403':
           description: The email trying to be set for the guest is associated with an account. The customer must sign in.
           content: {}
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
         '429':
           description: Unable to determine if provided email is associated with an account. The customer must sign in.
           content: {}
@@ -1285,6 +1295,9 @@ paths:
                 createdTime: '2019-01-10T17:18:00+00:00'
                 updatedTime: '2019-01-10T17:19:47+00:00'
                 customerMessage: ''
+                version: 1
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
   '/checkouts/{checkoutId}/consignments/{consignmentId}':
     parameters:
       - $ref: '#/components/parameters/CheckoutIdPath'
@@ -1450,6 +1463,9 @@ paths:
                 createdTime: '2019-01-10T17:18:00+00:00'
                 updatedTime: '2019-01-10T17:19:47+00:00'
                 customerMessage: ''
+                version: 1
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
       x-codegen-request-body-name: body
     delete:
       tags:
@@ -1463,6 +1479,11 @@ paths:
         > * The Send a Test Request feature is not currently supported for this endpoint.
         > * This endpoint requires using Stencil CLI, a local session, and a csrf token to work.
       operationId: deleteCheckoutConsignment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteConsignmentRequest'
       responses:
         '200':
           description: ''
@@ -1579,6 +1600,9 @@ paths:
                 createdTime: '2019-01-10T17:18:00+00:00'
                 updatedTime: '2019-01-10T17:19:47+00:00'
                 customerMessage: ''
+                version: 1
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
   '/checkouts/{checkoutId}/gift-certificates':
     parameters:
       - $ref: '#/components/parameters/CheckoutIdPath'
@@ -1721,6 +1745,7 @@ paths:
                 createdTime: '2019-01-10T17:18:00+00:00'
                 updatedTime: '2019-01-10T17:19:47+00:00'
                 customerMessage: ''
+                version: 1
         '404':
           description: Gift certificate code not found
           content:
@@ -1785,6 +1810,9 @@ paths:
                 couponCode:
                   type: string
                   description: ''
+                version:
+                  type: integer
+                  description: The expected version of the checkout.
         required: true
       responses:
         '200':
@@ -1902,6 +1930,9 @@ paths:
                 createdTime: '2019-01-10T17:18:00+00:00'
                 updatedTime: '2019-01-10T17:19:47+00:00'
                 customerMessage: ''
+                version: 1
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
       x-codegen-request-body-name: body
   '/checkouts/{checkoutId}/coupons/{couponCode}':
     parameters:
@@ -1920,6 +1951,11 @@ paths:
         > * The Send a Test Request feature is not currently supported for this endpoint.
         > * This endpoint requires using Stencil CLI, a local session, and a csrf token to work.
       operationId: deleteCheckoutCoupon
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteCouponCodeRequest'
       responses:
         '200':
           description: ''
@@ -2140,6 +2176,9 @@ paths:
                 createdTime: '2018-09-18T15:48:26+00:00'
                 updatedTime: '2018-09-18T17:47:35+00:00'
                 customerMessage: ''
+                version: 1
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
   '/checkouts/{checkoutId}/store-credit':
     parameters:
       - $ref: '#/components/parameters/CheckoutIdPath'
@@ -2301,6 +2340,10 @@ components:
           type: boolean
           description: |
             `true` value indicates StoreCredit has been applied.
+        version:
+          type: integer
+          description: The current version of the checkout.
+          example: 1
       description: ''
       x-internal: false
     CartCoupon:
@@ -2449,6 +2492,16 @@ components:
           description: This can also be an array for fields that need to support list of values; for example, a set of checkboxes. When doing a PUT or POST to the `fieldValue` with a pick list, the input must be a number. The response will be a string.
       description: 'When doing a PUT or POST to the `fieldValue` with a pick list, the input must be a number. The response will be a string.'
       x-internal: false
+    BillingAddressRequest:
+      title: Billing address request
+      allOf:
+        - $ref: '#/components/schemas/address_Base'
+        - type: object
+          properties:
+            version:
+              type: integer
+              description: The expected version of the checkout.
+      x-internal: false
     consignment_Full:
       title: consignment_Full
       type: object
@@ -2567,6 +2620,9 @@ components:
         customerMessage:
           type: string
           description: ''
+        version:
+          type: integer
+          description: The expected version of the checkout.
       x-internal: false
     checkouts_Resp:
       title: checkouts_Resp
@@ -3473,6 +3529,25 @@ components:
           properties:
             pickupMethodId:
               type: integer
+        version:
+          type: integer
+          description: The expected version of the checkout.
+      x-internal: false
+    DeleteCouponCodeRequest:
+      title: Delete Coupon Request
+      type: object
+      properties:
+        version:
+          type: integer
+          description: The expected version of the checkout.
+      x-internal: false
+    DeleteConsignmentRequest:
+      title: Delete Consignment Request
+      type: object
+      properties:
+        version:
+          type: integer
+          description: The expected version of the checkout.
       x-internal: false
     GiftCertificateRequest:
       title: Gift Certificate Request
@@ -3579,6 +3654,9 @@ components:
           properties:
             pickupMethodId:
               type: integer
+        version:
+          type: integer
+          description: The expected version of the checkout.
       description: One or more of these three fields is mandatory. You can update address and line items in one request. You have to update shipping option ID or pickup option ID in a separate request since changing the address or line items can invalidate the previously available shipping options.
       x-internal: false
     checkoutCart:
@@ -4125,6 +4203,24 @@ components:
             createdTime: '2019-01-10T17:18:00+00:00'
             updatedTime: '2019-01-10T17:19:47+00:00'
             customerMessage: ''
+            version: 1
+    CartConflictErrorResponse:
+      description: 'Cart conflict'
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+              title:
+                type: string
+              type:
+                type: string
+          example:
+            status: 409
+            title: The request cannot be processed due to a possible conflict. Please review the changes and try again.
+            type: https://developer.bigcommerce.com/api-docs/getting-started/api-status-codes
   parameters:
     Accept:
       name: Accept

--- a/reference/checkouts.v3.yml
+++ b/reference/checkouts.v3.yml
@@ -790,6 +790,7 @@ paths:
                             - homepage
                             - cartpage
                           text: Some text
+                  version: 1
         '404':
           description: Error code that is displayed when a given checkout ID is not found.
           content:
@@ -980,6 +981,7 @@ paths:
                   created_time: '2019-08-05T15:38:14+00:00'
                   updated_time: '2019-08-05T15:41:28+00:00'
                   customer_message: ''
+                  version: 1
                 meta: {}
             Selected Shipping Options:
               example:
@@ -1093,6 +1095,7 @@ paths:
                   created_time: '2019-08-05T15:38:14+00:00'
                   updated_time: '2019-08-05T15:41:28+00:00'
                   customer_message: ''
+                  version: 1
                 meta: {}
             Coupon Applied:
               example:
@@ -1206,6 +1209,7 @@ paths:
                   created_time: '2021-11-08T22:46:23+00:00'
                   updated_time: '2021-11-09T16:08:01+00:00'
                   customer_message: ''
+                  version: 1
                 meta: {}
             No Coupon Applied:
               example:
@@ -1292,6 +1296,7 @@ paths:
                   created_time: '2021-11-08T22:46:23+00:00'
                   updated_time: '2021-11-09T16:06:56+00:00'
                   customer_message: ''
+                  version: 1
                 meta: {}
             Include promotions:
               example:
@@ -1386,6 +1391,7 @@ paths:
                             - homepage
                             - cartpage
                           text: Some text
+                  version: 1
                 meta: {}
             example-1:
               example:
@@ -1579,6 +1585,9 @@ paths:
                             - homepage
                             - cartpage
                           text: Some text
+                  version: 1
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
       x-unitTests: []
       x-operation-settings:
         CollectParameters: false
@@ -1604,6 +1613,8 @@ paths:
 
         Required Fields:
         * `discounted_amount` at the cart-level or at the item-level
+
+        To prevent lost updates due to concurrent requests overriding changes made by others, it is recommended to enable optimistic concurrency control by including the `version` field in the request payload. If the provided version does not match the version on the server, a conflict error will be returned, which the client can handle accordingly.
       operationId: addCheckoutDiscount
       parameters:
         - $ref: '#/components/parameters/checkoutId'
@@ -1642,11 +1653,15 @@ paths:
                               discounted_amount:
                                 type: number
                                 example: 15
+                    version:
+                      type: integer
+                      description: The expected version of the checkout.
             example:
-              carts:
+              cart:
                 discounts: 
                   - discounted_amount: 10
                     name: "manual-discount"
+              version: 1
         required: false
       responses:
         '200':
@@ -2468,6 +2483,9 @@ paths:
                             - homepage
                             - cartpage
                           text: Some text
+                  version: 1
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
   '/checkouts/{checkoutId}/billing-address':
     post:
       tags:
@@ -2479,6 +2497,8 @@ paths:
         **Required Fields**
         * email
         * country_code
+
+        To prevent lost updates due to concurrent requests overriding changes made by others, it is recommended to enable optimistic concurrency control by including the `version` field in the request payload. If the provided version does not match the version on the server, a conflict error will be returned, which the client can handle accordingly.
       operationId: addCheckoutBillingAddress
       parameters:
         - $ref: '#/components/parameters/checkoutId'
@@ -2633,6 +2653,7 @@ paths:
                   created_time: '2019-08-05T15:38:14+00:00'
                   updated_time: '2019-08-05T15:41:28+00:00'
                   customer_message: ''
+                  version: 1
                 meta: {}
             Selected Shipping Options:
               example:
@@ -2746,6 +2767,7 @@ paths:
                   created_time: '2019-08-05T15:38:14+00:00'
                   updated_time: '2019-08-05T15:41:28+00:00'
                   customer_message: ''
+                  version: 1
                 meta: {}
             Coupon Applied:
               example:
@@ -2859,6 +2881,7 @@ paths:
                   created_time: '2021-11-08T22:46:23+00:00'
                   updated_time: '2021-11-09T16:08:01+00:00'
                   customer_message: ''
+                  version: 1
                 meta: {}
             No Coupon Applied:
               example:
@@ -2945,6 +2968,7 @@ paths:
                   created_time: '2021-11-08T22:46:23+00:00'
                   updated_time: '2021-11-09T16:06:56+00:00'
                   customer_message: ''
+                  version: 1
                 meta: {}
             Include promotions:
               example:
@@ -3039,6 +3063,7 @@ paths:
                             - homepage
                             - cartpage
                           text: Some text
+                  version: 1
                 meta: {}
             example-1:
               example:
@@ -3232,6 +3257,9 @@ paths:
                             - homepage
                             - cartpage
                           text: Some text
+                  version: 1
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
       x-unitTests: []
       x-operation-settings:
         CollectParameters: false
@@ -3243,7 +3271,10 @@ paths:
       tags:
         - Checkout Billing Address
       summary: Update Checkout Billing Address
-      description: Updates an existing billing address on a checkout.
+      description: |-
+        Updates an existing billing address on a checkout.
+
+        To prevent lost updates due to concurrent requests overriding changes made by others, it is recommended to enable optimistic concurrency control by including the `version` field in the request payload. If the provided version does not match the version on the server, a conflict error will be returned, which the client can handle accordingly.
       operationId: updateCheckoutBillingAddress
       parameters:
         - $ref: '#/components/parameters/checkoutId'
@@ -3403,6 +3434,7 @@ paths:
                   created_time: '2019-08-05T15:38:14+00:00'
                   updated_time: '2019-08-05T15:41:28+00:00'
                   customer_message: ''
+                  version: 1
                 meta: {}
             Selected Shipping Options:
               example:
@@ -3516,6 +3548,7 @@ paths:
                   created_time: '2019-08-05T15:38:14+00:00'
                   updated_time: '2019-08-05T15:41:28+00:00'
                   customer_message: ''
+                  version: 1
                 meta: {}
             Coupon Applied:
               example:
@@ -3629,6 +3662,7 @@ paths:
                   created_time: '2021-11-08T22:46:23+00:00'
                   updated_time: '2021-11-09T16:08:01+00:00'
                   customer_message: ''
+                  version: 1
                 meta: {}
             No Coupon Applied:
               example:
@@ -3715,6 +3749,7 @@ paths:
                   created_time: '2021-11-08T22:46:23+00:00'
                   updated_time: '2021-11-09T16:06:56+00:00'
                   customer_message: ''
+                  version: 1
                 meta: {}
             Include promotions:
               example:
@@ -3809,6 +3844,7 @@ paths:
                             - homepage
                             - cartpage
                           text: Some text
+                  version: 1
                 meta: {}
             example-1:
               example:
@@ -4002,6 +4038,9 @@ paths:
                             - homepage
                             - cartpage
                           text: Some text
+                  version: 1
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
       x-unitTests: []
       x-operation-settings:
         CollectParameters: false
@@ -4017,7 +4056,7 @@ paths:
         Adds a new consignment to a checkout.
 
 
-        Please note that this API endpoint is not concurrent safe, meaning multiple simultaneous requests could result in unexpected and inconsistent results.
+        To prevent lost updates due to concurrent requests overriding changes made by others, it is recommended to enable optimistic concurrency control by including the `version` field in the request payload. If the provided version does not match the version on the server, a conflict error will be returned, which the client can handle accordingly.
 
         For more information about working with consignments, see [Checkout consignment](/docs/storefront/cart-checkout/guide/consignments).  
 
@@ -4067,14 +4106,16 @@ paths:
                           field_value: "string"
                     line_items: 
                       - item_id: "118f8774-387c-485e-a095-6ef76d5f1bbd"
-                        quantity: 1 
+                        quantity: 1
+                    version: 1
               Pickup Consignment:
                 value: 
                   - line_items:
                       - item_id: "118f8774-387c-485e-a095-6ef76d5f1bbd"
                         quantity: 1
                     pickup_option:
-                      pickup_method_id: 1                 
+                      pickup_method_id: 1
+                    version: 1
       responses:
         '200':
           description: ''
@@ -4817,6 +4858,9 @@ paths:
                             - homepage
                             - cartpage
                           text: Some text
+                  version: 1
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
       x-unitTests: []
       x-operation-settings:
         CollectParameters: false
@@ -4848,7 +4892,7 @@ paths:
         
         To update an existing address and line item IDs, assign a new address and line item IDs by sending a `PUT` request.
 
-        Please note that this API endpoint is not concurrent safe, meaning multiple simultaneous requests could result in unexpected and inconsistent results.
+        To prevent lost updates due to concurrent requests overriding changes made by others, it is recommended to enable optimistic concurrency control by including the `version` field in the request payload. If the provided version does not match the version on the server, a conflict error will be returned, which the client can handle accordingly.
         
 
         2. Assign a shipping option to the new consignment by sending a `PUT` request to update the consignment's `shipping_option_id` with a returned value from `data.consignments[N].available_shipping_option[N].id` obtained in Step One. 
@@ -5604,13 +5648,23 @@ paths:
                             - homepage
                             - cartpage
                           text: Some text
+                  version: 1
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
     delete:
       tags:
         - Checkout Consignments
       summary: Delete Checkout Consignment
       description: |-
         Removes an existing consignment from a checkout.
+
+        To prevent lost updates due to concurrent requests overriding changes made by others, it is recommended to enable optimistic concurrency control by including the `version` field in the request payload. If the provided version does not match the version on the server, a conflict error will be returned, which the client can handle accordingly.
       operationId: deleteCheckoutConsignment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteConsignmentRequest'
       responses:
         '200':
           description: ''
@@ -6353,6 +6407,7 @@ paths:
                             - homepage
                             - cartpage
                           text: Some text
+                  version: 1
   '/checkouts/{checkoutId}/coupons':
     post:
       tags:
@@ -6367,7 +6422,9 @@ paths:
         * coupon_code
 
         **Limits**
-        * Coupon codes have a 50-character limit. 
+        * Coupon codes have a 50-character limit.
+
+        To prevent lost updates due to concurrent requests overriding changes made by others, it is recommended to enable optimistic concurrency control by including the `version` field in the request payload. If the provided version does not match the version on the server, a conflict error will be returned, which the client can handle accordingly.
       operationId: addCheckoutCoupon
       parameters:
         - $ref: '#/components/parameters/checkoutId'
@@ -7121,6 +7178,9 @@ paths:
                             - homepage
                             - cartpage
                           text: Some text
+                  version: 1
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
       x-unitTests: []
       x-operation-settings:
         CollectParameters: false
@@ -7132,7 +7192,10 @@ paths:
       tags:
         - Checkout Coupons
       summary: Delete Checkout Coupon
-      description: Deletes a coupon code from a checkout.
+      description: |-
+        Deletes a coupon code from a checkout.
+
+        To prevent lost updates due to concurrent requests overriding changes made by others, it is recommended to enable optimistic concurrency control by including the `version` field in the request payload. If the provided version does not match the version on the server, a conflict error will be returned, which the client can handle accordingly.
       operationId: deleteCheckoutCoupon
       parameters:
         - $ref: '#/components/parameters/checkoutId'
@@ -7143,6 +7206,11 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteCouponCodeRequest'
       responses:
         '200':
           description: ''
@@ -7693,6 +7761,8 @@ paths:
                             - cartpage
                           text: Some text
                 meta: {}
+        '409':
+          $ref: '#/components/responses/CartConflictErrorResponse'
   '/checkouts/{checkoutId}/orders':
     post:
       tags:
@@ -8646,6 +8716,10 @@ components:
                     text:
                       type: string
                       description: Text of the banner.
+        version:
+          type: integer
+          description: The current version of the checkout.
+          example: 1
     Checkout_Put:
       title: Checkout_Put
       required:
@@ -8655,6 +8729,9 @@ components:
         customer_message:
           type: string
           description: ''
+        version:
+          type: integer
+          description: The expected version of the checkout.
       x-internal: false
     AppliedCoupon:
       title: Applied Coupon
@@ -8737,6 +8814,9 @@ components:
               field_value:
                 type: string
                 description: 'This can also be an array for fields that need to support a list of values (e.g., a set of check boxes.)'
+        version:
+          type: integer
+          description: The expected version of the checkout.
       x-internal: false
     CreateConsignmentRequest:
       title: Create Consignment Request
@@ -8827,7 +8907,18 @@ components:
             properties:
               pickup_method_id:
                 type: integer
-                example: 1                  
+                example: 1
+          version:
+            type: integer
+            description: The expected version of the checkout.
+      x-internal: false
+    DeleteConsignmentRequest:
+      title: Delete Consignment Request
+      type: object
+      properties:
+        version:
+          type: integer
+          description: The expected version of the checkout.
       x-internal: false
     UpdateConsignmentRequest:
       title: Update Consignment Request
@@ -8925,6 +9016,9 @@ components:
               description:
                 type: string
                 example: "custom shipping"
+          version:
+            type: integer
+            description: The expected version of the checkout.
       description: One or more of these three fields are mandatory. `address` and `line_items` can be updated in one request. `shipping_option_id` has to be updated in a separate request because changing the address or line items can invalidate the previously available shipping options.
       x-internal: false
     CouponCodeRequest:
@@ -8934,6 +9028,17 @@ components:
         coupon_code:
           type: string
           description: Coupon codes have a 50-character limit.
+        version:
+          type: integer
+          description: The expected version of the checkout.
+      x-internal: false
+    DeleteCouponCodeRequest:
+      title: Delete Coupon Request
+      type: object
+      properties:
+        version:
+          type: integer
+          description: The expected version of the checkout.
       x-internal: false
     Order:
       title: Order
@@ -9725,6 +9830,24 @@ components:
                         - homepage
                         - cartpage
                       text: Some text
+              version: 1
+    CartConflictErrorResponse:
+      description: 'Cart conflict'
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+              title:
+                type: string
+              type:
+                type: string
+          example:
+            status: 409
+            title: The request cannot be processed due to a possible conflict. Please review the changes and try again.
+            type: https://developer.bigcommerce.com/api-docs/getting-started/api-status-codes
     checkout_settings_resp:
       description: ''
       content:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6022]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Added `version` field to the request and response payload of the Storefront and Management REST Cart and Checkout API.
* Added a description explaining that this field can be used to enable optimistic concurrency control to prevent lost updates caused by concurrent updates.

## Release notes draft
We are happy to announce that the Cart and Checkout API now supports optimistic concurrency control. This feature helps prevent lost updates caused by concurrent requests overriding changes made by others. If the `version` number provided by an API client does not match the version on the server, the request will be rejected, allowing the client to handle the error accordingly.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @bigcommerce/dev-docs @bigcommerce/team-checkout 


[DEVDOCS-6022]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ