### PR TITLE
docs(orders): ORDERS-6461 clarify PUT discounts behaviour

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -97,7 +97,7 @@ paths:
         
         To remove a product from an order, set that product’s `quantity` to `0`.
 
-        After the update, the PUT request clears all discounts and promotions applied to the order. Since the order data syncs with other ERP systems, like Amazon or eBay, the updated order returns to the default setting, removing any applied discounts.
+        After the update, the PUT request clears all discounts and promotions applied to the changed order line items. Since the order data syncs with other ERP systems, like Amazon or eBay, the updated order returns to the default setting, removing any applied discounts.
         
         To learn more about creating or updating orders, see [Orders Overview](/docs/store-operations/orders).
       summary: Update an Order


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# ORDERS-6461


## What changed?
<!-- Provide a bulleted list in the present tense -->
*  Correct behaviour for orders PUT. Old description implied discounts are wiped on the whole order when in reality we only wipe discounts off the line items changed in the request.

## Release notes draft
None

## Anything else?

ping @bigcommerce/team-orders 
