### PR TITLE
DEVDOCS-6025 [new]: Inventory API, add `sku_id` field

### DIFF
--- a/reference/inventory.v3.yml
+++ b/reference/inventory.v3.yml
@@ -590,6 +590,9 @@ components:
               type: integer
               description: ID of product.
               example: 120
+            sku_id: 
+              type: integer
+              description: Read-only reference to Catalog V2 API's SKU ID. `null` if the item is a base variant.
         locations:
           type: array
           items:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6025]

Relevant slack conversation https://bigcommerce.slack.com/archives/C05HK588YMN/p1723872133959149

## What changed?
<!-- Provide a bulleted list in the present tense -->
* Add `sku_id` field to the response for Get Inventory at Locations endpoint

## Release notes draft
- Updated Get Inventory at Locations endpoint response body to have the `sku_id` field


## Anything else?
@bigcommerce/team-inventory 


[DEVDOCS-6025]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ