### PR TITLE
doc(orders): ORDERS-6254 support product refund deduction (adjustment) in Refund API

### DIFF
--- a/reference/orders.v3.yml
+++ b/reference/orders.v3.yml
@@ -2571,6 +2571,11 @@ components:
           type: integer
           example: 1
           description: Order Product ID.
+        adjustments:
+          type: array
+          description: 'Array of product refund deductions'
+          items:
+            $ref: '#/components/schemas/RefundItemAdjustment'
         quantity:
           type: integer
           example: 3
@@ -2581,6 +2586,25 @@ components:
           minLength: 0
           maxLength: 1000
       x-internal: false
+    RefundItemAdjustment:
+      type: object
+      title: Refund Item Adjustment
+      description: Use to reduce the amount refunded for an item.
+      properties:
+        amount:
+          type: number
+          format: float
+          description: 'A negative 2 decimal place rounded value to deduct from the amount refunded.'
+          example: -10.2
+          title: Refund Item Adjustment Amount
+          exclusiveMaximum: True
+          maximum: 0
+        description:
+          type: string
+          description: Description of reason for the adjustment.
+          minLength: 0
+          maxLength: 255
+          example: 'Service fee'
     TaxExemptItem:
       type: object
       title: Tax Exempt (Order Level)
@@ -2732,6 +2756,11 @@ components:
         quantity:
           type: integer
           description: 'Quantity of item refunded. Note: this will only be populated for item_type PRODUCT'
+        adjustments:
+          type: array
+          description: Adjustments to apply to the refunded amount for an item. Only supported for item_type PRODUCT
+          items:
+            $ref: '#/components/schemas/RefundItemAdjustment'
         requested_amount:
           $ref: '#/components/schemas/Amount'
       title: Refund Item


### PR DESCRIPTION
# [ORDERS-6254]
Update swagger file of the Refund API to support product refund deductions (adjustment)

## What changed?
* New field `adjustments` in request body of `POST /orders/{order_id}/payment_actions/refund_quotes` and `POST 
/orders/{order_id}/payment_actions/refunds`, and in  the response of `GET /orders/{order_id}/payment_actions/refunds`

<img width="967" alt="image" src="https://github.com/user-attachments/assets/3ebc6c11-6507-41d2-a4d1-09d3bc62fdf0">

<img width="984" alt="image" src="https://github.com/user-attachments/assets/ee0cba71-973e-4787-bd79-8fa0fd6d61d6">

<img width="986" alt="image" src="https://github.com/user-attachments/assets/e7b7ab0e-25cd-43e3-bd93-541fe982e36e">

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?

PROJECT-5156

ping @bigcommerce/team-orders 


[ORDERS-6254]: https://bigcommercecloud.atlassian.net/browse/ORDERS-6254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ