### PR TITLE
DEVDOCS-6022: Add example value to version field for cart/checkout API

### DIFF
--- a/reference/carts.sf.yml
+++ b/reference/carts.sf.yml
@@ -531,6 +531,7 @@ components:
             version:
               type: integer
               description: The expected version of the cart.
+              example: 1
           required:
             - lineItems
         - type: object
@@ -542,6 +543,7 @@ components:
             version:
               type: integer
               description: The expected version of the cart.
+              example: 1
           required:
             - giftCertificates
         - type: object
@@ -555,6 +557,7 @@ components:
             version:
               type: integer
               description: The expected version of the cart.
+              example: 1
           required:
             - lineItems
             - giftCertificates
@@ -570,6 +573,7 @@ components:
             version:
               type: integer
               description: The expected version of the cart.
+              example: 1
           required:
             - lineItem
           title: Line item
@@ -580,6 +584,7 @@ components:
             version:
               type: integer
               description: The expected version of the cart.
+              example: 1
           required:
             - giftCertificates
           title: Gift certificate item
@@ -592,6 +597,7 @@ components:
             version:
               type: integer
               description: The expected version of the cart.
+              example: 1
           required:
             - lineItem
             - giftCertificates
@@ -603,6 +609,7 @@ components:
         version:
           type: integer
           description: The expected version of the cart.
+          example: 1
     responseCartCurrency:
       title: Currency
       type: object

--- a/reference/carts.v3.yml
+++ b/reference/carts.v3.yml
@@ -1525,6 +1525,7 @@ components:
         version:
           type: integer
           description: The expected version of the cart.
+          example: 1
       title: Cart Update Put Request Data
       x-internal: false
     LineItemRequestData:
@@ -2893,12 +2894,14 @@ components:
         version:
           type: integer
           description: The expected version of the cart.
+          example: 1
     CartLineItemDelete:
       type: object
       properties:
         version:
           type: integer
           description: The expected version of the cart.
+          example: 1
     Redirect_urls_Post:
       type: object
       title: Redirect_urls_Post
@@ -2981,6 +2984,7 @@ components:
         version:
           type: integer
           description: The expected version of the cart.
+          example: 1
     cart_PostCustomItem:
       type: array
       title: Custom item

--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -1813,6 +1813,7 @@ paths:
                 version:
                   type: integer
                   description: The expected version of the checkout.
+                  example: 1
         required: true
       responses:
         '200':
@@ -2501,6 +2502,7 @@ components:
             version:
               type: integer
               description: The expected version of the checkout.
+              example: 1
       x-internal: false
     consignment_Full:
       title: consignment_Full
@@ -2623,6 +2625,7 @@ components:
         version:
           type: integer
           description: The expected version of the checkout.
+          example: 1
       x-internal: false
     checkouts_Resp:
       title: checkouts_Resp
@@ -3532,6 +3535,7 @@ components:
         version:
           type: integer
           description: The expected version of the checkout.
+          example: 1
       x-internal: false
     DeleteCouponCodeRequest:
       title: Delete Coupon Request
@@ -3540,6 +3544,7 @@ components:
         version:
           type: integer
           description: The expected version of the checkout.
+          example: 1
       x-internal: false
     DeleteConsignmentRequest:
       title: Delete Consignment Request
@@ -3548,6 +3553,7 @@ components:
         version:
           type: integer
           description: The expected version of the checkout.
+          example: 1
       x-internal: false
     GiftCertificateRequest:
       title: Gift Certificate Request
@@ -3657,6 +3663,7 @@ components:
         version:
           type: integer
           description: The expected version of the checkout.
+          example: 1
       description: One or more of these three fields is mandatory. You can update address and line items in one request. You have to update shipping option ID or pickup option ID in a separate request since changing the address or line items can invalidate the previously available shipping options.
       x-internal: false
     checkoutCart:

--- a/reference/checkouts.v3.yml
+++ b/reference/checkouts.v3.yml
@@ -1656,6 +1656,7 @@ paths:
                     version:
                       type: integer
                       description: The expected version of the checkout.
+                      example: 1
             example:
               cart:
                 discounts: 
@@ -8732,6 +8733,7 @@ components:
         version:
           type: integer
           description: The expected version of the checkout.
+          example: 1
       x-internal: false
     AppliedCoupon:
       title: Applied Coupon
@@ -8817,6 +8819,7 @@ components:
         version:
           type: integer
           description: The expected version of the checkout.
+          example: 1
       x-internal: false
     CreateConsignmentRequest:
       title: Create Consignment Request
@@ -8911,6 +8914,7 @@ components:
           version:
             type: integer
             description: The expected version of the checkout.
+            example: 1
       x-internal: false
     DeleteConsignmentRequest:
       title: Delete Consignment Request
@@ -8919,6 +8923,7 @@ components:
         version:
           type: integer
           description: The expected version of the checkout.
+          example: 1
       x-internal: false
     UpdateConsignmentRequest:
       title: Update Consignment Request
@@ -9019,6 +9024,7 @@ components:
           version:
             type: integer
             description: The expected version of the checkout.
+            example: 1
       description: One or more of these three fields are mandatory. `address` and `line_items` can be updated in one request. `shipping_option_id` has to be updated in a separate request because changing the address or line items can invalidate the previously available shipping options.
       x-internal: false
     CouponCodeRequest:
@@ -9031,6 +9037,7 @@ components:
         version:
           type: integer
           description: The expected version of the checkout.
+          example: 1
       x-internal: false
     DeleteCouponCodeRequest:
       title: Delete Coupon Request
@@ -9039,6 +9046,7 @@ components:
         version:
           type: integer
           description: The expected version of the checkout.
+          example: 1
       x-internal: false
     Order:
       title: Order


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6022]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Add `example` to `version` field for cart/checkout API. Otherwise, it shows up as `version: 0`, which is an invalid value.

## Release notes draft
N/A

## Anything else?
Related PR: https://github.com/bigcommerce/docs/pull/439

ping @bigcommerce/dev-docs 


[DEVDOCS-6022]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ