### PR TITLE
DEVDOCS-6034 [update]: Settings API, update docs for channel overrides

### DIFF
--- a/reference/settings.v3.yml
+++ b/reference/settings.v3.yml
@@ -792,9 +792,10 @@ paths:
     get:
       summary: Get Locale Settings
       operationId: getSettingsLocale
-      description: Returns global locale settings.
+      description: Return locale settings for the global store or a channel. 
       parameters:
         - $ref: '#/components/parameters/Accept'
+        - $ref: '#/components/parameters/ChannelIdParam'
       responses:
         '200':
           description: ''
@@ -821,10 +822,11 @@ paths:
       summary: Update Locale Settings
       operationId: updateSettingsLocale
       description: |-
-        Updates global locale settings.
+        Update locale settings for the global store or a channel.
       parameters:
         - $ref: '#/components/parameters/Accept'
         - $ref: '#/components/parameters/ContentType'
+        - $ref: '#/components/parameters/ChannelIdParam'
       requestBody:
         content:
           application/json:
@@ -835,7 +837,7 @@ paths:
                   shopper_language_selection_method: default_shopper_language
                   store_country: United States
             schema:
-              $ref: '#/components/schemas/Locale'
+              $ref: '#/components/schemas/Locale_Req'
       responses:
         '200':
           description: ''
@@ -2037,9 +2039,39 @@ components:
           description: Describes whether out-of-stock messages are shown on product listing pages.
           default: false
           example: true
+    Locale_Req:
+      description: 'The basic locale settings for a store, used to give shopper information about languages, countries, etc.'
+      type: object
+      properties:
+        default_shopper_language:
+          type: string
+          example: 'en, en-us'
+          default: en
+          nullable: true
+        shopper_language_selection_method:
+          description: |-
+            Determines whether to display the storefront content in the shopperʼs browser language or the shopperʼs selected default language.
+
+            Available values:
+            * `browser` - language updates automatically based on the shopper browser language. Multiple languages are supported.
+            * `default_shopper_language` - content is displayed in a single language based on the set `default_shopper_language`. Only the selected language is supported.
+          type: string
+          example: default_shopper_language
+          default: default_shopper_language
+          enum:
+            - browser
+            - default_shopper_language
+          nullable: true
+        store_country:
+          type: string
+          default: United States
+          nullable: true
+      required:
+        - default_shopper_language
     Locale:
       description: 'The basic locale settings for a store, used to give shopper information about languages, countries, etc.'
       type: object
+      nullable: true
       properties:
         default_shopper_language:
           type: string
@@ -2061,8 +2093,6 @@ components:
         store_country:
           type: string
           default: United States
-      required:
-        - default_shopper_language
       x-internal: false
     LogoSettings:
       type: object

--- a/reference/settings.v3.yml
+++ b/reference/settings.v3.yml
@@ -792,13 +792,13 @@ paths:
     get:
       summary: Get Locale Settings
       operationId: getSettingsLocale
-      description: Return locale settings for the global store or a channel. 
+      description: Return locale settings for the global store or a channel.
       parameters:
         - $ref: '#/components/parameters/Accept'
         - $ref: '#/components/parameters/ChannelIdParam'
       responses:
         '200':
-          description: ''
+          description: 'If a channel uses global settings, `data` returns as `null`'
           content:
             application/json:
               examples:
@@ -823,6 +823,8 @@ paths:
       operationId: updateSettingsLocale
       description: |-
         Update locale settings for the global store or a channel.
+
+        To remove channel overrides, set all the request body fields to `null` and use the `channel_id` query parameter.
       parameters:
         - $ref: '#/components/parameters/Accept'
         - $ref: '#/components/parameters/ContentType'


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6034]

This PR addresses [issue 388](https://github.com/bigcommerce/docs/issues/388)

Relevant slack [conversation](https://bigcommerce.slack.com/archives/C01FWQ4LPE3/p1723647892148459)

## What changed?
<!-- Provide a bulleted list in the present tense -->

[Get Locale Settings](https://developer.bigcommerce.com/docs/rest-management/settings/store-locale#get-locale-settings) & [Update Locale Settings](https://developer.bigcommerce.com/docs/rest-management/settings/store-locale#update-locale-settings) endpoint:
* add `channel_id` query parameter
* Response body: if there are no channel overrides, `data` will be `null`

Update Locale Settings endpoint:
* Document how to remove overrides (set each field to `null`) 

## Release notes draft
N / A

## Anything else?
@bigcommerce/team-multi-storefront 


[DEVDOCS-6034]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ