### PR TITLE
DEVDOCS-6025 [update]: Store Information, add country_code & favicon_url into schema

### DIFF
--- a/reference/store_information.v2.yml
+++ b/reference/store_information.v2.yml
@@ -200,6 +200,10 @@ components:
           description: Country where the store is located (as defined during the store sign-up process).
           example: United States
           type: string
+        country_code:
+          type: string
+          example: AU
+          description: Two-letter ISO 3166-1 country code
         phone:
           description: Display phone number.
           type: string
@@ -211,6 +215,9 @@ components:
           description: Email address for orders and fulfillment.
           example: 'orders@example.com'
           type: string
+        favicon_url:
+          description: The URL of the favicon image associated with the website. This should be a valid URL pointing to an `.ico` or other supported icon format file.
+          type: string 
         timezone:
           $ref: '#/components/schemas/Timezone'
         language:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6025]

Relevant slack conversation https://bigcommerce.slack.com/archives/C011NMGSUE9/p1723843420293349

## What changed?
- add `country_code` & `favicon_url` into schema for Get Store Information endpoint

## Release notes draft
N / A

## Anything else?


[DEVDOCS-6025]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ