### PR TITLE
Add deprecation notice to v2 B2B API endpoints (yaml)

### DIFF
--- a/docs/b2b-edition/specs/api-v2/openAPI.yaml
+++ b/docs/b2b-edition/specs/api-v2/openAPI.yaml
@@ -20,6 +20,7 @@ paths:
     get:
       tags:
       - Address
+      deprecated: true
       summary: Convert Country State
       description: Convert country/state name to their code or code to name
       operationId: addresses_country_state_list
@@ -155,6 +156,7 @@ paths:
     post:
       tags:
       - Company
+      deprecated: true
       summary: Create Company From CG
       description: Create company from bigCommerce customer group. This API only enable
         for non-MSF store.
@@ -443,6 +445,7 @@ paths:
     post:
       tags:
       - Order
+      deprecated: true
       summary: Create Order Without CompanyID
       description: "Create an order from bigCommerce, you must known order id"
       operationId: companies_users_orders_create
@@ -609,6 +612,7 @@ paths:
     get:
       tags:
       - Address
+      deprecated: true
       summary: Get Company Addresses
       description: Get all addresses for a company
       operationId: companies_addresses_list
@@ -877,6 +881,7 @@ paths:
     post:
       tags:
       - Address
+      deprecated: true
       summary: Create A Company Address
       description: "Creates a new address for a company. You will specify the address\
         \ fields and the type of address. The address can be billing, shipping, or\
@@ -1129,6 +1134,7 @@ paths:
     get:
       tags:
       - Address
+      deprecated: true
       summary: Get A Company Address
       description: Get an address for a company
       operationId: companies_addresses_read
@@ -1318,6 +1324,7 @@ paths:
     put:
       tags:
       - Address
+      deprecated: true
       summary: Update A Company Address
       description: "Updates an address for a company. You can change whether the address\
         \ is for billing, shipping, or both. You can also update the address to be\
@@ -1570,6 +1577,7 @@ paths:
     delete:
       tags:
       - Address
+      deprecated: true
       summary: Delete A Company Address
       description: Deletes an address from a company.
       operationId: companies_addresses_delete
@@ -1679,6 +1687,7 @@ paths:
     get:
       tags:
       - Company
+      deprecated: true
       summary: Get Company Basic Information
       description: Get company's basic information
       operationId: companies_basic-info_list
@@ -1875,6 +1884,7 @@ paths:
     put:
       tags:
       - Company
+      deprecated: true
       summary: Update Company Basic Information
       description: "Update a company's basic info, you can update on or more options"
       operationId: companies_basic-info_update
@@ -2106,6 +2116,7 @@ paths:
     delete:
       tags:
       - Company
+      deprecated: true
       summary: Delete Company With Related
       description: Force Delete A Company and its Related Information.
       operationId: companies_force-del_delete
@@ -2210,6 +2221,7 @@ paths:
     get:
       tags:
       - Company
+      deprecated: true
       summary: Get BC Order Id List By Company Id
       description: Get bC order ID list by company id
       operationId: companies_orderBCIds_list
@@ -2360,6 +2372,7 @@ paths:
     get:
       tags:
       - Order
+      deprecated: true
       summary: Get Company Orders
       description: "Get company all orders, with pagination data"
       operationId: companies_orders_list
@@ -2637,6 +2650,7 @@ paths:
     get:
       tags:
       - Payment
+      deprecated: true
       summary: Get Company Payments Methods
       description: "Get company payments methods, include inactive"
       operationId: companies_payments_list
@@ -2747,6 +2761,7 @@ paths:
     put:
       tags:
       - Payment
+      deprecated: true
       summary: Update Company Payments Methods
       description: "Update Company payments methods' status, change them active or\
         \ not"
@@ -2925,6 +2940,7 @@ paths:
     get:
       tags:
       - SalesRep
+      deprecated: true
       summary: Get Company Sales Reps
       description: Get company sales reps' basic info
       operationId: companies_sales-reps_list
@@ -3039,6 +3055,7 @@ paths:
     put:
       tags:
       - SalesRep
+      deprecated: true
       summary: Update Company Sales reps
       description: Update company reps
       operationId: companies_sales-reps_update
@@ -3203,6 +3220,7 @@ paths:
     post:
       tags:
       - Order
+      deprecated: true
       summary: Create An Order
       description: "Create an order from bigCommerce, you must known order id"
       operationId: companies_user_orders_create
@@ -3374,6 +3392,7 @@ paths:
     put:
       tags:
       - User
+      deprecated: true
       summary: Update A Company User
       description: Update a company user info
       operationId: companies_user_update
@@ -3457,6 +3476,7 @@ paths:
     get:
       tags:
       - User
+      deprecated: true
       summary: Get Company Users
       description: "Get company users, with pagination data"
       operationId: companies_users_list
@@ -3678,6 +3698,7 @@ paths:
     put:
       tags:
       - User
+      deprecated: true
       summary: Update Company User
       description: "Update company user's field, user identified by email field.fields\
         \ can not omit"
@@ -3872,6 +3893,7 @@ paths:
     post:
       tags:
       - User
+      deprecated: true
       summary: Create A Company User
       description: "Create a company user, which belongs company"
       operationId: companies_users_create
@@ -4074,6 +4096,7 @@ paths:
     post:
       tags:
       - User
+      deprecated: true
       summary: Bulk Create Company User
       description: Create company users in batch
       operationId: companies_users_bulk_create_create
@@ -4354,6 +4377,7 @@ paths:
     get:
       tags:
       - User
+      deprecated: true
       summary: Get A Company User
       description: "Get a company user's info, by company and customer id"
       operationId: companies_users_read
@@ -4534,6 +4558,7 @@ paths:
     delete:
       tags:
       - User
+      deprecated: true
       summary: Delete A Company User
       description: "Delete a company user, if this user is the only one administrator\
         \ of company, will return a 500 Error"
@@ -4644,6 +4669,7 @@ paths:
     put:
       tags:
       - Order
+      deprecated: true
       summary: Update Company Order With BC OrderId
       description: "Update order, billingAddress and products can not be omitted.\
         \ products can be two format. \n 1. Product with variants. \n 2. Base product"
@@ -5053,6 +5079,7 @@ paths:
     put:
       tags:
       - Order
+      deprecated: true
       summary: Update B2BE User's Orders' company attribute.
       description: Update the orders belong to a B2BE company to another B2BE company.
       operationId: orders_company_update
@@ -5179,6 +5206,7 @@ paths:
     post:
       tags:
       - Order
+      deprecated: true
       summary: Update BC Order's 'Company attribute'
       description: "Add Company identifier for BigCommerce Customer Individual Orders,\
         \ which can be used to convert BigCommerce Customer Individual Orders to Company-level\
@@ -5301,6 +5329,7 @@ paths:
     get:
       tags:
       - Order
+      deprecated: true
       summary: Get Orders Images
       description: Get all orders' images
       operationId: orders_images_list
@@ -5388,6 +5417,7 @@ paths:
     get:
       tags:
       - Order
+      deprecated: true
       summary: Get Company By BC OrderId
       description: Get company basic info by bc order id
       operationId: orders_companyIdBCId_list
@@ -5541,6 +5571,7 @@ paths:
     get:
       tags:
       - Order
+      deprecated: true
       summary: Get Company Id By Order Id
       description: Get company ID by order id
       operationId: orders_companyId_list
@@ -5621,6 +5652,7 @@ paths:
     get:
       tags:
       - Order
+      deprecated: true
       summary: Get Order Detail
       description: Get order's Detail
       operationId: orders_details_list
@@ -6425,6 +6457,7 @@ paths:
     get:
       tags:
       - Order
+      deprecated: true
       summary: Get Order Product
       description: Get order's products info
       operationId: orders_products_list
@@ -6549,6 +6582,7 @@ paths:
     post:
       tags:
       - Proxy
+      deprecated: true
       summary: Third party API proxy
       description: Get response data of third party APIs through this API.
       operationId: proxy_create
@@ -6668,6 +6702,7 @@ paths:
     get:
       tags:
       - SalesRep
+      deprecated: true
       summary: Get Companies & Sales reps
       description: "Get all companies and their sales reps, default order by company"
       operationId: sales-reps_companies_list
@@ -6847,6 +6882,7 @@ paths:
     get:
       tags:
       - Payment
+      deprecated: true
       summary: Get Store's All Payments
       description: Get store's all payments
       operationId: store_payments_list
@@ -6942,6 +6978,7 @@ paths:
     get:
       tags:
       - Company
+      deprecated: true
       summary: Get Company By CustomerId
       description: "Get company by customer Id, if company not in bigCommerce will\
         \ delete the company"


### PR DESCRIPTION
## What changed?

Updated the B2B v2 APIs yaml spec with deprecation notices.

## Release notes draft

Now that the v3 B2B APIs are widely released, we've deprecated our set of v2 B2B endpoints.
