### PR TITLE
DEVDOCS-6086 [update]: Sites API, update schema 

### DIFF
--- a/docs/start/best-practices/sunsets.mdx
+++ b/docs/start/best-practices/sunsets.mdx
@@ -65,6 +65,7 @@ We have removed the following properties.
 | API | Sunset property | Replacement property |
 |:----|:----------------|:---------------------|
 | [Channels V3](/docs/rest-management/channels#get-all-channels) |`is_enabled` | `status` |
+| [Sites](/docs/rest-management/sites) | `ssl_status` | [Site Certificates](/docs/rest-management/sites/site-certificate) `status` |
 
 ## Related resources 
 

--- a/reference/sites.v3.yml
+++ b/reference/sites.v3.yml
@@ -657,10 +657,14 @@ components:
           example: '2022-01-04T04:15:50.000Z'
         ssl_status:
           type: string
+          deprecated: true
           enum:
             - dedicated
             - shared
-          description: Indicates whether a site is using a private/dedicated SSL or a shared SSL.
+          description: |
+            Deprecated - Use the [Get a Site's SSL/TLS Certificate Information](/docs/rest-management/sites/site-certificate#get-a-sites-ssl-tls-certificate-information) endpoint instead.
+            
+            Indicates whether a site is using a private/dedicated SSL or a shared SSL.
         urls:
           type: array
           description: 'All URLs that belong to the site, including `primary`, `canonical`, and `checkout` URLs.'
@@ -1159,7 +1163,6 @@ components:
                   channel_id: 234
                   created_at: '2018-01-04T04:15:50.000Z'
                   updated_at: '2018-01-04T04:15:50.000Z'
-                  ssl_status: dedicated
                   urls:
                     - url: 'https://example.com'
                       type: primary

--- a/reference/sites.v3.yml
+++ b/reference/sites.v3.yml
@@ -241,7 +241,7 @@ paths:
       operationId: deleteSite
       responses:
         '204':
-          description: ''
+          description: No Content
       tags:
         - Sites
       description: 'Delete a site with site ID `{site_id}`.'

--- a/reference/sites.v3.yml
+++ b/reference/sites.v3.yml
@@ -1066,6 +1066,21 @@ components:
       properties: {}
       additionalProperties: true
       description: Response metadata.
+    Meta: 
+      type: object
+      properties:
+        pagination:
+          type: object
+          properties:
+            offset:
+              type: integer
+              description: The number of items skipped before starting the set of items returned. 
+            limit:
+              type: integer
+              description: The maximum number of items returned per page.
+            total_items:
+              type: integer
+              description: The total number of items available across all pages. 
   responses:
     502_GatewayError:
       description: 'If something happens during the request that causes it to fail, a 502 response will be returned. A new request should be made; however, it could fail.'
@@ -1236,7 +1251,7 @@ components:
                 items:
                   $ref: '#/components/schemas/_site'
               meta:
-                $ref: '#/components/schemas/_metaCollection'
+                $ref: '#/components/schemas/Meta'
           examples: {}
     siteRoute_Resp:
       description: ''

--- a/reference/sites.v3.yml
+++ b/reference/sites.v3.yml
@@ -241,10 +241,10 @@ paths:
       operationId: deleteSite
       responses:
         '204':
-          description: No Content
+          description: No Content.
       tags:
         - Sites
-      description: 'Delete a site with site ID `{site_id}`.'
+      description: 'Delete a site with site ID `{site_id}`. Remove the URL set for a given site ID.'
     parameters:
       - $ref: '#/components/parameters/Accept'
       - name: site_id

--- a/reference/sites.v3.yml
+++ b/reference/sites.v3.yml
@@ -1153,7 +1153,7 @@ components:
               data:
                 $ref: '#/components/schemas/_site'
               meta:
-                $ref: '#/components/schemas/_metaCollection'
+                $ref: '#/components/schemas/MetaOpen'
           examples:
             Example:
               value:
@@ -1177,11 +1177,7 @@ components:
                       created_at: '2020-11-03T19:26:12Z'
                       updated_at: '2021-08-31T21:46:50Z'
                   is_checkout_url_customized: true
-                meta:
-                  pagination:
-                    offset: 0
-                    limit: 50
-                    total_items: 1
+                meta: {}
     BulkErrorResponse:
       description: ''
       content:

--- a/reference/sites.v3.yml
+++ b/reference/sites.v3.yml
@@ -661,10 +661,7 @@ components:
           enum:
             - dedicated
             - shared
-          description: |
-            Deprecated - Use the [Get a Site's SSL/TLS Certificate Information](/docs/rest-management/sites/site-certificate#get-a-sites-ssl-tls-certificate-information) endpoint instead.
-            
-            Indicates whether a site is using a private/dedicated SSL or a shared SSL.
+          description: Indicates whether a site is using a private/dedicated SSL or a shared SSL.
         urls:
           type: array
           description: 'All URLs that belong to the site, including `primary`, `canonical`, and `checkout` URLs.'


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6086]

Relevant slack conversation https://bigcommerce.slack.com/archives/CESJ2NAH3/p1723146059526569

## What changed?
<!-- Provide a bulleted list in the present tense -->
* Update schema for Sites API

## Release notes draft
- Updated [Sites API](https://developer.bigcommerce.com/docs/rest-management/sites) reference to deprecate the `ssl_status` field. To find out whether a site uses a private or shared SSL, retrieve the `status` field from the [Site Certificate](https://developer.bigcommerce.com/docs/rest-management/sites/site-certificate#get-a-sites-ssl-tls-certificate-information) endpoint instead.

## Anything else?
@bigcommerce/team-multi-storefront 
