### PR TITLE
DEVDOCS-6025 [update]: Storefront Checkouts, update response schema

### DIFF
--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -912,7 +912,6 @@ components:
           shouldEncourageSignIn: false 
           storeCredit: 1.00
         customerMessage: 'Thank you, BigCommerce'
-        fees: []
         giftCertificates:
         - balance: 4.00
           code: '1234ABC'
@@ -974,11 +973,6 @@ components:
         customerMessage:
           type: string
           description: Shopperʼs message provided as details for the order to be created from this cart
-        fees: 
-          type: array
-          items:
-            type: object
-            properties: {}
         giftCertificates:
           type: array
           description: Applied gift certificate (as a payment method).

--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -2302,7 +2302,6 @@ components:
       properties:
         token:
           type: string
-      x-internal: false
     checkout_Full:
       title: checkout_Full
       type: object
@@ -2437,7 +2436,6 @@ components:
           type: number
           description: The discounted amount applied within a given context.
           format: double
-      x-internal: false
     CheckoutCoupon:
       title: Checkout Coupon
       required:
@@ -2468,7 +2466,6 @@ components:
           type: number
           description: The discounted amount applied within a given context.
           format: double
-      x-internal: false
     Customer: 
       type: object
       properties:
@@ -2520,7 +2517,6 @@ components:
           type: string
           description: ''
       description: Model for sender and receiver objects.
-      x-internal: false
     address_Full:
       title: address_Full
       description: ''
@@ -2534,7 +2530,6 @@ components:
             shouldSaveAddress:
               type: boolean
               description: Indicates whether we should add this address to the customer address book.
-      x-internal: false
     address_Base:
       title: address_Base
       required:
@@ -2595,7 +2590,6 @@ components:
           type: string
           description: This can also be an array for fields that need to support list of values; for example, a set of checkboxes. When doing a PUT or POST to the `fieldValue` with a pick list, the input must be a number. The response will be a string.
       description: 'When doing a PUT or POST to the `fieldValue` with a pick list, the input must be a number. The response will be a string.'
-      x-internal: false
     BillingAddressRequest:
       title: Billing address request
       allOf:
@@ -2606,7 +2600,6 @@ components:
               type: integer
               description: The expected version of the checkout.
               example: 1
-      x-internal: false
     consignment_Full:
       title: consignment_Full
       type: object
@@ -2705,7 +2698,6 @@ components:
               description: Is this shipping method the recommended shipping option or not.
             additionalDescription:
               type: string
-      x-internal: false
     checkoutTax:
       title: checkoutTax
       type: object
@@ -2717,7 +2709,6 @@ components:
           type: number
           description: ''
           format: double
-      x-internal: false
     checkout_Put:
       title: checkout_Put
       type: object
@@ -2729,7 +2720,6 @@ components:
           type: integer
           description: The expected version of the checkout.
           example: 1
-      x-internal: false
     cartLineItemPut:
       title: cartLineItemPut
       type: object
@@ -2748,7 +2738,6 @@ components:
           format: double
         giftWrapping:
           $ref: '#/components/schemas/cartLineItemGiftWrapping_Put'
-      x-internal: false
     cartLineItemGiftCertificate_Put:
       title: cartLineItemGiftCertificate_Put
       required:
@@ -2779,7 +2768,6 @@ components:
           type: number
           description: ''
           format: double
-      x-internal: false
     cartLineItemGiftWrapping_Put:
       title: Gift Wrapping Request Data
       required:
@@ -2905,7 +2893,6 @@ components:
           type: integer
           description: The expected version of the checkout.
           example: 1
-      x-internal: false
     DeleteCouponCodeRequest:
       title: Delete Coupon Request
       type: object
@@ -2914,7 +2901,6 @@ components:
           type: integer
           description: The expected version of the checkout.
           example: 1
-      x-internal: false
     DeleteConsignmentRequest:
       title: Delete Consignment Request
       type: object
@@ -2923,7 +2909,6 @@ components:
           type: integer
           description: The expected version of the checkout.
           example: 1
-      x-internal: false
     GiftCertificateRequest:
       title: Gift Certificate Request
       type: object
@@ -2931,7 +2916,6 @@ components:
         giftCertificateCode:
           type: string
           description: ''
-      x-internal: false
     cart_Put:
       title: cart_Put
       type: object
@@ -2940,7 +2924,6 @@ components:
           $ref: '#/components/schemas/cartLineItemPut'
         giftCertificate:
           $ref: '#/components/schemas/cartLineItemGiftCertificate_Put'
-      x-internal: false
     NewUpdateConsignment:
       title: Update Consignment Request
       type: object
@@ -3034,7 +3017,6 @@ components:
           description: The expected version of the checkout.
           example: 1
       description: One or more of these three fields is mandatory. You can update address and line items in one request. You have to update shipping option ID or pickup option ID in a separate request since changing the address or line items can invalidate the previously available shipping options.
-      x-internal: false
     checkoutCart:
       title: checkoutCart
       type: object
@@ -3212,7 +3194,6 @@ components:
           type: integer 
           description: Cart version.
       description: A cart contains a collection of items, prices, discounts, etc. It does not contain customer-related data.
-      x-internal: false
     lineItemPhysicalDigital: 
       type: object
       required:

--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -58,6 +58,7 @@ paths:
                 $ref: '#/components/schemas/checkouts_Resp'
               example:
                 id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
+                channelId: 1
                 cart:
                   id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
                   customerId: 18
@@ -73,11 +74,12 @@ paths:
                   cartAmount: 7.95
                   coupons: []
                   discounts:
-                    - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
+                    - id: 1
                       discountedAmount: 0
                   lineItems:
                     physicalItems:
                       - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
+                        categoryNames: ["Essentials", "Just arrived"]
                         parentId: ''
                         variantId: 345
                         productId: 174
@@ -94,9 +96,16 @@ paths:
                         originalPrice: 7.95
                         listPrice: 7.95
                         salePrice: 7.95
+                        comparisonPrice: 0
+                        extendedComparisonPrice: 0
                         extendedListPrice: 7.95
                         extendedSalePrice: 7.95
                         isShippingRequired: true
+                        options: 
+                        - name: "Color"
+                          nameId: 1
+                          value: "Red" 
+                          valueId: "2"
                         giftWrapping: {}
                         addedByPromotion: false
                     digitalItems: []
@@ -104,6 +113,8 @@ paths:
                     customItems: []
                   createdTime: '2019-01-10T17:18:00+00:00'
                   updatedTime: '2019-01-10T17:19:47+00:00'
+                  locale: "en"
+                  version: 1
                 billingAddress:
                   id: 5c377ead301c2
                   firstName: Dwayne
@@ -128,10 +139,19 @@ paths:
                     discounts: []
                     lineItemIds:
                       - 243c9ca2-22b4-417a-8b09-b3fc05778b52
+                    availableShippingOptions:
+                      - id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
+                        type: shipping_byweight
+                        description: Ship by Weight
+                        additionalDescription: Fragile items
+                        imageUrl: ''
+                        cost: 8
+                        transitTime: ''
                     selectedShippingOption:
                       id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
                       type: shipping_byweight
                       description: Ship by Weight
+                      additionalDescription: Fragile items
                       imageUrl: ''
                       cost: 8
                       transitTime: ''
@@ -150,9 +170,26 @@ paths:
                       postalCode: '96720'
                       phone: '8081234567'
                       customFields: []
+                customer:
+                  addresses: []
+                  customerGroup:
+                    id: 1
+                    name: "Wholesale Customers"
+                  email: ""
+                  firstName: "" 
+                  fullName: "" 
+                  id: 0 
+                  isGuest: true 
+                  lastName: "" 
+                  shouldEncourageSignIn: false 
+                  storeCredit: 0
+                fees: []
+                payments: [{}]
+                promotions: []
                 orderId: null
                 shippingCostTotal: 8
                 shippingCostBeforeDiscount: 8
+                shouldExecuteSpamCheck: false
                 handlingCostTotal: 0
                 taxTotal: 1.22
                 coupons: []
@@ -242,7 +279,7 @@ paths:
                   cartAmount: 7.95
                   coupons: []
                   discounts:
-                    - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
+                    - id: 1
                       discountedAmount: 0
                   lineItems:
                     physicalItems:

--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -2307,10 +2307,6 @@ components:
       title: checkout_Full
       type: object
       properties:
-        id:
-          type: string
-          description: ''
-          format: uuid
         billingAddress:
           $ref: '#/components/schemas/address_Base'
         cart:
@@ -2328,11 +2324,11 @@ components:
           description: Coupons applied at the checkout level.
           items:
             $ref: '#/components/schemas/CheckoutCoupon'
-        customer: 
-            $ref: '#/components/schemas/Customer'
         createdTime:
           type: string
           description: Time when the cart was created.
+        customer: 
+            $ref: '#/components/schemas/Customer'
         customerMessage:
           type: string
           description: Shopperʼs message provided as details for the order to be created from this cart
@@ -2346,17 +2342,21 @@ components:
           description: Applied gift certificate (as a payment method).
           items:
             $ref: '#/components/schemas/checkoutGiftCertificates'
+        giftWrappingCostTotal:
+          type: number
+          description: Gift wrapping cost for all items, including or excluding tax.
         grandTotal:
           type: number
           description: The total payable amount, before applying any store credit or gift certificate.
           format: float
-        giftWrappingCostTotal:
-          type: number
-          description: Gift wrapping cost for all items, including or excluding tax.
         handlingCostTotal:
           type: number
           description: Handling cost for all consignments including or excluding tax.
           format: float
+        id:
+          type: string
+          description: ''
+          format: uuid
         isStoreCreditApplied:
           type: boolean
           description: |
@@ -2408,7 +2408,6 @@ components:
           description: The current version of the checkout.
           example: 1
       description: ''
-      x-internal: false
     CartCoupon:
       title: Cart Coupon
       required:
@@ -2542,18 +2541,6 @@ components:
         - countryCode
       type: object
       properties:
-        firstName:
-          type: string
-          description: ''
-        lastName:
-          type: string
-          description: ''
-        email:
-          type: string
-          description: ''
-        company:
-          type: string
-          description: ''
         address1:
           type: string
           description: ''
@@ -2563,10 +2550,7 @@ components:
         city:
           type: string
           description: ''
-        stateOrProvince:
-          type: string
-          description: Represents state or province.
-        stateOrProvinceCode:
+        company:
           type: string
           description: ''
         country:
@@ -2575,18 +2559,32 @@ components:
         countryCode:
           type: string
           description: 'ISO 3166-1 alpha-2 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
-        postalCode:
+        customFields:
+          type: array
+          items:
+            $ref: '#/components/schemas/customFields'
+        email:
+          type: string
+          description: ''
+        firstName:
+          type: string
+          description: ''
+        lastName:
+          type: string
+          description: ''
+        stateOrProvince:
+          type: string
+          description: Represents state or province.
+        stateOrProvinceCode:
           type: string
           description: ''
         phone:
           pattern: '^\+?[1-9]\d{1,14}(x\d{1-5})?$'
           type: string
           description: ''
-        customFields:
-          type: array
-          items:
-            $ref: '#/components/schemas/customFields'
-      x-internal: false
+        postalCode:
+          type: string
+          description: ''
     customFields:
       title: customFields
       type: object
@@ -2613,23 +2611,46 @@ components:
       title: consignment_Full
       type: object
       properties:
-        id:
-          type: string
-          description: ''
-        shippingAddress:
-          type: object
-          properties: {}
-          deprecated: true
-          description: Use the `address` field instead.
         address:
           $ref: '#/components/schemas/address_Full'
-        selectedPickupOption:
-          $ref: '#/components/schemas/PickupOption'
         availableShippingOptions:
           type: array
           description: 'This is available only when "include=consignments.availableShippingOptions" is present in the URL.'
           items:
             $ref: '#/components/schemas/consignmentAvailableShippingOptions'
+        couponDiscounts:
+          type: array
+          description: List of consignment discounts applied through coupons.
+          items:
+            title: Consignment Coupon Discount
+            type: object
+            properties:
+              amount:
+                type: number
+                description: ''
+                format: double
+              code:
+                type: string
+                description: Coupon code that applied this discount.
+        discounts:
+          type: array
+          description: List of consignment discounts applied through cart level discounts.
+          items:
+            title: Consignment Discount
+            type: object
+            properties:
+              id:
+                type: string
+                description: Discount rule ID that applied this discount.
+        handlingCost:
+          type: number
+          description: The handling cost of shipping for this consignment.
+          format: double
+        id:
+          type: string
+          description: ''
+        selectedPickupOption:
+          $ref: '#/components/schemas/PickupOption'
         selectedShippingOption:
           title: Selected Shipping Option
           type: object
@@ -2658,37 +2679,14 @@ components:
               type: string
               description: Read only. Field used for Shipping Provider API.
               readOnly: true
-        couponDiscounts:
-          type: array
-          description: List of consignment discounts applied through coupons.
-          items:
-            title: Consignment Coupon Discount
-            type: object
-            properties:
-              code:
-                type: string
-                description: Coupon code that applied this discount.
-              amount:
-                type: number
-                description: ''
-                format: double
-        discounts:
-          type: array
-          description: List of consignment discounts applied through cart level discounts.
-          items:
-            title: Consignment Discount
-            type: object
-            properties:
-              id:
-                type: string
-                description: Discount rule ID that applied this discount.
+        shippingAddress:
+          type: object
+          properties: {}
+          deprecated: true
+          description: Use the `address` field instead.
         shippingCost:
           type: number
           description: The shipping cost for this consignment.
-          format: double
-        handlingCost:
-          type: number
-          description: The handling cost of shipping for this consignment.
           format: double
         lineItemIds:
           type: array
@@ -2696,7 +2694,6 @@ components:
           items:
             type: string
       description: This allows us to have multiple shipping addresses. Where there is only one shipping address, this array will contain only one value, with all the items.
-      x-internal: false
     consignmentAvailableShippingOptions:
       title: consignmentAvailableShippingOptions
       allOf:
@@ -3042,55 +3039,48 @@ components:
       title: checkoutCart
       type: object
       properties:
-        id:
-          type: string
-          description: Cart ID, provided after creating a cart with a POST.
-          format: uuid
-        customerId:
-          type: integer
-          description: ID of the customer to which the cart belongs.
-          format: int32
-        email:
-          type: string
-          description: The cartʼs email. This is the same email that is used in the billing address.
-        currency:
-          title: Currency
-          type: object
-          properties:
-            name:
-              type: string
-              description: The currency name.
-            code:
-              type: string
-              description: 'ISO-4217 currency code. (See: https://www.iso.org/iso-4217-currency-codes.html.)'
-            symbol:
-              type: string
-              description: The currency symbol.
-            decimalPlaces:
-              type: number
-              description: The number of decimal places for the currency. For example, the USD currency has two decimal places.
-              format: double
-          description: The currency in which prices are displayed; the store default currency.
-        isTaxIncluded:
-          type: boolean
-          description: Boolean representing whether tax information is included.
         baseAmount:
           type: number
           description: Cost of cart’s contents, before applying discounts.
-          format: double
-        discountAmount:
-          type: number
-          description: Order-based discounted amount only - Excludes coupon discounts and product-based discounts.
           format: double
         cartAmount:
           type: number
           description: Sum of line-items amounts, minus cart-level discounts and coupons. This amount includes taxes, where applicable.
           format: double
+        createdTime:
+          type: string
+          description: Time when the cart was created.
         coupons:
           type: array
           description: ''
           items:
             $ref: '#/components/schemas/CartCoupon'
+        currency:
+          title: Currency
+          type: object
+          properties:
+            code:
+              type: string
+              description: 'ISO-4217 currency code. (See: https://www.iso.org/iso-4217-currency-codes.html.)'
+            decimalPlaces:
+              type: number
+              description: The number of decimal places for the currency. For example, the USD currency has two decimal places.
+              format: double
+            name:
+              type: string
+              description: The currency name.
+            symbol:
+              type: string
+              description: The currency symbol.
+          description: The currency in which prices are displayed; the store default currency.
+        customerId:
+          type: integer
+          description: ID of the customer to which the cart belongs.
+          format: int32
+        discountAmount:
+          type: number
+          description: Order-based discounted amount only - Excludes coupon discounts and product-based discounts.
+          format: double
         discounts:
           type: array
           description: ''
@@ -3105,6 +3095,16 @@ components:
                 type: number
                 description: The discounted amount applied within a given context.
                 format: double
+        email:
+          type: string
+          description: The cartʼs email. This is the same email that is used in the billing address.
+        id:
+          type: string
+          description: Cart ID, provided after creating a cart with a POST.
+          format: uuid
+        isTaxIncluded:
+          type: boolean
+          description: Boolean representing whether tax information is included.
         lineItems:
           type: object
           description: ''
@@ -3113,11 +3113,30 @@ components:
             - digitalItems
             - physicalItems
           properties:
-            physicalItems:
-              type: array
-              description: ''
-              items:
-                $ref: '#/components/schemas/lineItemPhysicalDigital'
+            customItems:
+                type: array
+                items:
+                  title: Item Custom
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: ID of the custom item.
+                    listPrice:
+                      type: string
+                      description: Price of the item. With or without tax depending on your store setup.
+                    name:
+                      type: string
+                      description: Item name.
+                    quantity:
+                      type: string
+                    sku:
+                      type: string
+                      description: Custom item SKU.
+                  description: |-
+                    Add a custom item to the shoppers cart.
+                    * Custom items are not added to the catalog.
+                    * The price should be set to match the store settings for taxes.
             digitalItems:
               type: array
               description: ''
@@ -3135,32 +3154,19 @@ components:
                   - theme
                 type: object
                 properties:
-                  id:
-                    type: string
-                    description: Gift certificate identifier
-                  name:
-                    type: string
-                    description: 'The name of the purchased gift certificate; for example, `$20 Gift Certificate`.'
-                  theme:
-                    type: string
-                    description: 'Currently supports `Birthday`, `Boy`, `Celebration`, `Christmas`, `General`, and `Girl`.'
                   amount:
                     type: number
                     description: 'Value must be between $1.00 and $1,000.00.'
                     format: double
-                  taxable:
-                    type: boolean
-                    description: ''
-                  sender:
-                    title: Contact Entity
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                        description: ''
-                      email:
-                        type: string
-                        description: ''
+                  id:
+                    type: string
+                    description: Gift certificate identifier
+                  message:
+                    type: string
+                    description: Limited to 200 characters.
+                  name:
+                    type: string
+                    description: 'The name of the purchased gift certificate; for example, `$20 Gift Certificate`.'
                   recipient:
                     title: Contact Entity
                     type: object
@@ -3171,46 +3177,37 @@ components:
                       email:
                         type: string
                         description: ''
-                  message:
+                  sender:
+                    title: Contact Entity
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: ''
+                      email:
+                        type: string
+                        description: ''
+                  taxable:
+                    type: boolean
+                    description: ''
+                  theme:
                     type: string
-                    description: Limited to 200 characters.
+                    description: 'Currently supports `Birthday`, `Boy`, `Celebration`, `Christmas`, `General`, and `Girl`.'
                   type:
                     type: string
                     description: Explicitly specifying the gift certificate type.
-            customItems:
-                type: array
-                items:
-                  title: Item Custom
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                      description: ID of the custom item.
-                    sku:
-                      type: string
-                      description: Custom item SKU.
-                    name:
-                      type: string
-                      description: Item name.
-                    quantity:
-                      type: string
-                    listPrice:
-                      type: string
-                      description: Price of the item. With or without tax depending on your store setup.
-                  description: |-
-                    Add a custom item to the shoppers cart.
-                    * Custom items are not added to the catalog.
-                    * The price should be set to match the store settings for taxes.
-        createdTime:
-          type: string
-          description: Time when the cart was created.
-        updatedTime:
-          type: string
-          description: Time when the cart was last updated.
+            physicalItems:
+              type: array
+              description: ''
+              items:
+                $ref: '#/components/schemas/lineItemPhysicalDigital'
         locale:
           type: string
           description: Shopper's locale.
           example: "en"
+        updatedTime:
+          type: string
+          description: Time when the cart was last updated.
         version:
           type: integer 
           description: Cart version.
@@ -3221,41 +3218,20 @@ components:
       required:
         - quantity
       properties:
-        id:
-          type: string
-          description: The line-item ID.
+        addedByPromotion:
+          type: boolean
+          description: If the item was added automatically by a promotion, such as a coupon or buy one, get one.
         categoryNames: 
           type: array
           items: 
             type: string
-        parentId:
-          type: string
-          description: The product is part of a bundle such as a product pick list, then the parentId or the main product ID will populate.
-        variantId:
-          type: integer
-          description: ID of the variant.
-        productId:
-          type: integer
-          description: ID of the product.
-        sku:
-          type: string
-          description: SKU of the variant.
-        name:
-          type: string
-          description: The itemʼs product name.
-        url:
-          type: string
-          description: The product URL.
-        quantity:
+        comparisonPrice:
           type: number
-          description: Quantity of this item.
+          description: The itemʼs comparison price
+        couponAmount:
+          type: number
+          description: The total value of all coupons applied to this item.
           format: double
-        isTaxable:
-          type: boolean
-          description: Whether the item is taxable.
-        imageUrl:
-          type: string
-          description: A publicly-accessible URL for an image of this item.
         discounts:
           type: array
           description: A list of discounts applied to this item, as an array of AppliedDiscount objects.
@@ -3274,21 +3250,9 @@ components:
           type: number
           description: The total value of all discounts applied to this item (excluding coupon).
           format: double
-        couponAmount:
+        extendedComparisonPrice:
           type: number
-          description: The total value of all coupons applied to this item.
-          format: double
-        listPrice:
-          type: number
-          description: The item’s list price, as quoted by the manufacturer or distributor.
-          format: double
-        originalPrice:
-          type: number
-          description: The item’s original price is the same as the product’s default price.
-        salePrice:
-          type: number
-          description: The itemʼs price after all discounts are applied. The final price before tax calculation.
-          format: double
+          description: The itemʼs comparison price multiplied by the quantity.
         extendedListPrice:
           type: number
           description: The itemʼs list price multiplied by the quantity.
@@ -3297,12 +3261,42 @@ components:
           type: number
           description: The itemʼs sale price multiplied by the quantity.
           format: double
-        comparisonPrice:
+        giftWrapping:
+          title: Gift Wrapping
+          type: object
+          properties:
+            name:
+              type: string
+              description: ''
+            message:
+              type: string
+              description: ''
+            amount:
+              type: number
+              description: ''
+              format: double
+        id:
+          type: string
+          description: The line-item ID.
+        imageUrl:
+          type: string
+          description: A publicly-accessible URL for an image of this item.
+        isMutable:
+          type: boolean
+          description: ''
+        isShippingRequired:
+          type: boolean
+          description: Whether this item requires shipping to a physical address.
+        isTaxable:
+          type: boolean
+          description: Whether the item is taxable.
+        listPrice:
           type: number
-          description: The itemʼs comparison price
-        extendedComparisonPrice:
-          type: number
-          description: The itemʼs comparison price multiplied by the quantity.
+          description: The item’s list price, as quoted by the manufacturer or distributor.
+          format: double
+        name:
+          type: string
+          description: The itemʼs product name.
         options: 
           type: array
           items: 
@@ -3320,32 +3314,35 @@ components:
               valueId:
                 type: string
                 description: Option value ID.
+        originalPrice:
+          type: number
+          description: The item’s original price is the same as the product’s default price.
+        parentId:
+          type: string
+          description: The product is part of a bundle such as a product pick list, then the parentId or the main product ID will populate.
+        productId:
+          type: integer
+          description: ID of the product.
+        sku:
+          type: string
+          description: SKU of the variant.
+        quantity:
+          type: number
+          description: Quantity of this item.
+          format: double
+        salePrice:
+          type: number
+          description: The itemʼs price after all discounts are applied. The final price before tax calculation.
+          format: double
         type:
           type: string
           description: the product type - physical or digital
-        addedByPromotion:
-          type: boolean
-          description: If the item was added automatically by a promotion, such as a coupon or buy one, get one.
-        isShippingRequired:
-          type: boolean
-          description: Whether this item requires shipping to a physical address.
-        isMutable:
-          type: boolean
-          description: ''
-        giftWrapping:
-          title: Gift Wrapping
-          type: object
-          properties:
-            name:
-              type: string
-              description: ''
-            message:
-              type: string
-              description: ''
-            amount:
-              type: number
-              description: ''
-              format: double
+        url:
+          type: string
+          description: The product URL.
+        variantId:
+          type: integer
+          description: ID of the variant.
     checkoutGiftCertificates:
       title: checkoutGiftCertificates
       description: Applied gift certificate (as a payment method).
@@ -3374,6 +3371,10 @@ components:
       title: consignmentShippingOption_Base
       type: object
       properties:
+        cost:
+          type: number
+          description: ''
+          format: double
         description:
           type: string
           description: Read only.
@@ -3381,20 +3382,15 @@ components:
         id:
           type: string
           description: ''
-        type:
-          type: string
-          description: Specifies the type of shipping option; for example, flat rate, UPS, etc.
         imageUrl:
           type: string
           description: ''
-        cost:
-          type: number
-          description: ''
-          format: double
         transitTime:
           type: string
           description: An estimate of the arrival time.
-      x-internal: false
+        type:
+          type: string
+          description: Specifies the type of shipping option; for example, flat rate, UPS, etc.
     PickupOption:
       type: object
       title: Pickup Option

--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -3110,7 +3110,7 @@ components:
               type: string
               description: Time when the cart was last updated.
             version: 
-              type: string
+              type: integer
               description: Cart version.
           description: A cart contains a collection of items, prices, discounts, etc. It does not contain customer-related data.
         billingAddress:

--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -1035,7 +1035,17 @@ components:
           type: array
           items: 
             type: object 
-            properties: {}
+            properties: 
+              type: 
+                type: string 
+                enum: 
+                - promotion
+                - upsell
+                - eligible 
+                - applied
+              text: 
+                type: string
+                description: Text displayed on the storefront for the promotion.
         shippingCostBeforeDiscount:
           type: number
           description: The shipping cost before discounts are applied.

--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -1136,12 +1136,57 @@ components:
           format: double
     Customer: 
       type: object
+      description: Customer details.
       properties:
         addresses: 
           type: array
           items:
             type: object
-            properties: {}
+            properties:
+              id: 
+                type: integer
+                description: ''
+              firstName: 
+                type: string 
+                description: ''
+              lastName:
+                type: string
+                description: ''
+              company:
+                type: string
+                description: ''
+              address1:
+                type: string
+                description: ''
+              address2:
+                type: string
+                description: ''
+              city:
+                type: string
+                description: ''
+              stateOrProvince:
+                type: string
+                description: State or province.
+              stateOrProvinceCode:
+                type: string
+                description: ''
+              countryCode:
+                type: string
+                description: '[ISO 3166-1 alpha-2 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) for the country.'
+              postalCode:
+                type: string
+                description: ''
+              phone:
+                pattern: '^\+?[1-9]\d{1,14}(x\d{1-5})?$'
+                type: string
+                description: ''
+              type:
+                type: string
+                description: 'Address type.'
+              customFields:
+                type: array
+                items:
+                  $ref: '#/components/schemas/customFields'              
         customerGroup: 
           type: object
           properties:

--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -186,7 +186,7 @@ paths:
                 fees: []
                 payments: [{}]
                 promotions: []
-                orderId: null
+                orderId: "1234"
                 shippingCostTotal: 8
                 shippingCostBeforeDiscount: 8
                 shouldExecuteSpamCheck: false
@@ -356,7 +356,7 @@ paths:
                       postalCode: '96720'
                       phone: '8081234567'
                       customFields: []
-                orderId: null
+                orderId: "1234"
                 shippingCostTotal: 8
                 shippingCostBeforeDiscount: 8
                 handlingCostTotal: 0
@@ -4350,7 +4350,7 @@ components:
                   postalCode: '96720'
                   phone: '8081234567'
                   customFields: []
-            orderId: null
+            orderId: "1234"
             shippingCostTotal: 8
             shippingCostBeforeDiscount: 8
             handlingCostTotal: 0

--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -2631,735 +2631,853 @@ components:
       title: checkouts_Resp
       type: object
       properties:
-        data:
-          title: Checkout
+        id:
+          type: string
+          description: ''
+          format: uuid
+        cart:
+          title: Cart
           type: object
           properties:
             id:
               type: string
-              description: ''
+              description: Cart ID, provided after creating a cart with a POST.
               format: uuid
-            cart:
-              title: Cart
+            customerId:
+              type: integer
+              description: ID of the customer to which the cart belongs.
+              format: int32
+            email:
+              type: string
+              description: The cartʼs email. This is the same email that is used in the billing address
+            currency:
+              title: Currency
               type: object
               properties:
-                id:
+                name:
                   type: string
-                  description: Cart ID, provided after creating a cart with a POST.
-                  format: uuid
-                customer_id:
-                  type: integer
-                  description: ID of the customer to which the cart belongs.
-                  format: int32
-                email:
+                  description: The currency name.
+                code:
                   type: string
-                  description: The cartʼs email. This is the same email that is used in the billing address
-                currency:
-                  title: Currency
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                      description: The currency name.
-                    code:
-                      type: string
-                      description: 'ISO-4217 currency code. (See: https://www.iso.org/iso-4217-currency-codes.html.)'
-                    symbol:
-                      type: string
-                      description: The currency symbol.
-                    decimalPlaces:
-                      type: number
-                      description: The number of decimal places for the currency. For example, the USD currency has two decimal places.
-                      format: double
-                  description: The currency in which prices are displayed (the store default currency).
-                istaxIncluded:
-                  type: boolean
-                  description: Boolean representing whether tax information is included.
-                baseAmount:
+                  description: 'ISO-4217 currency code. (See: https://www.iso.org/iso-4217-currency-codes.html.)'
+                symbol:
+                  type: string
+                  description: The currency symbol.
+                decimalPlaces:
                   type: number
-                  description: The cost of the cart’s contents, before applying discounts.
+                  description: The number of decimal places for the currency. For example, the USD currency has two decimal places.
                   format: double
-                discountAmount:
-                  type: number
-                  description: Order-based discounted amount only - Excludes coupon discounts and product-based discounts.
-                  format: double
-                cartAmount:
-                  type: number
-                  description: Sum of line-items amounts, minus cart-level discounts and coupons. This amount includes taxes, where applicable.
-                  format: double
-                coupons:
-                  type: array
-                  description: ''
-                  items:
-                    title: Applied Coupon
-                    required:
-                      - code
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        description: The coupon ID.
-                      code:
-                        type: string
-                        description: the coupon code
-                      displayName:
-                        type: string
-                        description: The coupon title based on different types provided in control panel section.
-                      couponType:
-                        type: string
-                        description: Key name to identify the type of coupon.
-                      discountedAmount:
-                        type: number
-                        description: The discounted amount applied within a given context.
-                        format: double
-                discounts:
-                  type: array
-                  description: ''
-                  items:
-                    title: Applied Discount
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                        description: The name provided by the merchant.
-                      discountedAmount:
-                        type: number
-                        description: The discounted amount applied within a given context.
-                        format: double
-                lineItems:
-                  type: object
-                  description: ''
-                  title: Line Items
-                  required:
-                    - digitalItems
-                    - physicalItems
-                  properties:
-                      physicalItems:
-                        type: array
-                        description: ''
-                        items:
-                          title: Item Physical
-                          required:
-                            - quantity
-                          type: object
-                          properties:
-                            id:
-                              type: string
-                              description: The line-item ID.
-                            parentId:
-                              type: string
-                              description: The product is part of a bundle, such as a product pick list, then the parentId or the main product ID will populate.
-                            variantId:
-                              type: integer
-                              description: ID of the variant.
-                            productId:
-                              type: integer
-                              description: ID of the product.
-                            sku:
-                              type: string
-                              description: SKU of the variant.
-                            name:
-                              type: string
-                              description: The itemʼs product name.
-                            url:
-                              type: string
-                              description: The product URL.
-                            quantity:
-                              type: number
-                              description: Quantity of this item.
-                              format: double
-                            isTaxable:
-                              type: boolean
-                              description: Whether the item is taxable.
-                            imageUrl:
-                              type: string
-                              description: A publicly-accessible URL for an image of this item.
-                            discounts:
-                              type: array
-                              description: A list of discounts applied to this item, as an array of AppliedDiscount objects.
-                              items:
-                                title: Applied Discount
-                                type: object
-                                properties:
-                                  name:
-                                    type: string
-                                    description: The name provided by the merchant.
-                                  discountedAmount:
-                                    type: number
-                                    description: The discounted amount applied within a given context.
-                                    format: double
-                            discountAmount:
-                              type: number
-                              description: The total value of all discounts applied to this item (excluding coupon).
-                              format: double
-                            brand:
-                              type: string
-                              description: The product's brand.
-                            couponAmount:
-                              type: number
-                              description: The total value of all coupons applied to this item.
-                              format: double
-                            originalPrice:
-                              type: number
-                              description: The item’s original price is the same as the product’s default price.
-                            listPrice:
-                              type: number
-                              description: The item’s list price, as quoted by the manufacturer or distributor.
-                              format: double
-                            salePrice:
-                              type: number
-                              description: The itemʼs price after all discounts are applied. (The final price before tax calculation.)
-                              format: double
-                            extendedListPrice:
-                              type: number
-                              description: The itemʼs list price multiplied by the quantity.
-                              format: double
-                            extendedSalePrice:
-                              type: number
-                              description: The itemʼs sale price multiplied by the quantity.
-                              format: double
-                            type:
-                              type: string
-                              description: the product type - physical or digital
-                            addedByPromotion:
-                              type: boolean
-                              description: If the item was added automatically by a promotion, such as a coupon or buy one, get one.
-                            isShippingRequired:
-                              type: boolean
-                              description: Whether this item requires shipping to a physical address.
-                            isMutable:
-                              type: boolean
-                              description: ''
-                            giftWrapping:
-                              title: Gift Wrapping
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  description: ''
-                                message:
-                                  type: string
-                                  description: ''
-                                amount:
-                                  type: number
-                                  description: ''
-                                  format: double
-                      digitalItems:
-                        type: array
-                        description: ''
-                        items:
-                          title: Item Digital
-                          required:
-                            - quantity
-                          type: object
-                          properties:
-                            id:
-                              type: string
-                              description: The line-item ID.
-                            parentId:
-                              type: string
-                              description: Bundled items will have their parentʼs item ID.
-                            variantId:
-                              type: number
-                              description: ID of the variant.
-                              format: double
-                            productId:
-                              type: number
-                              description: ID of the product.
-                              format: double
-                            sku:
-                              type: string
-                              description: SKU of the variant.
-                            name:
-                              type: string
-                              description: The itemʼs product name.
-                            url:
-                              type: string
-                              description: The product URL.
-                            quantity:
-                              type: number
-                              description: Quantity of this item.
-                              format: double
-                            brand:
-                              type: string
-                              description: The itemʼs brand.
-                            isTaxable:
-                              type: boolean
-                              description: Whether the item is taxable.
-                            imageUrl:
-                              type: string
-                              description: A publicly-accessible URL for an image of this item.
-                            discounts:
-                              type: array
-                              description: List of discounts applied to this item, as an array of AppliedDiscount objects.
-                              items:
-                                title: Applied Discount
-                                type: object
-                                properties:
-                                  name:
-                                    type: string
-                                    description: The name provided by the merchant.
-                                  discountedAmount:
-                                    type: number
-                                    description: The discounted amount applied within a given context.
-                                    format: double
-                            discountAmount:
-                              type: number
-                              description: The total value of all discounts applied to this item (excluding coupon).
-                              format: double
-                            couponAmount:
-                              type: number
-                              description: The total value of all coupons applied to this item.
-                              format: double
-                            originalPrice:
-                              type: number
-                              description: The item’s original price is the same as the product’s default price.
-                            listPrice:
-                              type: number
-                              description: The item’s list price, as quoted by the manufacturer or distributor.
-                              format: double
-                            salePrice:
-                              type: number
-                              description: The itemʼs price after all discounts are applied. (The final price before tax calculation.)
-                              format: double
-                            extendedListPrice:
-                              type: number
-                              description: The itemʼs list price multiplied by the quantity.
-                              format: double
-                            extendedSalePrice:
-                              type: number
-                              description: The itemʼs sale price multiplied by the quantity.
-                              format: double
-                            type:
-                              type: string
-                              description: the product type - physical or digital
-                            isMutable:
-                              type: boolean
-                              description: ''
-                            isShippingRequired:
-                              type: boolean
-                              description: Whether this item requires shipping to a physical address.
-                            downloadFileUrls:
-                              type: array
-                              description: URLs to download all product files.
-                              items:
-                                type: string
-                            downloadPageUrl:
-                              type: string
-                              description: The URL for the combined downloads page.
-                            downloadSize:
-                              type: string
-                              description: 'Specifies the combined download size in human-readable style; for example, `30MB`.'
-                      giftCertificate:
-                        type: array
-                        description: ''
-                        items:
-                          title: Item Gift Certificate
-                          required:
-                            - amount
-                            - recipient
-                            - sender
-                            - theme
-                          type: object
-                          properties:
-                            id:
-                              type: string
-                              description: Gift certificate identifier
-                            name:
-                              type: string
-                              description: 'The name of the purchased gift certificate; for example, `$20 Gift Certificate`.'
-                            theme:
-                              type: string
-                              description: 'Currently supports `Birthday`, `Boy`, `Celebration`, `Christmas`, `General`, and `Girl`.'
-                            amount:
-                              type: number
-                              description: 'Value must be between $1.00 and $1,000.00.'
-                              format: double
-                            taxable:
-                              type: boolean
-                              description: ''
-                            sender:
-                              title: Contact Entity
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  description: ''
-                                email:
-                                  type: string
-                                  description: ''
-                            recipient:
-                              title: Contact Entity
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  description: ''
-                                email:
-                                  type: string
-                                  description: ''
-                            message:
-                              type: string
-                              description: Limited to 200 characters.
-                            type:
-                              type: string
-                              description: Explicitly specifying the gift certificate type.
-                      customItems:
-                        type: array
-                        items:
-                          title: Item Custom
-                          type: object
-                          properties:
-                            id:
-                              type: string
-                              description: ID of the custom item
-                            sku:
-                              type: string
-                              description: Custom item SKU
-                            name:
-                              type: string
-                              description: Item name
-                            quantity:
-                              type: string
-                            listPrice:
-                              type: string
-                              description: Price of the item. With or without tax depending on your store setup.
-                          description: |-
-                            Add a custom item to the shoppers cart.
-                            * Custom items are not added to the catalog.
-                            * The price should be set to match the store settings for taxes.
-                createdTime:
-                  type: string
-                  description: Time when the cart was created.
-                updatedTime:
-                  type: string
-                  description: Time when the cart was last updated.
-              description: A cart contains a collection of items, prices, discounts, etc. It does not contain customer-related data.
-            billingAddress:
-              title: Address Response
-              allOf:
-                - title: Address Properties
-                  required:
-                    - countryCode
-                  type: object
-                  properties:
-                    firstName:
-                      type: string
-                      description: ''
-                    lastName:
-                      type: string
-                      description: ''
-                    email:
-                      type: string
-                      description: ''
-                    company:
-                      type: string
-                      description: ''
-                    address1:
-                      type: string
-                      description: ''
-                    address2:
-                      type: string
-                      description: ''
-                    city:
-                      type: string
-                      description: ''
-                    stateOrProvince:
-                      type: string
-                      description: Represents state or province.
-                    stateOrProvinceCode:
-                      type: string
-                      description: ''
-                    countryCode:
-                      type: string
-                      description: 'ISO 3166-1 alpha-2 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
-                    postalCode:
-                      type: string
-                      description: ''
-                    phone:
-                      pattern: '^\+?[1-9]\d{1,14}(x\d{1-5})?$'
-                      type: string
-                      description: ''
-                    customFields:
-                      type: array
-                      description: ''
-                      items:
-                        title: CustomField
-                        type: object
-                        properties:
-                          fieldId:
-                            type: string
-                            description: ''
-                          fieldValue:
-                            type: string
-                            description: This can also be an array for fields that need to support list of values; for example, a set of checkboxes.
-                - type: object
-                  properties:
-                    id:
-                      type: string
-                      description: ''
-            consignments:
+              description: The currency in which prices are displayed (the store default currency).
+            isTaxIncluded:
+              type: boolean
+              description: Boolean representing whether tax information is included.
+            baseAmount:
+              type: number
+              description: The cost of the cart’s contents, before applying discounts.
+              format: double
+            discountAmount:
+              type: number
+              description: Order-based discounted amount only - Excludes coupon discounts and product-based discounts.
+              format: double
+            cartAmount:
+              type: number
+              description: Sum of line-items amounts, minus cart-level discounts and coupons. This amount includes taxes, where applicable.
+              format: double
+            coupons:
               type: array
-              description: This allows you to have multiple shipping addresses per checkout. Where there is only one shipping address, this array will contain only one value, with all the items.
+              description: ''
               items:
-                title: Consignment
+                title: Applied Coupon
+                required:
+                  - code
                 type: object
                 properties:
                   id:
                     type: string
+                    description: The coupon ID.
+                  code:
+                    type: string
+                    description: the coupon code
+                  displayName:
+                    type: string
+                    description: The coupon title based on different types provided in control panel section.
+                  couponType:
+                    type: string
+                    description: Key name to identify the type of coupon.
+                  discountedAmount:
+                    type: number
+                    description: The discounted amount applied within a given context.
+                    format: double
+            discounts:
+              type: array
+              description: ''
+              items:
+                title: Applied Discount
+                type: object
+                properties:
+                  id:
+                    type: integer
+                    description: Discount ID.
+                  discountedAmount:
+                    type: number
+                    description: The discounted amount applied within a given context.
+                    format: double
+            lineItems:
+              type: object
+              description: ''
+              title: Line Items
+              required:
+                - digitalItems
+                - physicalItems
+              properties:
+                  physicalItems:
+                    type: array
                     description: ''
-                  shippingAddress:
-                    type: object
-                    properties: {}
-                    x-deprecated: true
-                  address:
-                    title: Address Response
-                    allOf:
-                      - title: Address Properties
-                        required:
-                          - countryCode
-                        type: object
-                        properties:
-                          firstName:
-                            type: string
-                            description: ''
-                          lastName:
-                            type: string
-                            description: ''
-                          email:
-                            type: string
-                            description: ''
-                          company:
-                            type: string
-                            description: ''
-                          address1:
-                            type: string
-                            description: ''
-                          address2:
-                            type: string
-                            description: ''
-                          city:
-                            type: string
-                            description: ''
-                          stateOrProvince:
-                            type: string
-                            description: Represents state or province.
-                          stateOrProvinceCode:
-                            type: string
-                            description: ''
-                          countryCode:
-                            type: string
-                            description: 'ISO 3166-1 alpha-2 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
-                          postalCode:
-                            type: string
-                            description: ''
-                          phone:
-                            pattern: '^\+?[1-9]\d{1,14}(x\d{1-5})?$'
-                            type: string
-                            description: ''
-                          customFields:
-                            type: array
-                            description: ''
-                            items:
-                              title: CustomField
-                              type: object
-                              properties:
-                                fieldId:
-                                  type: string
-                                  description: ''
-                                fieldValue:
-                                  type: string
-                                  description: This can also be an array for fields that need to support list of values; for example, a set of checkboxes.
-                      - type: object
-                        properties:
-                          id:
-                            type: string
-                            description: ''
-                  availableShippingOptions:
-                    type: array
-                    description: This is available only when "include=consignments.availableShippingOptions" is presented in the URL.
                     items:
-                      title: Shipping Option Entity
-                      allOf:
-                        - title: Selected Shipping Option
-                          type: object
-                          properties:
-                            description:
-                              type: string
-                              description: Read only.
-                              readOnly: true
-                            id:
-                              type: string
-                              description: ''
-                            type:
-                              type: string
-                              description: 'Specified the type of shipping option. Flat rate, UPS, etc.,'
-                            imageUrl:
-                              type: string
-                              description: ''
-                            cost:
-                              type: number
-                              description: ''
-                              format: double
-                            transitTime:
-                              type: string
-                              description: An estimate of the arrival time.
-                        - type: object
-                          properties:
-                            isRecommended:
-                              type: boolean
-                              description: Is this shipping method the recommended shipping option or not.
-                  selectedShippingOption:
-                    title: Selected Shipping Option
-                    type: object
-                    properties:
-                      description:
-                        type: string
-                        description: Read only.
-                        readOnly: true
-                      id:
-                        type: string
-                        description: ''
-                      type:
-                        type: string
-                        description: Specifies the type of shipping option; for example, flat rate, UPS, etc.
-                      imageUrl:
-                        type: string
-                        description: ''
-                      cost:
-                        type: number
-                        description: ''
-                        format: double
-                      transitTime:
-                        type: string
-                        description: An estimate of the arrival time.
-                  couponDiscounts:
-                    type: array
-                    description: List of consignment discounts applied through coupons
-                    items:
-                      title: Consignment Coupon Discount
-                      type: object
-                      properties:
-                        code:
-                          type: string
-                          description: Coupon code that applied this discount
-                        amount:
-                          type: number
-                          description: ''
-                          format: double
-                  discounts:
-                    type: array
-                    description: List of consignment discounts applied through cart level discounts.
-                    items:
-                      title: Consignment Discount
+                      title: Item Physical
+                      required:
+                        - quantity
                       type: object
                       properties:
                         id:
                           type: string
-                          description: Discount rule ID that applied this discount
-                  shippingCost:
-                    type: number
-                    description: The shipping cost for this consignment.
-                    format: double
-                  handlingCost:
-                    type: number
-                    description: The handling cost of shipping for this consignment.
-                    format: double
-                  lineItemIds:
+                          description: The line-item ID.
+                        categoryNames: 
+                          type: array
+                          items: 
+                            type: string
+                        comparisonPrice:
+                          type: number
+                        extendedComparisonPrice: 
+                          type: number
+                        options: 
+                          type: array
+                          items: 
+                            type: object
+                            properties:
+                              name: 
+                                type: string
+                                description: Option name.
+                              nameId:
+                                type: integer
+                                description: Option ID.
+                              value: 
+                                type: string
+                                description: Option value.
+                              valueId:
+                                type: string
+                                description: Option value ID.
+                        parentId:
+                          type: string
+                          description: The product is part of a bundle, such as a product pick list, then the parentId or the main product ID will populate.
+                        variantId:
+                          type: integer
+                          description: ID of the variant.
+                        productId:
+                          type: integer
+                          description: ID of the product.
+                        sku:
+                          type: string
+                          description: SKU of the variant.
+                        name:
+                          type: string
+                          description: The itemʼs product name.
+                        url:
+                          type: string
+                          description: The product URL.
+                        quantity:
+                          type: number
+                          description: Quantity of this item.
+                          format: double
+                        isTaxable:
+                          type: boolean
+                          description: Whether the item is taxable.
+                        imageUrl:
+                          type: string
+                          description: A publicly-accessible URL for an image of this item.
+                        discounts:
+                          type: array
+                          description: A list of discounts applied to this item, as an array of AppliedDiscount objects.
+                          items:
+                            title: Applied Discount
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+                                description: Discount ID.
+                              discountedAmount:
+                                type: number
+                                description: The discounted amount applied within a given context.
+                                format: double
+                        discountAmount:
+                          type: number
+                          description: The total value of all discounts applied to this item (excluding coupon).
+                          format: double
+                        brand:
+                          type: string
+                          description: The product's brand.
+                        couponAmount:
+                          type: number
+                          description: The total value of all coupons applied to this item.
+                          format: double
+                        originalPrice:
+                          type: number
+                          description: The item’s original price is the same as the product’s default price.
+                        listPrice:
+                          type: number
+                          description: The item’s list price, as quoted by the manufacturer or distributor.
+                          format: double
+                        salePrice:
+                          type: number
+                          description: The itemʼs price after all discounts are applied. (The final price before tax calculation.)
+                          format: double
+                        extendedListPrice:
+                          type: number
+                          description: The itemʼs list price multiplied by the quantity.
+                          format: double
+                        extendedSalePrice:
+                          type: number
+                          description: The itemʼs sale price multiplied by the quantity.
+                          format: double
+                        type:
+                          type: string
+                          description: the product type - physical or digital
+                        addedByPromotion:
+                          type: boolean
+                          description: If the item was added automatically by a promotion, such as a coupon or buy one, get one.
+                        isShippingRequired:
+                          type: boolean
+                          description: Whether this item requires shipping to a physical address.
+                        isMutable:
+                          type: boolean
+                          description: ''
+                        giftWrapping:
+                          title: Gift Wrapping
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: ''
+                            message:
+                              type: string
+                              description: ''
+                            amount:
+                              type: number
+                              description: ''
+                              format: double
+                  digitalItems:
                     type: array
                     description: ''
                     items:
-                      type: string
-                description: ''
-            coupons:
-              type: array
-              description: Coupons applied at checkout level.
-              items:
-                $ref: '#/components/schemas/CheckoutCoupon'
-            orderId:
-              type: string
-              description: ''
-            shippingCostTotal:
-              type: number
-              description: Shipping cost before any discounts are applied.
-              format: float
-            giftWrappingCostTotal:
-              type: number
-              description: Gift wrapping for all items, including or excluding tax.
-            handlingCostTotal:
-              type: number
-              description: Handling cost for all consignments including or excluding tax.
-              format: float
-            taxTotal:
-              type: number
-              description: ''
-              format: float
-            taxes:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    description: Name of the tax charged. This is either the system default or the custom name created for the tax.
-                    example: Texas Taxes
-                  amount:
-                    type: number
-                    description: Amount of the tax.
-                    format: float
-                    example: 1.12
-            subtotal:
-              type: number
-              description: Subtotal of the checkout before applying item-level discounts. Tax inclusive based on the store settings.
-              format: float
-            grandTotal:
-              type: number
-              description: The total payable amount, before applying any store credit or gift certificate.
-              format: float
-            giftCertificates:
-              type: array
-              description: Applied gift certificate (as a payment method).
-              items:
-                title: Gift Certificate
-                type: object
-                properties:
-                  balance:
-                    type: number
+                      title: Item Digital
+                      required:
+                        - quantity
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          description: The line-item ID.
+                        categoryNames: 
+                          type: array
+                          items: 
+                            type: string
+                        comparisonPrice:
+                          type: number
+                        extendedComparisonPrice: 
+                          type: number
+                        options: 
+                          type: array
+                          items: 
+                            type: object
+                            properties:
+                              name: 
+                                type: string
+                                description: Option name.
+                              nameId:
+                                type: integer
+                                description: Option ID.
+                              value: 
+                                type: string
+                                description: Option value.
+                              valueId:
+                                type: string
+                                description: Option value ID.
+                        parentId:
+                          type: string
+                          description: Bundled items will have their parentʼs item ID.
+                        variantId:
+                          type: number
+                          description: ID of the variant.
+                          format: double
+                        productId:
+                          type: number
+                          description: ID of the product.
+                          format: double
+                        sku:
+                          type: string
+                          description: SKU of the variant.
+                        name:
+                          type: string
+                          description: The itemʼs product name.
+                        url:
+                          type: string
+                          description: The product URL.
+                        quantity:
+                          type: number
+                          description: Quantity of this item.
+                          format: double
+                        brand:
+                          type: string
+                          description: The itemʼs brand.
+                        isTaxable:
+                          type: boolean
+                          description: Whether the item is taxable.
+                        imageUrl:
+                          type: string
+                          description: A publicly-accessible URL for an image of this item.
+                        discounts:
+                          type: array
+                          description: List of discounts applied to this item, as an array of AppliedDiscount objects.
+                          items:
+                            title: Applied Discount
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                                description: Discount ID.
+                              discountedAmount:
+                                type: number
+                                description: The discounted amount applied within a given context.
+                                format: double
+                        discountAmount:
+                          type: number
+                          description: The total value of all discounts applied to this item (excluding coupon).
+                          format: double
+                        couponAmount:
+                          type: number
+                          description: The total value of all coupons applied to this item.
+                          format: double
+                        originalPrice:
+                          type: number
+                          description: The item’s original price is the same as the product’s default price.
+                        listPrice:
+                          type: number
+                          description: The item’s list price, as quoted by the manufacturer or distributor.
+                          format: double
+                        salePrice:
+                          type: number
+                          description: The itemʼs price after all discounts are applied. (The final price before tax calculation.)
+                          format: double
+                        extendedListPrice:
+                          type: number
+                          description: The itemʼs list price multiplied by the quantity.
+                          format: double
+                        extendedSalePrice:
+                          type: number
+                          description: The itemʼs sale price multiplied by the quantity.
+                          format: double
+                        type:
+                          type: string
+                          description: the product type - physical or digital
+                        isMutable:
+                          type: boolean
+                          description: ''
+                        isShippingRequired:
+                          type: boolean
+                          description: Whether this item requires shipping to a physical address.
+                  giftCertificates:
+                    type: array
                     description: ''
-                    format: double
-                  code:
-                    type: string
-                    description: ''
-                  purchaseDate:
-                    type: string
-                    description: ''
-                    format: date
-                  remaining:
-                    type: number
-                    description: ''
-                    format: double
-                  used:
-                    type: number
-                    description: ''
-                    format: double
-                description: The values presented here are projections of how much we would be using out of an existing gift certificate.
+                    items:
+                      title: Item Gift Certificate
+                      required:
+                        - amount
+                        - recipient
+                        - sender
+                        - theme
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          description: Gift certificate identifier
+                        name:
+                          type: string
+                          description: 'The name of the purchased gift certificate; for example, `$20 Gift Certificate`.'
+                        theme:
+                          type: string
+                          description: 'Currently supports `Birthday`, `Boy`, `Celebration`, `Christmas`, `General`, and `Girl`.'
+                        amount:
+                          type: number
+                          description: 'Value must be between $1.00 and $1,000.00.'
+                          format: double
+                        taxable:
+                          type: boolean
+                          description: ''
+                        sender:
+                          title: Contact Entity
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: ''
+                            email:
+                              type: string
+                              description: ''
+                        recipient:
+                          title: Contact Entity
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: ''
+                            email:
+                              type: string
+                              description: ''
+                        message:
+                          type: string
+                          description: Limited to 200 characters.
+                        type:
+                          type: string
+                          description: Explicitly specifying the gift certificate type.
+                  customItems:
+                    type: array
+                    items:
+                      title: Item Custom
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          description: ID of the custom item
+                        sku:
+                          type: string
+                          description: Custom item SKU
+                        name:
+                          type: string
+                          description: Item name
+                        quantity:
+                          type: string
+                        listPrice:
+                          type: string
+                          description: Price of the item. With or without tax depending on your store setup.
+                      description: |-
+                        Add a custom item to the shoppers cart.
+                        * Custom items are not added to the catalog.
+                        * The price should be set to match the store settings for taxes.
             createdTime:
               type: string
               description: Time when the cart was created.
+            locale: 
+              type: string
+              description: Shopper's locale.
             updatedTime:
               type: string
               description: Time when the cart was last updated.
-            customerMessage:
+            version: 
               type: string
-              description: Shopperʼs message provided as details for the order to be created from this cart.
-            outstandingBalance:
-              type: number
-              description: |
-                `grandTotal` subtract the store-credit amount
-            isStoreCreditApplied:
+              description: Cart version.
+          description: A cart contains a collection of items, prices, discounts, etc. It does not contain customer-related data.
+        billingAddress:
+          title: Address Response
+          allOf:
+            - title: Address Properties
+              required:
+                - countryCode
+              type: object
+              properties:
+                firstName:
+                  type: string
+                  description: ''
+                lastName:
+                  type: string
+                  description: ''
+                email:
+                  type: string
+                  description: ''
+                company:
+                  type: string
+                  description: ''
+                address1:
+                  type: string
+                  description: ''
+                address2:
+                  type: string
+                  description: ''
+                city:
+                  type: string
+                  description: ''
+                stateOrProvince:
+                  type: string
+                  description: Represents state or province.
+                stateOrProvinceCode:
+                  type: string
+                  description: ''
+                country: 
+                  type: string
+                  description: Country name.
+                countryCode:
+                  type: string
+                  description: 'ISO 3166-1 alpha-2 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
+                postalCode:
+                  type: string
+                  description: ''
+                phone:
+                  pattern: '^\+?[1-9]\d{1,14}(x\d{1-5})?$'
+                  type: string
+                  description: ''
+                customFields:
+                  type: array
+                  description: ''
+                  items:
+                    title: CustomField
+                    type: object
+                    properties:
+                      fieldId:
+                        type: string
+                        description: ''
+                      fieldValue:
+                        type: string
+                        description: This can also be an array for fields that need to support list of values; for example, a set of checkboxes.
+            - type: object
+              properties:
+                id:
+                  type: string
+                  description: ''
+        channelId:
+          type: integer
+          description: Channel ID.
+        consignments:
+          type: array
+          description: This allows you to have multiple shipping addresses per checkout. Where there is only one shipping address, this array will contain only one value, with all the items.
+          items:
+            title: Consignment
+            type: object
+            properties:
+              id:
+                type: string
+                description: ''
+              shippingAddress:
+                type: object
+                properties: {}
+                description: Deprecated - Use `address` instead.
+                deprecated: true
+              address:
+                title: Address Response
+                allOf:
+                  - title: Address Properties
+                    required:
+                      - countryCode
+                    type: object
+                    properties:
+                      firstName:
+                        type: string
+                        description: ''
+                      lastName:
+                        type: string
+                        description: ''
+                      email:
+                        type: string
+                        description: ''
+                      company:
+                        type: string
+                        description: ''
+                      address1:
+                        type: string
+                        description: ''
+                      address2:
+                        type: string
+                        description: ''
+                      city:
+                        type: string
+                        description: ''
+                      stateOrProvince:
+                        type: string
+                        description: Represents state or province.
+                      stateOrProvinceCode:
+                        type: string
+                        description: ''
+                      country: 
+                        type: string 
+                        description: Country name.
+                      countryCode:
+                        type: string
+                        description: 'ISO 3166-1 alpha-2 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
+                      postalCode:
+                        type: string
+                        description: ''
+                      phone:
+                        pattern: '^\+?[1-9]\d{1,14}(x\d{1-5})?$'
+                        type: string
+                        description: ''
+                      customFields:
+                        type: array
+                        description: ''
+                        items:
+                          title: CustomField
+                          type: object
+                          properties:
+                            fieldId:
+                              type: string
+                              description: ''
+                            fieldValue:
+                              type: string
+                              description: This can also be an array for fields that need to support list of values; for example, a set of checkboxes.
+                  - type: object
+                    properties:
+                      id:
+                        type: string
+                        description: ''
+              availableShippingOptions:
+                type: array
+                description: This is available only when "include=consignments.availableShippingOptions" is presented in the URL.
+                items:
+                  title: Shipping Option Entity
+                  allOf:
+                    - title: Selected Shipping Option
+                      type: object
+                      properties:
+                        additionalDescription: 
+                          type: string
+                        description:
+                          type: string
+                          description: Read only.
+                          readOnly: true
+                        id:
+                          type: string
+                          description: ''
+                        type:
+                          type: string
+                          description: 'Specified the type of shipping option. Flat rate, UPS, etc.,'
+                        imageUrl:
+                          type: string
+                          description: ''
+                        cost:
+                          type: number
+                          description: ''
+                          format: double
+                        transitTime:
+                          type: string
+                          description: An estimate of the arrival time.
+                    - type: object
+                      properties:
+                        isRecommended:
+                          type: boolean
+                          description: Is this shipping method the recommended shipping option or not.
+              selectedShippingOption:
+                title: Selected Shipping Option
+                type: object
+                properties:
+                  additionalDescription: 
+                    type: string
+                  description:
+                    type: string
+                    description: Read only.
+                    readOnly: true
+                  id:
+                    type: string
+                    description: ''
+                  type:
+                    type: string
+                    description: Specifies the type of shipping option; for example, flat rate, UPS, etc.
+                  imageUrl:
+                    type: string
+                    description: ''
+                  cost:
+                    type: number
+                    description: ''
+                    format: double
+                  transitTime:
+                    type: string
+                    description: An estimate of the arrival time.
+              couponDiscounts:
+                type: array
+                description: List of consignment discounts applied through coupons
+                items:
+                  title: Consignment Coupon Discount
+                  type: object
+                  properties:
+                    code:
+                      type: string
+                      description: Coupon code that applied this discount
+                    amount:
+                      type: number
+                      description: ''
+                      format: double
+              discounts:
+                type: array
+                description: List of consignment discounts applied through cart level discounts.
+                items:
+                  title: Consignment Discount
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: Discount rule ID that applied this discount
+              shippingCost:
+                type: number
+                description: The shipping cost for this consignment.
+                format: double
+              handlingCost:
+                type: number
+                description: The handling cost of shipping for this consignment.
+                format: double
+              lineItemIds:
+                type: array
+                description: ''
+                items:
+                  type: string
+            description: ''
+        coupons:
+          type: array
+          description: Coupons applied at checkout level.
+          items:
+            $ref: '#/components/schemas/CheckoutCoupon'
+        customer: 
+          type: object
+          properties:
+            addresses: 
+              type: array
+              items:
+                type: object
+                properties: {}
+            customerGroup: 
+              type: object
+              properties:
+                id: 
+                  type: integer
+                  description: ID of the customer group.
+                name: 
+                  type: string
+                  description: Name of the customer group.
+            email: 
+              type: string
+              description: Customer email.
+            firstName:
+              type: string
+              description: Customer's first name.
+            fullName:
+              type: string
+              description: Customer's full name.
+            id:
+              type: integer
+              description: Customer ID.
+            isGuest: 
+              type: boolean 
+              description: Whether the shopper is a guest or a logged-in customer. 
+            lastName:
+              type: string
+              description: Customer's last name.
+            shouldEncourageSignIn:
               type: boolean
-              description: |
-                `true` value indicates StoreCredit has been applied.
+            storeCredit: 
+              type: number
+              description: The amount of store credit a customer has.
+        orderId:
+          type: string
+          description: ''
+        payments: 
+          type: array
+          items:
+            type: object
+            properties: {}
+        promotions: 
+          type: array
+          items: 
+            type: object 
+            properties: {}
+        shippingCostBeforeDiscount:
+          type: number
+          description: The shipping cost before discounts are applied.
+        shippingCostTotal:
+          type: number
+          description: Shipping cost before any discounts are applied.
+          format: float
+        shouldExecuteSpamCheck: 
+          type: boolean
+        giftWrappingCostTotal:
+          type: number
+          description: Gift wrapping for all items, including or excluding tax.
+        handlingCostTotal:
+          type: number
+          description: Handling cost for all consignments including or excluding tax.
+          format: float
+        taxTotal:
+          type: number
+          description: ''
+          format: float
+        taxes:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: Name of the tax charged. This is either the system default or the custom name created for the tax.
+                example: Texas Taxes
+              amount:
+                type: number
+                description: Amount of the tax.
+                format: float
+                example: 1.12
+        subtotal:
+          type: number
+          description: Subtotal of the checkout before applying item-level discounts. Tax inclusive based on the store settings.
+          format: float
+        fees: 
+          type: array
+          items:
+            type: object
+            properties: {}
+        grandTotal:
+          type: number
+          description: The total payable amount, before applying any store credit or gift certificate.
+          format: float
+        giftCertificates:
+          type: array
+          description: Applied gift certificate (as a payment method).
+          items:
+            title: Gift Certificate
+            type: object
+            properties:
+              balance:
+                type: number
+                description: ''
+                format: double
+              code:
+                type: string
+                description: ''
+              purchaseDate:
+                type: string
+                description: ''
+                format: date
+              remaining:
+                type: number
+                description: ''
+                format: double
+              used:
+                type: number
+                description: ''
+                format: double
+            description: The values presented here are projections of how much we would be using out of an existing gift certificate.
+        createdTime:
+          type: string
+          description: Time when the cart was created.
+        updatedTime:
+          type: string
+          description: Time when the cart was last updated.
+        customerMessage:
+          type: string
+          description: Shopperʼs message provided as details for the order to be created from this cart.
+        outstandingBalance:
+          type: number
+          description: |
+            `grandTotal` subtract the store-credit amount
+        isStoreCreditApplied:
+          type: boolean
+          description: |
+            `true` value indicates StoreCredit has been applied.
+        version:
+          type: integer
+          description: The current version of the checkout.
       x-internal: false
     cartLineItemPut:
       title: cartLineItemPut

--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -56,153 +56,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/checkout_Full'
-              example:
-                id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                channelId: 1
-                cart:
-                  id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                  customerId: 18
-                  email: dwaynecole@testing.com
-                  currency:
-                    name: US Dollars
-                    code: USD
-                    symbol: $
-                    decimalPlaces: 2
-                  isTaxIncluded: true
-                  baseAmount: 7.95
-                  discountAmount: 0
-                  cartAmount: 7.95
-                  coupons: []
-                  discounts:
-                    - id: 1
-                      discountedAmount: 0
-                  lineItems:
-                    physicalItems:
-                      - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                        categoryNames: ["Essentials", "Just arrived"]
-                        parentId: ''
-                        variantId: 345
-                        productId: 174
-                        sku: ''
-                        name: 1L Le Parfait Jar
-                        url: 'https://{store_domain}/all/1l-le-parfait-jar/'
-                        quantity: 1
-                        brand: OFS
-                        isTaxable: true
-                        imageUrl: 'https://cdn11.bigcommerce.com/s-{store_hash}/products/174/images/425/leparfaitmedium3_1024x1024_1024x1024__37756__81924.1534344526.330.500.jpg?c=2'
-                        discounts: []
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 7.95
-                        listPrice: 7.95
-                        salePrice: 7.95
-                        comparisonPrice: 0
-                        extendedComparisonPrice: 0
-                        extendedListPrice: 7.95
-                        extendedSalePrice: 7.95
-                        isShippingRequired: true
-                        options: 
-                        - name: "Color"
-                          nameId: 1
-                          value: "Red" 
-                          valueId: "2"
-                        giftWrapping: {}
-                        addedByPromotion: false
-                    digitalItems: []
-                    giftCertificates: []
-                    customItems: []
-                  createdTime: '2019-01-10T17:18:00+00:00'
-                  updatedTime: '2019-01-10T17:19:47+00:00'
-                  locale: "en"
-                  version: 1
-                billingAddress:
-                  id: 5c377ead301c2
-                  firstName: Dwayne
-                  lastName: Cole
-                  email: dwaynecole@testing.com
-                  company: ''
-                  address1: Mauna Kea Access Rd
-                  address2: ''
-                  city: Hilo
-                  stateOrProvince: Hawaii
-                  stateOrProvinceCode: HI
-                  country: United States
-                  countryCode: US
-                  postalCode: '96720'
-                  phone: '8081234567'
-                  customFields: []
-                consignments:
-                  - id: 5c377ead30ac1
-                    shippingCost: 8
-                    handlingCost: 0
-                    couponDiscounts: []
-                    discounts: []
-                    lineItemIds:
-                      - 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                    availableShippingOptions:
-                      - id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
-                        type: shipping_byweight
-                        description: Ship by Weight
-                        additionalDescription: Fragile items
-                        imageUrl: ''
-                        cost: 8
-                        transitTime: ''
-                    selectedShippingOption:
-                      id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
-                      type: shipping_byweight
-                      description: Ship by Weight
-                      additionalDescription: Fragile items
-                      imageUrl: ''
-                      cost: 8
-                      transitTime: ''
-                    address:
-                      firstName: Dwayne
-                      lastName: Cole
-                      email: dwaynecole@testing.com
-                      company: ''
-                      address1: Mauna Kea Access Rd
-                      address2: ''
-                      city: Hilo
-                      stateOrProvince: Hawaii
-                      stateOrProvinceCode: HI
-                      country: United States
-                      countryCode: US
-                      postalCode: '96720'
-                      phone: '8081234567'
-                      customFields: []
-                customer:
-                  addresses: []
-                  customerGroup:
-                    id: 1
-                    name: "Wholesale Customers"
-                  email: ""
-                  firstName: "" 
-                  fullName: "" 
-                  id: 0 
-                  isGuest: true 
-                  lastName: "" 
-                  shouldEncourageSignIn: false 
-                  storeCredit: 0
-                fees: []
-                payments: [{}]
-                promotions: []
-                orderId: "1234"
-                shippingCostTotal: 8
-                shippingCostBeforeDiscount: 8
-                shouldExecuteSpamCheck: false
-                handlingCostTotal: 0
-                taxTotal: 1.22
-                coupons: []
-                taxes:
-                  - name: Tax
-                    amount: 1.22
-                subtotal: 7.95
-                grandTotal: 15.95
-                giftCertificates: []
-                createdTime: '2019-01-10T17:18:00+00:00'
-                updatedTime: '2019-01-10T17:19:47+00:00'
-                customerMessage: ''
-                version: 1
+              example: 
+                $ref: '#/components/examples/CheckoutResp'
         '400':
           description: When a problem arises, returns a generic response.
           content:
@@ -262,116 +117,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/checkout_Full'
-              example:
-                id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                cart:
-                  id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                  customerId: 18
-                  email: dwaynecole@testing.com
-                  currency:
-                    name: US Dollars
-                    code: USD
-                    symbol: $
-                    decimalPlaces: 2
-                  isTaxIncluded: true
-                  baseAmount: 7.95
-                  discountAmount: 0
-                  cartAmount: 7.95
-                  coupons: []
-                  discounts:
-                    - id: 1
-                      discountedAmount: 0
-                  lineItems:
-                    physicalItems:
-                      - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                        parentId: ''
-                        variantId: 345
-                        productId: 174
-                        sku: ''
-                        name: 1L Le Parfait Jar
-                        url: 'https://{store_domain}/all/1l-le-parfait-jar/'
-                        quantity: 1
-                        brand: OFS
-                        isTaxable: true
-                        imageUrl: 'https://cdn11.bigcommerce.com/s-{store_hash}/products/174/images/425/leparfaitmedium3_1024x1024_1024x1024__37756__81924.1534344526.330.500.jpg?c=2'
-                        discounts: []
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 7.95
-                        listPrice: 7.95
-                        salePrice: 7.95
-                        extendedListPrice: 7.95
-                        extendedSalePrice: 7.95
-                        isShippingRequired: true
-                        giftWrapping: {}
-                        addedByPromotion: false
-                    digitalItems: []
-                    giftCertificates: []
-                    customItems: []
-                  createdTime: '2019-01-10T17:18:00+00:00'
-                  updatedTime: '2019-01-10T17:19:47+00:00'
-                billingAddress:
-                  id: 5c377ead301c2
-                  firstName: Dwayne
-                  lastName: Cole
-                  email: dwaynecole@testing.com
-                  company: ''
-                  address1: Mauna Kea Access Rd
-                  address2: ''
-                  city: Hilo
-                  stateOrProvince: Hawaii
-                  stateOrProvinceCode: HI
-                  country: United States
-                  countryCode: US
-                  postalCode: '96720'
-                  phone: '8081234567'
-                  customFields: []
-                consignments:
-                  - id: 5c377ead30ac1
-                    shippingCost: 8
-                    handlingCost: 0
-                    couponDiscounts: []
-                    discounts: []
-                    lineItemIds:
-                      - 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                    selectedShippingOption:
-                      id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
-                      type: shipping_byweight
-                      description: Ship by Weight
-                      imageUrl: ''
-                      cost: 8
-                      transitTime: ''
-                    address:
-                      firstName: Dwayne
-                      lastName: Cole
-                      email: dwaynecole@testing.com
-                      company: ''
-                      address1: Mauna Kea Access Rd
-                      address2: ''
-                      city: Hilo
-                      stateOrProvince: Hawaii
-                      stateOrProvinceCode: HI
-                      country: United States
-                      countryCode: US
-                      postalCode: '96720'
-                      phone: '8081234567'
-                      customFields: []
-                orderId: "1234"
-                shippingCostTotal: 8
-                shippingCostBeforeDiscount: 8
-                handlingCostTotal: 0
-                taxTotal: 1.22
-                coupons: []
-                taxes:
-                  - name: Tax
-                    amount: 1.22
-                subtotal: 7.95
-                grandTotal: 15.95
-                giftCertificates: []
-                createdTime: '2019-01-10T17:18:00+00:00'
-                updatedTime: '2019-01-10T17:19:47+00:00'
-                customerMessage: ''
-                version: 1
+              example: 
+                $ref: '#/components/examples/CheckoutResp'
         '409':
           $ref: '#/components/responses/CartConflictErrorResponse'
       x-codegen-request-body-name: body
@@ -412,115 +159,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/checkout_Full'
               example:
-                id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                cart:
-                  id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                  customerId: 18
-                  email: dwaynecole@testing.com
-                  currency:
-                    name: US Dollars
-                    code: USD
-                    symbol: $
-                    decimalPlaces: 2
-                  isTaxIncluded: true
-                  baseAmount: 7.95
-                  discountAmount: 0
-                  cartAmount: 7.95
-                  coupons: []
-                  discounts:
-                    - id: 1
-                      discountedAmount: 0
-                  lineItems:
-                    physicalItems:
-                      - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                        parentId: ''
-                        variantId: 345
-                        productId: 174
-                        sku: ''
-                        name: 1L Le Parfait Jar
-                        url: 'https://{store_domain}/all/1l-le-parfait-jar/'
-                        quantity: 1
-                        brand: OFS
-                        isTaxable: true
-                        imageUrl: 'https://cdn11.bigcommerce.com/s-{store_hash}/products/174/images/425/leparfaitmedium3_1024x1024_1024x1024__37756__81924.1534344526.330.500.jpg?c=2'
-                        discounts: []
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 7.95
-                        listPrice: 7.95
-                        salePrice: 7.95
-                        extendedListPrice: 7.95
-                        extendedSalePrice: 7.95
-                        isShippingRequired: true
-                        giftWrapping: {}
-                        addedByPromotion: false
-                    digitalItems: []
-                    giftCertificates: []
-                    customItems: []
-                  createdTime: '2019-01-10T17:18:00+00:00'
-                  updatedTime: '2019-01-10T17:19:47+00:00'
-                billingAddress:
-                  id: 5c377ead301c2
-                  firstName: Dwayne
-                  lastName: Cole
-                  email: dwaynecole@testing.com
-                  company: ''
-                  address1: Mauna Kea Access Rd
-                  address2: ''
-                  city: Hilo
-                  stateOrProvince: Hawaii
-                  stateOrProvinceCode: HI
-                  country: United States
-                  countryCode: US
-                  postalCode: '96720'
-                  phone: '8081234567'
-                  customFields: []
-                consignments:
-                  - id: 5c377ead30ac1
-                    shippingCost: 8
-                    handlingCost: 0
-                    couponDiscounts: []
-                    discounts: []
-                    lineItemIds:
-                      - 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                    selectedShippingOption:
-                      id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
-                      type: shipping_byweight
-                      description: Ship by Weight
-                      imageUrl: ''
-                      cost: 8
-                      transitTime: ''
-                    address:
-                      firstName: Dwayne
-                      lastName: Cole
-                      email: dwaynecole@testing.com
-                      company: ''
-                      address1: Mauna Kea Access Rd
-                      address2: ''
-                      city: Hilo
-                      stateOrProvince: Hawaii
-                      stateOrProvinceCode: HI
-                      country: United States
-                      countryCode: US
-                      postalCode: '96720'
-                      phone: '8081234567'
-                      customFields: []
-                orderId: null
-                shippingCostTotal: 8
-                shippingCostBeforeDiscount: 8
-                handlingCostTotal: 0
-                taxTotal: 1.22
-                coupons: []
-                taxes:
-                  - name: Tax
-                    amount: 1.22
-                subtotal: 7.95
-                grandTotal: 15.95
-                giftCertificates: []
-                createdTime: '2019-01-10T17:18:00+00:00'
-                updatedTime: '2019-01-10T17:19:47+00:00'
-                customerMessage: ''
-                version: 1
+                $ref: '#/components/examples/CheckoutResp'
       x-codegen-request-body-name: body
     delete:
       tags:
@@ -542,220 +181,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/checkout_Full'
               example:
-                id: b6fbd994-61a8-4f25-9167-6ec10489c448
-                cart:
-                  id: b6fbd994-61a8-4f25-9167-6ec10489c448
-                  customerId: 11
-                  email: janedoe@example.com
-                  currency:
-                    name: US Dollars
-                    code: USD
-                    symbol: $
-                    decimalPlaces: 2
-                  isTaxIncluded: false
-                  baseAmount: 119.93
-                  discountAmount: 0
-                  cartAmount: 112.93
-                  coupons:
-                    - id: 1
-                      code: S2549JM0Y
-                      displayName: $5.00 off the order total
-                      couponType: per_total_discount
-                      discountedAmount: 5
-                  discounts:
-                    - id: 1
-                      discountedAmount: 2.59
-                    - id: 2
-                      discountedAmount: 1.06
-                    - id: 3
-                      discountedAmount: 2.12
-                    - id: 4
-                      discountedAmount: 0.8
-                    - id: 5
-                      discountedAmount: 0.43
-                  lineItems:
-                    physicalItems:
-                      - id: 69791a88-85c9-4c19-8042-e537621e8a55
-                        parentId: ''
-                        variantId: 364
-                        productId: 184
-                        sku: SMA-RED
-                        name: Canvas Laundry Cart
-                        url: 'https://{store_domain}/all/canvas-laundry-cart/'
-                        quantity: 1
-                        isTaxable: true
-                        imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/184/images/445/naturalcanvascart2_1024x1024__92347__29648.1534344533.330.500.jpg?c=2'
-                        discounts:
-                          - id: 1
-                            discountedAmount: 0.59
-                          - id: 2
-                            discountedAmount: 2
-                        discountAmount: 2
-                        couponAmount: 0
-                        originalPrice: 17.99
-                        listPrice: 15.99
-                        salePrice: 13.99
-                        extendedListPrice: 15.99
-                        extendedSalePrice: 13.99
-                        isShippingRequired: true
-                        giftWrapping: {}
-                        addedByPromotion: false
-                      - id: ba2c619d-e6b4-48c2-8809-d88e424ed450
-                        parentId: ''
-                        variantId: 341
-                        productId: 170
-                        sku: ''
-                        name: Ceramic Measuring Spoons
-                        url: 'https://{store_domain}/all/ceramic-measuring-spoons/'
-                        quantity: 1
-                        isTaxable: true
-                        imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/170/images/411/measuringsquares2_1024x1024__07108__95421.1534344522.330.500.jpg?c=2'
-                        discounts:
-                          - id: 1
-                            discountedAmount: 1.06
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 25
-                        listPrice: 25
-                        salePrice: 25
-                        extendedListPrice: 25
-                        extendedSalePrice: 25
-                        isShippingRequired: true
-                        giftWrapping: {}
-                        addedByPromotion: false
-                      - id: c72d6651-978d-45e5-881b-c2bb5f7ff1d5
-                        parentId: ''
-                        variantId: 376
-                        productId: 158
-                        sku: SKU-A0C8A203
-                        name: Chambray Towel
-                        url: 'https://{store_domain}/all/chambray-towel/'
-                        quantity: 1
-                        isTaxable: true
-                        imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/158/images/382/foglinenbeigestripetowel1b_1024x1024__83011__60806.1534344511.330.500.jpg?c=2'
-                        discounts:
-                          - id: 1
-                            discountedAmount: 2.12
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 49.99
-                        listPrice: 49.99
-                        salePrice: 49.99
-                        extendedListPrice: 49.99
-                        extendedSalePrice: 49.99
-                        isShippingRequired: true
-                        giftWrapping: {}
-                        addedByPromotion: false
-                    digitalItems:
-                      - id: 6477a4a1-02cf-4287-8bf2-fd043bdd5234
-                        parentId: ''
-                        variantId: 360
-                        productId: 189
-                        name: Gather Journal Issue 7 - Digital
-                        url: 'https://{store_domain}/all/gather-journal-issue-7/'
-                        quantity: 1
-                        isTaxable: true
-                        imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/189/images/465/gather_1024x1024__17195__82620.1534344540.330.500.jpg?c=2'
-                        discounts:
-                          - id: 1
-                            discountedAmount: 0.8
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 18.95
-                        listPrice: 18.95
-                        salePrice: 18.95
-                        extendedListPrice: 18.95
-                        extendedSalePrice: 18.95
-                        isShippingRequired: false
-                        type: digital
-                    giftCertificates:
-                      - id: 871f1f56-4c88-43c3-a6e5-0a647d83d6ac
-                        name: $10.00 Gift Certificate
-                        theme: Celebration
-                        amount: 10
-                        taxable: false
-                        sender:
-                          name: Jane Doe
-                          email: janedoe@example.com
-                        recipient:
-                          name: John Doe
-                          email: johndoe@example.com
-                        message: Thank you!
-                        type: giftCertificate
-                  createdTime: '2018-09-18T15:48:26+00:00'
-                  updatedTime: '2018-09-18T16:59:45+00:00'
-                billingAddress:
-                  id: 5ba11e4a10fb5
-                  firstName: Jane
-                  lastName: Doe
-                  email: janedoe@example.com
-                  company: ''
-                  address1: 123 Main Street
-                  address2: ''
-                  city: Austin
-                  stateOrProvince: Texas
-                  stateOrProvinceCode: TX
-                  country: United States
-                  countryCode: US
-                  postalCode: '78751'
-                  phone: '1234567890'
-                  customFields:
-                    - fieldId: field_25
-                      fieldValue: Leave in backyard
-                consignments:
-                  - id: 5ba121929619b
-                    shippingCost: 69.94
-                    handlingCost: 0
-                    couponDiscounts: []
-                    discounts: []
-                    lineItemIds:
-                      - 69791a88-85c9-4c19-8042-e537621e8a55
-                      - ba2c619d-e6b4-48c2-8809-d88e424ed450
-                      - c72d6651-978d-45e5-881b-c2bb5f7ff1d5
-                    selectedShippingOption:
-                      id: bb3c818f-17ce-46fe-9475-65933095da0d
-                      type: shipping_upsready
-                      description: UPS® (UPS Next Day Air®)
-                      imageUrl: ''
-                      cost: 69.94
-                      transitTime: 1 business day
-                    address:
-                      firstName: Jane
-                      lastName: Doe
-                      email: janedoe@example.com
-                      company: ''
-                      address1: 123 Main Street
-                      address2: ''
-                      city: Austin
-                      stateOrProvince: Texas
-                      stateOrProvinceCode: TX
-                      country: United States
-                      countryCode: US
-                      postalCode: '78751'
-                      phone: '1234567890'
-                      customFields:
-                        - fieldId: field_25
-                          fieldValue: Leave in backyard
-                orderId: null
-                shippingCostTotal: 69.94
-                shippingCostBeforeDiscount: 69.94
-                handlingCostTotal: 0
-                taxTotal: 28.62
-                coupons:
-                  - id: 1
-                    code: S2549JM0Y
-                    displayName: $5.00 off the order total
-                    couponType: 2
-                    discountedAmount: 5
-                taxes:
-                  - name: Store Tax
-                    amount: 28.62
-                subtotal: 117.93
-                grandTotal: 211.49
-                giftCertificates: []
-                createdTime: '2018-09-18T15:48:26+00:00'
-                updatedTime: '2018-09-18T16:59:45+00:00'
-                customerMessage: 'Thank you, BigCommerce'
+                $ref: '#/components/examples/CheckoutResp'
   '/checkouts/{checkoutId}/billing-address':
     parameters:
       - $ref: '#/components/parameters/CheckoutIdPath'
@@ -793,115 +219,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/checkout_Full'
               example:
-                id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                cart:
-                  id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                  customerId: 18
-                  email: dwaynecole@testing.com
-                  currency:
-                    name: US Dollars
-                    code: USD
-                    symbol: $
-                    decimalPlaces: 2
-                  isTaxIncluded: true
-                  baseAmount: 7.95
-                  discountAmount: 0
-                  cartAmount: 7.95
-                  coupons: []
-                  discounts:
-                    - id: 1
-                      discountedAmount: 0
-                  lineItems:
-                    physicalItems:
-                      - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                        parentId: ''
-                        variantId: 345
-                        productId: 174
-                        sku: ''
-                        name: 1L Le Parfait Jar
-                        url: 'https://{store_domain}/all/1l-le-parfait-jar/'
-                        quantity: 1
-                        brand: OFS
-                        isTaxable: true
-                        imageUrl: 'https://cdn11.bigcommerce.com/s-{store_hash}/products/174/images/425/leparfaitmedium3_1024x1024_1024x1024__37756__81924.1534344526.330.500.jpg?c=2'
-                        discounts: []
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 7.95
-                        listPrice: 7.95
-                        salePrice: 7.95
-                        extendedListPrice: 7.95
-                        extendedSalePrice: 7.95
-                        isShippingRequired: true
-                        giftWrapping: {}
-                        addedByPromotion: false
-                    digitalItems: []
-                    giftCertificates: []
-                    customItems: []
-                  createdTime: '2019-01-10T17:18:00+00:00'
-                  updatedTime: '2019-01-10T17:19:47+00:00'
-                billingAddress:
-                  id: 5c377ead301c2
-                  firstName: Dwayne
-                  lastName: Cole
-                  email: dwaynecole@testing.com
-                  company: ''
-                  address1: Mauna Kea Access Rd
-                  address2: ''
-                  city: Hilo
-                  stateOrProvince: Hawaii
-                  stateOrProvinceCode: HI
-                  country: United States
-                  countryCode: US
-                  postalCode: '96720'
-                  phone: '8081234567'
-                  customFields: []
-                consignments:
-                  - id: 5c377ead30ac1
-                    shippingCost: 8
-                    handlingCost: 0
-                    couponDiscounts: []
-                    discounts: []
-                    lineItemIds:
-                      - 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                    selectedShippingOption:
-                      id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
-                      type: shipping_byweight
-                      description: Ship by Weight
-                      imageUrl: ''
-                      cost: 8
-                      transitTime: ''
-                    address:
-                      firstName: Dwayne
-                      lastName: Cole
-                      email: dwaynecole@testing.com
-                      company: ''
-                      address1: Mauna Kea Access Rd
-                      address2: ''
-                      city: Hilo
-                      stateOrProvince: Hawaii
-                      stateOrProvinceCode: HI
-                      country: United States
-                      countryCode: US
-                      postalCode: '96720'
-                      phone: '8081234567'
-                      customFields: []
-                orderId: null
-                shippingCostTotal: 8
-                shippingCostBeforeDiscount: 8
-                handlingCostTotal: 0
-                taxTotal: 1.22
-                coupons: []
-                taxes:
-                  - name: Tax
-                    amount: 1.22
-                subtotal: 7.95
-                grandTotal: 15.95
-                giftCertificates: []
-                createdTime: '2019-01-10T17:18:00+00:00'
-                updatedTime: '2019-01-10T17:19:47+00:00'
-                customerMessage: ''
-                version: 1
+                $ref: '#/components/examples/CheckoutResp'
         '403':
           description: The email trying to be set for the guest is associated with an account. The customer must sign in.
           content: {}
@@ -942,220 +260,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/checkout_Full'
               example:
-                id: b6fbd994-61a8-4f25-9167-6ec10489c448
-                cart:
-                  id: b6fbd994-61a8-4f25-9167-6ec10489c448
-                  customerId: 11
-                  email: janedoe@example.com
-                  currency:
-                    name: US Dollars
-                    code: USD
-                    symbol: $
-                    decimalPlaces: 2
-                  isTaxIncluded: false
-                  baseAmount: 119.93
-                  discountAmount: 0
-                  cartAmount: 112.93
-                  coupons:
-                    - id: 1
-                      code: S2549JM0Y
-                      displayName: $5.00 off the order total
-                      couponType: per_total_discount
-                      discountedAmount: 5
-                  discounts:
-                    - id: 1
-                      discountedAmount: 2.59
-                    - id: 2
-                      discountedAmount: 1.06
-                    - id: 3
-                      discountedAmount: 2.12
-                    - id: 4
-                      discountedAmount: 0.8
-                    - id: 5
-                      discountedAmount: 0.43
-                  lineItems:
-                    physicalItems:
-                      - id: 69791a88-85c9-4c19-8042-e537621e8a55
-                        parentId: ''
-                        variantId: 364
-                        productId: 184
-                        sku: SMA-RED
-                        name: Canvas Laundry Cart
-                        url: 'https://{store_domain}/all/canvas-laundry-cart/'
-                        quantity: 1
-                        isTaxable: true
-                        imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/184/images/445/naturalcanvascart2_1024x1024__92347__29648.1534344533.330.500.jpg?c=2'
-                        discounts:
-                          - id: 1
-                            discountedAmount: 0.59
-                          - id: 2
-                            discountedAmount: 2
-                        discountAmount: 2
-                        couponAmount: 0
-                        originalPrice: 17.99
-                        listPrice: 15.99
-                        salePrice: 13.99
-                        extendedListPrice: 15.99
-                        extendedSalePrice: 13.99
-                        isShippingRequired: true
-                        giftWrapping: {}
-                        addedByPromotion: false
-                      - id: ba2c619d-e6b4-48c2-8809-d88e424ed450
-                        parentId: ''
-                        variantId: 341
-                        productId: 170
-                        sku: ''
-                        name: Ceramic Measuring Spoons
-                        url: 'https://{store_domain}/all/ceramic-measuring-spoons/'
-                        quantity: 1
-                        isTaxable: true
-                        imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/170/images/411/measuringsquares2_1024x1024__07108__95421.1534344522.330.500.jpg?c=2'
-                        discounts:
-                          - id: 1
-                            discountedAmount: 1.06
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 25
-                        listPrice: 25
-                        salePrice: 25
-                        extendedListPrice: 25
-                        extendedSalePrice: 25
-                        isShippingRequired: true
-                        giftWrapping: {}
-                        addedByPromotion: false
-                      - id: c72d6651-978d-45e5-881b-c2bb5f7ff1d5
-                        parentId: ''
-                        variantId: 376
-                        productId: 158
-                        sku: SKU-A0C8A203
-                        name: Chambray Towel
-                        url: 'https://{store_domain}/all/chambray-towel/'
-                        quantity: 1
-                        isTaxable: true
-                        imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/158/images/382/foglinenbeigestripetowel1b_1024x1024__83011__60806.1534344511.330.500.jpg?c=2'
-                        discounts:
-                          - id: 1
-                            discountedAmount: 2.12
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 49.99
-                        listPrice: 49.99
-                        salePrice: 49.99
-                        extendedListPrice: 49.99
-                        extendedSalePrice: 49.99
-                        isShippingRequired: true
-                        giftWrapping: {}
-                        addedByPromotion: false
-                    digitalItems:
-                      - id: 6477a4a1-02cf-4287-8bf2-fd043bdd5234
-                        parentId: ''
-                        variantId: 360
-                        productId: 189
-                        name: Gather Journal Issue 7 - Digital
-                        url: 'https://{store_domain}/all/gather-journal-issue-7/'
-                        quantity: 1
-                        isTaxable: true
-                        imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/189/images/465/gather_1024x1024__17195__82620.1534344540.330.500.jpg?c=2'
-                        discounts:
-                          - id: 1
-                            discountedAmount: 0.8
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 18.95
-                        listPrice: 18.95
-                        salePrice: 18.95
-                        extendedListPrice: 18.95
-                        extendedSalePrice: 18.95
-                        isShippingRequired: false
-                        type: digital
-                    giftCertificates:
-                      - id: 871f1f56-4c88-43c3-a6e5-0a647d83d6ac
-                        name: $10.00 Gift Certificate
-                        theme: Celebration
-                        amount: 10
-                        taxable: false
-                        sender:
-                          name: Jane Doe
-                          email: janedoe@example.com
-                        recipient:
-                          name: John Doe
-                          email: johndoe@example.com
-                        message: Thank you!
-                        type: giftCertificate
-                  createdTime: '2018-09-18T15:48:26+00:00'
-                  updatedTime: '2018-09-18T16:59:45+00:00'
-                billingAddress:
-                  id: 5ba11e4a10fb5
-                  firstName: Jane
-                  lastName: Doe
-                  email: janedoe@example.com
-                  company: ''
-                  address1: 123 Main Street
-                  address2: ''
-                  city: Austin
-                  stateOrProvince: Texas
-                  stateOrProvinceCode: TX
-                  country: United States
-                  countryCode: US
-                  postalCode: '78751'
-                  phone: '1234567890'
-                  customFields:
-                    - fieldId: field_25
-                      fieldValue: Leave in backyard
-                consignments:
-                  - id: 5ba121929619b
-                    shippingCost: 69.94
-                    handlingCost: 0
-                    couponDiscounts: []
-                    discounts: []
-                    lineItemIds:
-                      - 69791a88-85c9-4c19-8042-e537621e8a55
-                      - ba2c619d-e6b4-48c2-8809-d88e424ed450
-                      - c72d6651-978d-45e5-881b-c2bb5f7ff1d5
-                    selectedShippingOption:
-                      id: bb3c818f-17ce-46fe-9475-65933095da0d
-                      type: shipping_upsready
-                      description: UPS® (UPS Next Day Air®)
-                      imageUrl: ''
-                      cost: 69.94
-                      transitTime: 1 business day
-                    address:
-                      firstName: Jane
-                      lastName: Doe
-                      email: janedoe@example.com
-                      company: ''
-                      address1: 123 Main Street
-                      address2: ''
-                      city: Austin
-                      stateOrProvince: Texas
-                      stateOrProvinceCode: TX
-                      country: United States
-                      countryCode: US
-                      postalCode: '78751'
-                      phone: '1234567890'
-                      customFields:
-                        - fieldId: field_25
-                          fieldValue: Leave in backyard
-                orderId: null
-                shippingCostTotal: 69.94
-                shippingCostBeforeDiscount: 69.94
-                handlingCostTotal: 0
-                taxTotal: 28.62
-                coupons:
-                  - id: 1
-                    code: S2549JM0Y
-                    displayName: $5.00 off the order total
-                    couponType: 2
-                    discountedAmount: 5
-                taxes:
-                  - name: Store Tax
-                    amount: 28.62
-                subtotal: 117.93
-                grandTotal: 211.49
-                giftCertificates: []
-                createdTime: '2018-09-18T15:48:26+00:00'
-                updatedTime: '2018-09-18T16:59:45+00:00'
-                customerMessage: 'Thank you, BigCommerce'
+                $ref: '#/components/examples/CheckoutResp'
         '403':
           description: The email trying to be set for the guest is associated with an account. The customer must sign in.
           content: {}
@@ -1223,116 +328,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/checkout_Full'
               example:
-                id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                cart:
-                  id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                  customerId: 18
-                  email: dwaynecole@testing.com
-                  currency:
-                    name: US Dollars
-                    code: USD
-                    symbol: $
-                    decimalPlaces: 2
-                  isTaxIncluded: true
-                  baseAmount: 7.95
-                  discountAmount: 0
-                  cartAmount: 7.95
-                  coupons: []
-                  discounts:
-                    - id: 1
-                      discountedAmount: 0
-                  lineItems:
-                    physicalItems:
-                      - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                        parentId: ''
-                        variantId: 345
-                        productId: 174
-                        sku: ''
-                        name: 1L Le Parfait Jar
-                        url: 'https://{store_domain}/all/1l-le-parfait-jar/'
-                        quantity: 1
-                        brand: OFS
-                        isTaxable: true
-                        imageUrl: 'https://cdn11.bigcommerce.com/s-{store_hash}/products/174/images/425/leparfaitmedium3_1024x1024_1024x1024__37756__81924.1534344526.330.500.jpg?c=2'
-                        discounts: []
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 7.95
-                        listPrice: 7.95
-                        salePrice: 7.95
-                        extendedListPrice: 7.95
-                        extendedSalePrice: 7.95
-                        isShippingRequired: true
-                        giftWrapping: {}
-                        addedByPromotion: false
-                    digitalItems: []
-                    giftCertificates: []
-                    customItems: []
-                  createdTime: '2019-01-10T17:18:00+00:00'
-                  updatedTime: '2019-01-10T17:19:47+00:00'
-                billingAddress:
-                  id: 5c377ead301c2
-                  firstName: Dwayne
-                  lastName: Cole
-                  email: dwaynecole@testing.com
-                  company: ''
-                  address1: Mauna Kea Access Rd
-                  address2: ''
-                  city: Hilo
-                  stateOrProvince: Hawaii
-                  stateOrProvinceCode: HI
-                  country: United States
-                  countryCode: US
-                  postalCode: '96720'
-                  phone: '8081234567'
-                  customFields: []
-                consignments:
-                  - id: 5c377ead30ac1
-                    shippingCost: 8
-                    handlingCost: 0
-                    couponDiscounts: []
-                    discounts: []
-                    lineItemIds:
-                      - 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                    selectedShippingOption:
-                      id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
-                      type: shipping_byweight
-                      description: Ship by Weight
-                      imageUrl: ''
-                      cost: 8
-                      transitTime: ''
-                    address:
-                      firstName: Dwayne
-                      lastName: Cole
-                      email: dwaynecole@example.com
-                      company: ''
-                      address1: Mauna Kea Access Rd
-                      address2: ''
-                      city: Hilo
-                      stateOrProvince: Hawaii
-                      stateOrProvinceCode: HI
-                      country: United States
-                      countryCode: US
-                      postalCode: '96720'
-                      phone: '8081234567'
-                      customFields: []
-                      shouldSaveAddress: true
-                orderId: null
-                shippingCostTotal: 8
-                shippingCostBeforeDiscount: 8
-                handlingCostTotal: 0
-                taxTotal: 1.22
-                coupons: []
-                taxes:
-                  - name: Tax
-                    amount: 1.22
-                subtotal: 7.95
-                grandTotal: 15.95
-                giftCertificates: []
-                createdTime: '2019-01-10T17:18:00+00:00'
-                updatedTime: '2019-01-10T17:19:47+00:00'
-                customerMessage: ''
-                version: 1
+                $ref: '#/components/examples/CheckoutResp'
         '409':
           $ref: '#/components/responses/CartConflictErrorResponse'
   '/checkouts/{checkoutId}/consignments/{consignmentId}':
@@ -1391,116 +387,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/checkout_Full'
               example:
-                id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                cart:
-                  id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                  customerId: 18
-                  email: dwaynecole@testing.com
-                  currency:
-                    name: US Dollars
-                    code: USD
-                    symbol: $
-                    decimalPlaces: 2
-                  isTaxIncluded: true
-                  baseAmount: 7.95
-                  discountAmount: 0
-                  cartAmount: 7.95
-                  coupons: []
-                  discounts:
-                    - id: 1
-                      discountedAmount: 0
-                  lineItems:
-                    physicalItems:
-                      - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                        parentId: ''
-                        variantId: 345
-                        productId: 174
-                        sku: ''
-                        name: 1L Le Parfait Jar
-                        url: 'https://{store_domain}/all/1l-le-parfait-jar/'
-                        quantity: 1
-                        brand: OFS
-                        isTaxable: true
-                        imageUrl: 'https://cdn11.bigcommerce.com/s-{store_hash}/products/174/images/425/leparfaitmedium3_1024x1024_1024x1024__37756__81924.1534344526.330.500.jpg?c=2'
-                        discounts: []
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 7.95
-                        listPrice: 7.95
-                        salePrice: 7.95
-                        extendedListPrice: 7.95
-                        extendedSalePrice: 7.95
-                        isShippingRequired: true
-                        giftWrapping: {}
-                        addedByPromotion: false
-                    digitalItems: []
-                    giftCertificates: []
-                    customItems: []
-                  createdTime: '2019-01-10T17:18:00+00:00'
-                  updatedTime: '2019-01-10T17:19:47+00:00'
-                billingAddress:
-                  id: 5c377ead301c2
-                  firstName: Dwayne
-                  lastName: Cole
-                  email: dwaynecole@testing.com
-                  company: ''
-                  address1: Mauna Kea Access Rd
-                  address2: ''
-                  city: Hilo
-                  stateOrProvince: Hawaii
-                  stateOrProvinceCode: HI
-                  country: United States
-                  countryCode: US
-                  postalCode: '96720'
-                  phone: '8081234567'
-                  customFields: []
-                consignments:
-                  - id: 5c377ead30ac1
-                    shippingCost: 8
-                    handlingCost: 0
-                    couponDiscounts: []
-                    discounts: []
-                    lineItemIds:
-                      - 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                    selectedShippingOption:
-                      id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
-                      type: shipping_byweight
-                      description: Ship by Weight
-                      imageUrl: ''
-                      cost: 8
-                      transitTime: ''
-                    address:
-                      firstName: Dwayne
-                      lastName: Cole
-                      email: dwaynecole@testing.com
-                      company: ''
-                      address1: Mauna Kea Access Rd
-                      address2: ''
-                      city: Hilo
-                      stateOrProvince: Hawaii
-                      stateOrProvinceCode: HI
-                      country: United States
-                      countryCode: US
-                      postalCode: '96720'
-                      phone: '8081234567'
-                      customFields: []
-                      shouldSaveAddress: true
-                orderId: null
-                shippingCostTotal: 8
-                shippingCostBeforeDiscount: 8
-                handlingCostTotal: 0
-                taxTotal: 1.22
-                coupons: []
-                taxes:
-                  - name: Tax
-                    amount: 1.22
-                subtotal: 7.95
-                grandTotal: 15.95
-                giftCertificates: []
-                createdTime: '2019-01-10T17:18:00+00:00'
-                updatedTime: '2019-01-10T17:19:47+00:00'
-                customerMessage: ''
-                version: 1
+                $ref: '#/components/examples/CheckoutResp'
         '409':
           $ref: '#/components/responses/CartConflictErrorResponse'
       x-codegen-request-body-name: body
@@ -1529,115 +416,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/checkout_Full'
               example:
-                id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                cart:
-                  id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                  customerId: 18
-                  email: dwaynecole@testing.com
-                  currency:
-                    name: US Dollars
-                    code: USD
-                    symbol: $
-                    decimalPlaces: 2
-                  isTaxIncluded: true
-                  baseAmount: 7.95
-                  discountAmount: 0
-                  cartAmount: 7.95
-                  coupons: []
-                  discounts:
-                    - id: 1
-                      discountedAmount: 0
-                  lineItems:
-                    physicalItems:
-                      - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                        parentId: ''
-                        variantId: 345
-                        productId: 174
-                        sku: ''
-                        name: 1L Le Parfait Jar
-                        url: 'https://{store_domain}/all/1l-le-parfait-jar/'
-                        quantity: 1
-                        brand: OFS
-                        isTaxable: true
-                        imageUrl: 'https://cdn11.bigcommerce.com/s-{store_hash}/products/174/images/425/leparfaitmedium3_1024x1024_1024x1024__37756__81924.1534344526.330.500.jpg?c=2'
-                        discounts: []
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 7.95
-                        listPrice: 7.95
-                        salePrice: 7.95
-                        extendedListPrice: 7.95
-                        extendedSalePrice: 7.95
-                        isShippingRequired: true
-                        giftWrapping: {}
-                        addedByPromotion: false
-                    digitalItems: []
-                    giftCertificates: []
-                    customItems: []
-                  createdTime: '2019-01-10T17:18:00+00:00'
-                  updatedTime: '2019-01-10T17:19:47+00:00'
-                billingAddress:
-                  id: 5c377ead301c2
-                  firstName: Dwayne
-                  lastName: Cole
-                  email: dwaynecole@testing.com
-                  company: ''
-                  address1: Mauna Kea Access Rd
-                  address2: ''
-                  city: Hilo
-                  stateOrProvince: Hawaii
-                  stateOrProvinceCode: HI
-                  country: United States
-                  countryCode: US
-                  postalCode: '96720'
-                  phone: '8081234567'
-                  customFields: []
-                consignments:
-                  - id: 5c377ead30ac1
-                    shippingCost: 8
-                    handlingCost: 0
-                    couponDiscounts: []
-                    discounts: []
-                    lineItemIds:
-                      - 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                    selectedShippingOption:
-                      id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
-                      type: shipping_byweight
-                      description: Ship by Weight
-                      imageUrl: ''
-                      cost: 8
-                      transitTime: ''
-                    address:
-                      firstName: Dwayne
-                      lastName: Cole
-                      email: dwaynecole@testing.com
-                      company: ''
-                      address1: Mauna Kea Access Rd
-                      address2: ''
-                      city: Hilo
-                      stateOrProvince: Hawaii
-                      stateOrProvinceCode: HI
-                      country: United States
-                      countryCode: US
-                      postalCode: '96720'
-                      phone: '8081234567'
-                      customFields: []
-                orderId: null
-                shippingCostTotal: 8
-                shippingCostBeforeDiscount: 8
-                handlingCostTotal: 0
-                taxTotal: 1.22
-                coupons: []
-                taxes:
-                  - name: Tax
-                    amount: 1.22
-                subtotal: 7.95
-                grandTotal: 15.95
-                giftCertificates: []
-                createdTime: '2019-01-10T17:18:00+00:00'
-                updatedTime: '2019-01-10T17:19:47+00:00'
-                customerMessage: ''
-                version: 1
+                $ref: '#/components/examples/CheckoutResp'
         '409':
           $ref: '#/components/responses/CartConflictErrorResponse'
   '/checkouts/{checkoutId}/gift-certificates':
@@ -1674,115 +453,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/checkout_Full'
               example:
-                id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                cart:
-                  id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                  customerId: 18
-                  email: dwaynecole@testing.com
-                  currency:
-                    name: US Dollars
-                    code: USD
-                    symbol: $
-                    decimalPlaces: 2
-                  isTaxIncluded: true
-                  baseAmount: 7.95
-                  discountAmount: 0
-                  cartAmount: 7.95
-                  coupons: []
-                  discounts:
-                    - id: 1
-                      discountedAmount: 0
-                  lineItems:
-                    physicalItems:
-                      - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                        parentId: ''
-                        variantId: 345
-                        productId: 174
-                        sku: ''
-                        name: 1L Le Parfait Jar
-                        url: 'https://{store_domain}/all/1l-le-parfait-jar/'
-                        quantity: 1
-                        brand: OFS
-                        isTaxable: true
-                        imageUrl: 'https://cdn11.bigcommerce.com/s-{store_hash}/products/174/images/425/leparfaitmedium3_1024x1024_1024x1024__37756__81924.1534344526.330.500.jpg?c=2'
-                        discounts: []
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 7.95
-                        listPrice: 7.95
-                        salePrice: 7.95
-                        extendedListPrice: 7.95
-                        extendedSalePrice: 7.95
-                        isShippingRequired: true
-                        giftWrapping: {}
-                        addedByPromotion: false
-                    digitalItems: []
-                    giftCertificates: []
-                    customItems: []
-                  createdTime: '2019-01-10T17:18:00+00:00'
-                  updatedTime: '2019-01-10T17:19:47+00:00'
-                billingAddress:
-                  id: 5c377ead301c2
-                  firstName: Dwayne
-                  lastName: Cole
-                  email: dwaynecole@testing.com
-                  company: ''
-                  address1: Mauna Kea Access Rd
-                  address2: ''
-                  city: Hilo
-                  stateOrProvince: Hawaii
-                  stateOrProvinceCode: HI
-                  country: United States
-                  countryCode: US
-                  postalCode: '96720'
-                  phone: '8081234567'
-                  customFields: []
-                consignments:
-                  - id: 5c377ead30ac1
-                    shippingCost: 8
-                    handlingCost: 0
-                    couponDiscounts: []
-                    discounts: []
-                    lineItemIds:
-                      - 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                    selectedShippingOption:
-                      id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
-                      type: shipping_byweight
-                      description: Ship by Weight
-                      imageUrl: ''
-                      cost: 8
-                      transitTime: ''
-                    address:
-                      firstName: Dwayne
-                      lastName: Cole
-                      email: dwaynecole@testing.com
-                      company: ''
-                      address1: Mauna Kea Access Rd
-                      address2: ''
-                      city: Hilo
-                      stateOrProvince: Hawaii
-                      stateOrProvinceCode: HI
-                      country: United States
-                      countryCode: US
-                      postalCode: '96720'
-                      phone: '8081234567'
-                      customFields: []
-                orderId: null
-                shippingCostTotal: 8
-                shippingCostBeforeDiscount: 8
-                handlingCostTotal: 0
-                taxTotal: 1.22
-                coupons: []
-                taxes:
-                  - name: Tax
-                    amount: 1.22
-                subtotal: 7.95
-                grandTotal: 15.95
-                giftCertificates: []
-                createdTime: '2019-01-10T17:18:00+00:00'
-                updatedTime: '2019-01-10T17:19:47+00:00'
-                customerMessage: ''
-                version: 1
+                $ref: '#/components/examples/CheckoutResp'
         '404':
           description: Gift certificate code not found
           content:
@@ -1860,115 +531,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/checkout_Full'
               example:
-                id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                cart:
-                  id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-                  customerId: 18
-                  email: dwaynecole@testing.com
-                  currency:
-                    name: US Dollars
-                    code: USD
-                    symbol: $
-                    decimalPlaces: 2
-                  isTaxIncluded: true
-                  baseAmount: 7.95
-                  discountAmount: 0
-                  cartAmount: 7.95
-                  coupons: []
-                  discounts:
-                    - id: 1
-                      discountedAmount: 0
-                  lineItems:
-                    physicalItems:
-                      - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                        parentId: ''
-                        variantId: 345
-                        productId: 174
-                        sku: ''
-                        name: 1L Le Parfait Jar
-                        url: 'https://{store_domain}/all/1l-le-parfait-jar/'
-                        quantity: 1
-                        brand: OFS
-                        isTaxable: true
-                        imageUrl: 'https://cdn11.bigcommerce.com/s-{store_hash}/products/174/images/425/leparfaitmedium3_1024x1024_1024x1024__37756__81924.1534344526.330.500.jpg?c=2'
-                        discounts: []
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 7.95
-                        listPrice: 7.95
-                        salePrice: 7.95
-                        extendedListPrice: 7.95
-                        extendedSalePrice: 7.95
-                        isShippingRequired: true
-                        giftWrapping: {}
-                        addedByPromotion: false
-                    digitalItems: []
-                    giftCertificates: []
-                    customItems: []
-                  createdTime: '2019-01-10T17:18:00+00:00'
-                  updatedTime: '2019-01-10T17:19:47+00:00'
-                billingAddress:
-                  id: 5c377ead301c2
-                  firstName: Dwayne
-                  lastName: Cole
-                  email: dwaynecole@testing.com
-                  company: ''
-                  address1: Mauna Kea Access Rd
-                  address2: ''
-                  city: Hilo
-                  stateOrProvince: Hawaii
-                  stateOrProvinceCode: HI
-                  country: United States
-                  countryCode: US
-                  postalCode: '96720'
-                  phone: '8081234567'
-                  customFields: []
-                consignments:
-                  - id: 5c377ead30ac1
-                    shippingCost: 8
-                    handlingCost: 0
-                    couponDiscounts: []
-                    discounts: []
-                    lineItemIds:
-                      - 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                    selectedShippingOption:
-                      id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
-                      type: shipping_byweight
-                      description: Ship by Weight
-                      imageUrl: ''
-                      cost: 8
-                      transitTime: ''
-                    address:
-                      firstName: Dwayne
-                      lastName: Cole
-                      email: dwaynecole@testing.com
-                      company: ''
-                      address1: Mauna Kea Access Rd
-                      address2: ''
-                      city: Hilo
-                      stateOrProvince: Hawaii
-                      stateOrProvinceCode: HI
-                      country: United States
-                      countryCode: US
-                      postalCode: '96720'
-                      phone: '8081234567'
-                      customFields: []
-                orderId: null
-                shippingCostTotal: 8
-                shippingCostBeforeDiscount: 8
-                handlingCostTotal: 0
-                taxTotal: 1.22
-                coupons: []
-                taxes:
-                  - name: Tax
-                    amount: 1.22
-                subtotal: 7.95
-                grandTotal: 15.95
-                giftCertificates: []
-                createdTime: '2019-01-10T17:18:00+00:00'
-                updatedTime: '2019-01-10T17:19:47+00:00'
-                customerMessage: ''
-                version: 1
+                $ref: '#/components/examples/CheckoutResp'
         '409':
           $ref: '#/components/responses/CartConflictErrorResponse'
       x-codegen-request-body-name: body
@@ -2001,220 +564,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/checkout_Full'
-              example:
-                id: b6fbd994-61a8-4f25-9167-6ec10489c448
-                cart:
-                  id: b6fbd994-61a8-4f25-9167-6ec10489c448
-                  customerId: 11
-                  email: janedoe@example.com
-                  currency:
-                    name: US Dollars
-                    code: USD
-                    symbol: $
-                    decimalPlaces: 2
-                  isTaxIncluded: false
-                  baseAmount: 119.93
-                  discountAmount: 0
-                  cartAmount: 117.93
-                  coupons: []
-                  discounts:
-                    - id: 1
-                      discountedAmount: 2
-                    - id: 2
-                      discountedAmount: 0
-                    - id: 3
-                      discountedAmount: 0
-                    - id: 4
-                      discountedAmount: 0
-                    - id: 5
-                      discountedAmount: 0
-                  lineItems:
-                    physicalItems:
-                      - id: 69791a88-85c9-4c19-8042-e537621e8a55
-                        variantId: 364
-                        productId: 184
-                        sku: SMA-RED
-                        name: Canvas Laundry Cart
-                        url: 'https://{store_domain}/all/canvas-laundry-cart/'
-                        quantity: 1
-                        isTaxable: true
-                        imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/184/images/445/naturalcanvascart2_1024x1024__92347__29648.1534344533.330.500.jpg?c=2'
-                        discounts:
-                          - id: 2
-                            discountedAmount: 2
-                        discountAmount: 2
-                        couponAmount: 0
-                        originalPrice: 17.99
-                        listPrice: 15.99
-                        salePrice: 13.99
-                        extendedListPrice: 15.99
-                        extendedSalePrice: 13.99
-                        isShippingRequired: true
-                        addedByPromotion: false
-                      - id: ba2c619d-e6b4-48c2-8809-d88e424ed450
-                        variantId: 341
-                        productId: 170
-                        sku: ''
-                        name: Ceramic Measuring Spoons
-                        url: 'https://{store_domain}/all/ceramic-measuring-spoons/'
-                        quantity: 1
-                        isTaxable: true
-                        imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/170/images/411/measuringsquares2_1024x1024__07108__95421.1534344522.330.500.jpg?c=2'
-                        discounts: []
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 25
-                        listPrice: 25
-                        salePrice: 25
-                        extendedListPrice: 25
-                        extendedSalePrice: 25
-                        isShippingRequired: true
-                        addedByPromotion: false
-                      - id: c72d6651-978d-45e5-881b-c2bb5f7ff1d5
-                        variantId: 376
-                        productId: 158
-                        sku: SKU-A0C8A203
-                        name: Chambray Towel
-                        url: 'https://{store_domain}/all/chambray-towel/'
-                        quantity: 1
-                        isTaxable: true
-                        imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/158/images/382/foglinenbeigestripetowel1b_1024x1024__83011__60806.1534344511.330.500.jpg?c=2'
-                        discounts: []
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 49.99
-                        listPrice: 49.99
-                        salePrice: 49.99
-                        extendedListPrice: 49.99
-                        extendedSalePrice: 49.99
-                        isShippingRequired: true
-                        addedByPromotion: false
-                    digitalItems:
-                      - id: 6477a4a1-02cf-4287-8bf2-fd043bdd5234
-                        variantId: 360
-                        productId: 189
-                        name: Gather Journal Issue 7 - Digital
-                        url: 'https://{store_domain}/all/gather-journal-issue-7/'
-                        quantity: 1
-                        isTaxable: true
-                        imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/189/images/465/gather_1024x1024__17195__82620.1534344540.330.500.jpg?c=2'
-                        discounts: []
-                        discountAmount: 0
-                        couponAmount: 0
-                        originalPrice: 18.95
-                        listPrice: 18.95
-                        salePrice: 18.95
-                        extendedListPrice: 18.95
-                        extendedSalePrice: 18.95
-                        isShippingRequired: false
-                        type: digital
-                    giftCertificates:
-                      - id: 871f1f56-4c88-43c3-a6e5-0a647d83d6ac
-                        name: $10.00 Gift Certificate
-                        theme: Celebration
-                        amount: 10
-                        taxable: false
-                        sender:
-                          name: Jane Doe
-                          email: janedoe@example.com
-                        recipient:
-                          name: John Doe
-                          email: johndoe@example.com
-                        message: Thank you!
-                        type: giftCertificate
-                  createdTime: '2018-09-18T15:48:26+00:00'
-                  updatedTime: '2018-09-18T17:47:35+00:00'
-                billingAddress:
-                  id: 5ba11e4a10fb5
-                  firstName: Jane
-                  lastName: Doe
-                  email: janedoe@example.com
-                  address1: 123 Main Street
-                  city: Austin
-                  stateOrProvince: Texas
-                  stateOrProvinceCode: TX
-                  country: United States
-                  countryCode: US
-                  postalCode: '78751'
-                  phone: '1234567890'
-                  customFields:
-                    - fieldId: field_25
-                      fieldValue: Leave in backyard
-                consignments:
-                  - id: 5ba13935c977a
-                    shippingCost: 8
-                    handlingCost: 0
-                    couponDiscounts: []
-                    discounts: []
-                    lineItemIds:
-                      - ba2c619d-e6b4-48c2-8809-d88e424ed450
-                      - c72d6651-978d-45e5-881b-c2bb5f7ff1d5
-                    selectedShippingOption:
-                      id: 8458d845-a589-477c-a70d-977eed19e0d6
-                      type: shipping_byweight
-                      description: Ship by Weight
-                      imageUrl: ''
-                      cost: 8
-                      transitTime: ''
-                    address:
-                      firstName: Jane
-                      lastName: Doe
-                      email: ''
-                      company: ''
-                      address1: 123 Main Street
-                      address2: ''
-                      city: Austin
-                      stateOrProvince: Texas
-                      stateOrProvinceCode: TX
-                      country: United States
-                      countryCode: US
-                      postalCode: '78751'
-                      phone: '1234567890'
-                      customFields: []
-                  - id: 5ba13995cf156
-                    shippingCost: 62.63
-                    handlingCost: 0
-                    couponDiscounts: []
-                    discounts: []
-                    lineItemIds:
-                      - 69791a88-85c9-4c19-8042-e537621e8a55
-                    selectedShippingOption:
-                      id: 989cdc72-2eee-49d8-bc71-5d466f905fdc
-                      type: shipping_upsready
-                      description: UPS® (UPS Next Day Air®)
-                      imageUrl: ''
-                      cost: 62.63
-                      transitTime: 1 business day
-                    address:
-                      firstName: John
-                      lastName: Doe
-                      email: ''
-                      company: ''
-                      address1: 555 South Street
-                      address2: ''
-                      city: Austin
-                      stateOrProvince: Texas
-                      stateOrProvinceCode: TX
-                      country: United States
-                      countryCode: US
-                      postalCode: '78751'
-                      phone: '1234567890'
-                      customFields: []
-                shippingCostTotal: 70.63
-                shippingCostBeforeDiscount: 70.63
-                handlingCostTotal: 0
-                taxTotal: 29.44
-                coupons: []
-                taxes:
-                  - name: Store Tax
-                    amount: 29.44
-                subtotal: 117.93
-                grandTotal: 218
-                giftCertificates: []
-                createdTime: '2018-09-18T15:48:26+00:00'
-                updatedTime: '2018-09-18T17:47:35+00:00'
-                customerMessage: ''
-                version: 1
+              example: 
+                $ref: '#/components/examples/CheckoutResp'
         '409':
           $ref: '#/components/responses/CartConflictErrorResponse'
   '/checkouts/{checkoutId}/store-credit':
@@ -2260,8 +611,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties: {}
+                $ref: '#/components/schemas/checkout_Full'
   '/checkouts/{checkoutId}/spam-protection':
     parameters:
       - $ref: '#/components/parameters/CheckoutIdPath'
@@ -2295,6 +645,295 @@ paths:
       deprecated: false
       x-codegen-request-body-name: body
 components:
+  examples:
+    CheckoutResp:
+      value:
+        id: b6fbd994-61a8-4f25-9167-6ec10489c448
+        billingAddress:
+          id: 5ba11e4a10fb5
+          firstName: Jane
+          lastName: Doe
+          email: janedoe@example.com
+          company: ''
+          address1: 123 Main Street
+          address2: ''
+          city: Austin
+          stateOrProvince: Texas
+          stateOrProvinceCode: TX
+          country: United States
+          countryCode: US
+          postalCode: '78751'
+          phone: '1234567890'
+          customFields:
+            - fieldId: field_25
+              fieldValue: Leave in backyard
+        channelId: 1
+        cart:
+          id: b6fbd994-61a8-4f25-9167-6ec10489c448
+          customerId: 11
+          email: janedoe@example.com
+          currency:
+            name: US Dollars
+            code: USD
+            symbol: $
+            decimalPlaces: 2
+          isTaxIncluded: false
+          baseAmount: 119.93
+          discountAmount: 0
+          cartAmount: 112.93
+          coupons:
+            - id: 1
+              code: S2549JM0Y
+              displayName: $5.00 off the order total
+              couponType: per_total_discount
+              discountedAmount: 5
+          discounts:
+            - id: 1
+              discountedAmount: 2.59
+            - id: 2
+              discountedAmount: 1.06
+            - id: 3
+              discountedAmount: 2.12
+            - id: 4
+              discountedAmount: 0.8
+            - id: 5
+              discountedAmount: 0.43
+          lineItems:
+            physicalItems:
+              - id: 69791a88-85c9-4c19-8042-e537621e8a55
+                categoryNames: ["Essentials", "Just arrived"]
+                parentId: ''
+                variantId: 364
+                productId: 184
+                sku: SMA-RED
+                name: Canvas Laundry Cart
+                url: 'https://{store_domain}/all/canvas-laundry-cart/'
+                quantity: 1
+                brand: OFS
+                isTaxable: true
+                imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/184/images/445/naturalcanvascart2_1024x1024__92347__29648.1534344533.330.500.jpg?c=2'
+                discounts:
+                  - id: 1
+                    discountedAmount: 0.59
+                  - id: 2
+                    discountedAmount: 2
+                discountAmount: 2
+                couponAmount: 0
+                originalPrice: 17.99
+                listPrice: 15.99
+                salePrice: 13.99
+                comparisonPrice: 0
+                extendedComparisonPrice: 0
+                extendedListPrice: 15.99
+                extendedSalePrice: 13.99
+                isShippingRequired: true
+                options: 
+                - name: "Color"
+                  nameId: 1
+                  value: "Red" 
+                  valueId: "2"
+                giftWrapping: {}
+                addedByPromotion: false
+              - id: ba2c619d-e6b4-48c2-8809-d88e424ed450
+                categoryNames: ["Essentials", "Just arrived"]
+                parentId: ''
+                variantId: 341
+                productId: 170
+                sku: ''
+                name: Ceramic Measuring Spoons
+                url: 'https://{store_domain}/all/ceramic-measuring-spoons/'
+                quantity: 1
+                brand: OFS
+                isTaxable: true
+                imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/170/images/411/measuringsquares2_1024x1024__07108__95421.1534344522.330.500.jpg?c=2'
+                discounts:
+                  - id: 1
+                    discountedAmount: 1.06
+                discountAmount: 0
+                couponAmount: 0
+                originalPrice: 25
+                listPrice: 25
+                salePrice: 25
+                comparisonPrice: 0
+                extendedComparisonPrice: 0
+                extendedListPrice: 25
+                extendedSalePrice: 25
+                isShippingRequired: true
+                options: 
+                - name: "Color"
+                  nameId: 1
+                  value: "Red" 
+                  valueId: "2"
+                giftWrapping: {}
+                addedByPromotion: false
+              - id: c72d6651-978d-45e5-881b-c2bb5f7ff1d5
+                categoryNames: ["Essentials", "Just arrived"]
+                parentId: ''
+                variantId: 376
+                productId: 158
+                sku: SKU-A0C8A203
+                name: Chambray Towel
+                url: 'https://{store_domain}/all/chambray-towel/'
+                quantity: 1
+                brand: OFS
+                isTaxable: true
+                imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/158/images/382/foglinenbeigestripetowel1b_1024x1024__83011__60806.1534344511.330.500.jpg?c=2'
+                discounts:
+                  - id: 1
+                    discountedAmount: 2.12
+                discountAmount: 0
+                couponAmount: 0
+                originalPrice: 49.99
+                listPrice: 49.99
+                salePrice: 49.99
+                comparisonPrice: 0
+                extendedComparisonPrice: 0
+                extendedListPrice: 49.99
+                extendedSalePrice: 49.99
+                isShippingRequired: true
+                options: 
+                - name: "Color"
+                  nameId: 1
+                  value: "Red" 
+                  valueId: "2"
+                giftWrapping: {}
+                addedByPromotion: false
+            digitalItems:
+              - id: 6477a4a1-02cf-4287-8bf2-fd043bdd5234
+                categoryNames: ["Essentials", "Just arrived"]
+                parentId: ''
+                variantId: 360
+                productId: 189
+                name: Gather Journal Issue 7 - Digital
+                url: 'https://{store_domain}/all/gather-journal-issue-7/'
+                quantity: 1
+                brand: OFS
+                isTaxable: true
+                imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/189/images/465/gather_1024x1024__17195__82620.1534344540.330.500.jpg?c=2'
+                discounts:
+                  - id: 1
+                    discountedAmount: 0.8
+                discountAmount: 0
+                couponAmount: 0
+                originalPrice: 18.95
+                listPrice: 18.95
+                salePrice: 18.95
+                comparisonPrice: 0
+                extendedComparisonPrice: 0
+                extendedListPrice: 18.95
+                extendedSalePrice: 18.95
+                options: 
+                - name: "Color"
+                  nameId: 1
+                  value: "Red" 
+                  valueId: "2"
+                isShippingRequired: false
+                type: digital
+            giftCertificates:
+              - id: 871f1f56-4c88-43c3-a6e5-0a647d83d6ac
+                name: $10.00 Gift Certificate
+                theme: Celebration
+                amount: 10
+                taxable: false
+                sender:
+                  name: Jane Doe
+                  email: janedoe@example.com
+                recipient:
+                  name: John Doe
+                  email: johndoe@example.com
+                message: Thank you!
+                type: giftCertificate
+            customItems: []
+          createdTime: '2018-09-18T15:48:26+00:00'
+          updatedTime: '2018-09-18T16:59:45+00:00'
+          locale: "en"
+          version: 1
+        customer: 
+          addresses: [{}]
+          customerGroup:
+            id: 1
+            name: Wholesale customers
+          email: "string" 
+          firstName: "string" 
+          fullName: "string" 
+          id: 1 
+          isGuest: false 
+          lastName: "string" 
+          shouldEncourageSignIn: false 
+          storeCredit: 1.00
+        customerMessage: 'Thank you, BigCommerce'
+        consignments:
+          - id: 5ba121929619b
+            shippingCost: 69.94
+            handlingCost: 0
+            couponDiscounts: []
+            discounts: []
+            lineItemIds:
+              - 69791a88-85c9-4c19-8042-e537621e8a55
+              - ba2c619d-e6b4-48c2-8809-d88e424ed450
+              - c72d6651-978d-45e5-881b-c2bb5f7ff1d5
+            availableShippingOptions:
+            - id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
+              type: shipping_byweight
+              description: Ship by Weight
+              additionalDescription: Fragile items
+              imageUrl: ''
+              cost: 8
+              transitTime: ''
+            selectedShippingOption:
+              additionalDescription: Fragile items
+              id: bb3c818f-17ce-46fe-9475-65933095da0d
+              type: shipping_upsready
+              description: UPS® (UPS Next Day Air®)
+              imageUrl: ''
+              cost: 69.94
+              transitTime: 1 business day
+            address:
+              firstName: Jane
+              lastName: Doe
+              email: janedoe@example.com
+              company: ''
+              address1: 123 Main Street
+              address2: ''
+              city: Austin
+              stateOrProvince: Texas
+              stateOrProvinceCode: TX
+              country: United States
+              countryCode: US
+              postalCode: '78751'
+              phone: '1234567890'
+              customFields:
+                - fieldId: field_25
+                  fieldValue: Leave in backyard
+        fees: []
+        payments: [{}]
+        promotions: []
+        orderId: null
+        shippingCostTotal: 69.94
+        shippingCostBeforeDiscount: 69.94
+        shouldExecuteSpamCheck: false
+        handlingCostTotal: 0
+        taxTotal: 28.62
+        coupons:
+          - id: 1
+            code: S2549JM0Y
+            displayName: $5.00 off the order total
+            couponType: 2
+            discountedAmount: 5
+        taxes:
+          - name: Store Tax
+            amount: 28.62
+        subtotal: 117.93
+        grandTotal: 211.49
+        giftCertificates:
+        - balance: 4.00
+          code: '1234ABC'
+          purchaseDate: "string"
+          remaining: 2.00
+          used: 5.00
+        createdTime: '2018-09-18T15:48:26+00:00'
+        updatedTime: '2018-09-18T16:59:45+00:00'
+        version: 1
   schemas:
     SpamProtectionRequest:
       title: SpamProtectionRequest
@@ -2327,7 +966,7 @@ components:
           type: string
           description: Time when the cart was created.
         customer: 
-            $ref: '#/components/schemas/Customer'
+          $ref: '#/components/schemas/Customer'
         customerMessage:
           type: string
           description: Shopperʼs message provided as details for the order to be created from this cart
@@ -3380,121 +2019,6 @@ components:
         pickupMethodId:
           type: integer  
   responses:
-    Checkout:
-      description: ''
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/checkout_Full'
-          example:
-            id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-            cart:
-              id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
-              customerId: 18
-              email: dwaynecole@testing.com
-              currency:
-                name: US Dollars
-                code: USD
-                symbol: $
-                decimalPlaces: 2
-              isTaxIncluded: true
-              baseAmount: 7.95
-              discountAmount: 0
-              cartAmount: 7.95
-              coupons: []
-              discounts:
-                - id: 1
-                  discountedAmount: 0
-              lineItems:
-                physicalItems:
-                  - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                    parentId: ''
-                    variantId: 345
-                    productId: 174
-                    sku: ''
-                    name: 1L Le Parfait Jar
-                    url: 'https://{store_domain}/all/1l-le-parfait-jar/'
-                    quantity: 1
-                    brand: OFS
-                    isTaxable: true
-                    imageUrl: 'https://cdn11.bigcommerce.com/s-{store_hash}/products/174/images/425/leparfaitmedium3_1024x1024_1024x1024__37756__81924.1534344526.330.500.jpg?c=2'
-                    discounts: []
-                    discountAmount: 0
-                    couponAmount: 0
-                    listPrice: 7.95
-                    salePrice: 7.95
-                    extendedListPrice: 7.95
-                    extendedSalePrice: 7.95
-                    isShippingRequired: true
-                    giftWrapping: {}
-                    addedByPromotion: false
-                digitalItems: []
-                giftCertificates: []
-                customItems: []
-              createdTime: '2019-01-10T17:18:00+00:00'
-              updatedTime: '2019-01-10T17:19:47+00:00'
-            billingAddress:
-              id: 5c377ead301c2
-              firstName: Dwayne
-              lastName: Cole
-              email: dwaynecole@testing.com
-              company: ''
-              address1: Mauna Kea Access Rd
-              address2: ''
-              city: Hilo
-              stateOrProvince: Hawaii
-              stateOrProvinceCode: HI
-              country: United States
-              countryCode: US
-              postalCode: '96720'
-              phone: '8081234567'
-              customFields: []
-            consignments:
-              - id: 5c377ead30ac1
-                shippingCost: 8
-                handlingCost: 0
-                couponDiscounts: []
-                discounts: []
-                lineItemIds:
-                  - 243c9ca2-22b4-417a-8b09-b3fc05778b52
-                selectedShippingOption:
-                  id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
-                  type: shipping_byweight
-                  description: Ship by Weight
-                  imageUrl: ''
-                  cost: 8
-                  transitTime: ''
-                address:
-                  firstName: Dwayne
-                  lastName: Cole
-                  email: dwaynecole@testing.com
-                  company: ''
-                  address1: Mauna Kea Access Rd
-                  address2: ''
-                  city: Hilo
-                  stateOrProvince: Hawaii
-                  stateOrProvinceCode: HI
-                  country: United States
-                  countryCode: US
-                  postalCode: '96720'
-                  phone: '8081234567'
-                  customFields: []
-            orderId: "1234"
-            shippingCostTotal: 8
-            shippingCostBeforeDiscount: 8
-            handlingCostTotal: 0
-            taxTotal: 1.22
-            coupons: []
-            taxes:
-              - name: Tax
-                amount: 1.22
-            subtotal: 7.95
-            grandTotal: 15.95
-            giftCertificates: []
-            createdTime: '2019-01-10T17:18:00+00:00'
-            updatedTime: '2019-01-10T17:19:47+00:00'
-            customerMessage: ''
-            version: 1
     CartConflictErrorResponse:
       description: 'Cart conflict'
       content:

--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -1009,7 +1009,28 @@ components:
           type: array
           items:
             type: object
-            properties: {}
+            properties:
+              providerId:
+                description: Payment provider ID.
+                type: string
+              gatewayId:
+                description: Payment gateway ID.
+                type: string 
+                nullable: true 
+              providerType: 
+                description: Type of payment provider.
+                type: string 
+                enum:
+                  - PAYMENT_TYPE_HOSTED
+              detail: 
+                type: array
+                description: Details regarding which checkout steps a shopper has completed.
+                items:
+                  type: string
+                  enum: 
+                  - FINALIZE
+                  - INITIALIZE
+                  - ACKNOWLEDGE
         promotions: 
           type: array
           items: 

--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -55,7 +55,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/checkouts_Resp'
+                $ref: '#/components/schemas/checkout_Full'
               example:
                 id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
                 channelId: 1
@@ -261,7 +261,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/checkouts_Resp'
+                $ref: '#/components/schemas/checkout_Full'
               example:
                 id: 29eb9b44-8f33-4e4a-9429-d0e8e24641ed
                 cart:
@@ -428,7 +428,7 @@ paths:
                   cartAmount: 7.95
                   coupons: []
                   discounts:
-                    - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
+                    - id: 1
                       discountedAmount: 0
                   lineItems:
                     physicalItems:
@@ -563,15 +563,15 @@ paths:
                       couponType: per_total_discount
                       discountedAmount: 5
                   discounts:
-                    - id: 69791a88-85c9-4c19-8042-e537621e8a55
+                    - id: 1
                       discountedAmount: 2.59
-                    - id: ba2c619d-e6b4-48c2-8809-d88e424ed450
+                    - id: 2
                       discountedAmount: 1.06
-                    - id: c72d6651-978d-45e5-881b-c2bb5f7ff1d5
+                    - id: 3
                       discountedAmount: 2.12
-                    - id: 6477a4a1-02cf-4287-8bf2-fd043bdd5234
+                    - id: 4
                       discountedAmount: 0.8
-                    - id: 871f1f56-4c88-43c3-a6e5-0a647d83d6ac
+                    - id: 5
                       discountedAmount: 0.43
                   lineItems:
                     physicalItems:
@@ -586,7 +586,7 @@ paths:
                         isTaxable: true
                         imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/184/images/445/naturalcanvascart2_1024x1024__92347__29648.1534344533.330.500.jpg?c=2'
                         discounts:
-                          - id: total-coupon
+                          - id: 1
                             discountedAmount: 0.59
                           - id: 2
                             discountedAmount: 2
@@ -611,7 +611,7 @@ paths:
                         isTaxable: true
                         imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/170/images/411/measuringsquares2_1024x1024__07108__95421.1534344522.330.500.jpg?c=2'
                         discounts:
-                          - id: total-coupon
+                          - id: 1
                             discountedAmount: 1.06
                         discountAmount: 0
                         couponAmount: 0
@@ -634,7 +634,7 @@ paths:
                         isTaxable: true
                         imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/158/images/382/foglinenbeigestripetowel1b_1024x1024__83011__60806.1534344511.330.500.jpg?c=2'
                         discounts:
-                          - id: total-coupon
+                          - id: 1
                             discountedAmount: 2.12
                         discountAmount: 0
                         couponAmount: 0
@@ -657,7 +657,7 @@ paths:
                         isTaxable: true
                         imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/189/images/465/gather_1024x1024__17195__82620.1534344540.330.500.jpg?c=2'
                         discounts:
-                          - id: total-coupon
+                          - id: 1
                             discountedAmount: 0.8
                         discountAmount: 0
                         couponAmount: 0
@@ -809,7 +809,7 @@ paths:
                   cartAmount: 7.95
                   coupons: []
                   discounts:
-                    - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
+                    - id: 1
                       discountedAmount: 0
                   lineItems:
                     physicalItems:
@@ -963,15 +963,15 @@ paths:
                       couponType: per_total_discount
                       discountedAmount: 5
                   discounts:
-                    - id: 69791a88-85c9-4c19-8042-e537621e8a55
+                    - id: 1
                       discountedAmount: 2.59
-                    - id: ba2c619d-e6b4-48c2-8809-d88e424ed450
+                    - id: 2
                       discountedAmount: 1.06
-                    - id: c72d6651-978d-45e5-881b-c2bb5f7ff1d5
+                    - id: 3
                       discountedAmount: 2.12
-                    - id: 6477a4a1-02cf-4287-8bf2-fd043bdd5234
+                    - id: 4
                       discountedAmount: 0.8
-                    - id: 871f1f56-4c88-43c3-a6e5-0a647d83d6ac
+                    - id: 5
                       discountedAmount: 0.43
                   lineItems:
                     physicalItems:
@@ -986,7 +986,7 @@ paths:
                         isTaxable: true
                         imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/184/images/445/naturalcanvascart2_1024x1024__92347__29648.1534344533.330.500.jpg?c=2'
                         discounts:
-                          - id: total-coupon
+                          - id: 1
                             discountedAmount: 0.59
                           - id: 2
                             discountedAmount: 2
@@ -1011,7 +1011,7 @@ paths:
                         isTaxable: true
                         imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/170/images/411/measuringsquares2_1024x1024__07108__95421.1534344522.330.500.jpg?c=2'
                         discounts:
-                          - id: total-coupon
+                          - id: 1
                             discountedAmount: 1.06
                         discountAmount: 0
                         couponAmount: 0
@@ -1034,7 +1034,7 @@ paths:
                         isTaxable: true
                         imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/158/images/382/foglinenbeigestripetowel1b_1024x1024__83011__60806.1534344511.330.500.jpg?c=2'
                         discounts:
-                          - id: total-coupon
+                          - id: 1
                             discountedAmount: 2.12
                         discountAmount: 0
                         couponAmount: 0
@@ -1057,7 +1057,7 @@ paths:
                         isTaxable: true
                         imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/189/images/465/gather_1024x1024__17195__82620.1534344540.330.500.jpg?c=2'
                         discounts:
-                          - id: total-coupon
+                          - id: 1
                             discountedAmount: 0.8
                         discountAmount: 0
                         couponAmount: 0
@@ -1239,7 +1239,7 @@ paths:
                   cartAmount: 7.95
                   coupons: []
                   discounts:
-                    - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
+                    - id: 1
                       discountedAmount: 0
                   lineItems:
                     physicalItems:
@@ -1407,7 +1407,7 @@ paths:
                   cartAmount: 7.95
                   coupons: []
                   discounts:
-                    - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
+                    - id: 1
                       discountedAmount: 0
                   lineItems:
                     physicalItems:
@@ -1545,7 +1545,7 @@ paths:
                   cartAmount: 7.95
                   coupons: []
                   discounts:
-                    - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
+                    - id: 1
                       discountedAmount: 0
                   lineItems:
                     physicalItems:
@@ -1690,7 +1690,7 @@ paths:
                   cartAmount: 7.95
                   coupons: []
                   discounts:
-                    - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
+                    - id: 1
                       discountedAmount: 0
                   lineItems:
                     physicalItems:
@@ -1876,7 +1876,7 @@ paths:
                   cartAmount: 7.95
                   coupons: []
                   discounts:
-                    - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
+                    - id: 1
                       discountedAmount: 0
                   lineItems:
                     physicalItems:
@@ -2018,15 +2018,15 @@ paths:
                   cartAmount: 117.93
                   coupons: []
                   discounts:
-                    - id: 69791a88-85c9-4c19-8042-e537621e8a55
+                    - id: 1
                       discountedAmount: 2
-                    - id: ba2c619d-e6b4-48c2-8809-d88e424ed450
+                    - id: 2
                       discountedAmount: 0
-                    - id: c72d6651-978d-45e5-881b-c2bb5f7ff1d5
+                    - id: 3
                       discountedAmount: 0
-                    - id: 6477a4a1-02cf-4287-8bf2-fd043bdd5234
+                    - id: 4
                       discountedAmount: 0
-                    - id: 871f1f56-4c88-43c3-a6e5-0a647d83d6ac
+                    - id: 5
                       discountedAmount: 0
                   lineItems:
                     physicalItems:
@@ -2241,7 +2241,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/checkouts_Resp'
+                $ref: '#/components/schemas/checkout_Full'
     delete:
       tags:
         - Checkout Store Credit
@@ -2311,10 +2311,13 @@ components:
           type: string
           description: ''
           format: uuid
-        cart:
-          $ref: '#/components/schemas/checkoutCart'
         billingAddress:
           $ref: '#/components/schemas/address_Base'
+        cart:
+          $ref: '#/components/schemas/checkoutCart'
+        channelId:
+          type: integer
+          description: Channel ID.
         consignments:
           type: array
           description: ''
@@ -2325,13 +2328,27 @@ components:
           description: Coupons applied at the checkout level.
           items:
             $ref: '#/components/schemas/CheckoutCoupon'
-        orderId:
+        customer: 
+            $ref: '#/components/schemas/Customer'
+        createdTime:
           type: string
-          description: ''
-          nullable: true
-        shippingCostTotal:
+          description: Time when the cart was created.
+        customerMessage:
+          type: string
+          description: Shopperʼs message provided as details for the order to be created from this cart
+        fees: 
+          type: array
+          items:
+            type: object
+            properties: {}
+        giftCertificates:
+          type: array
+          description: Applied gift certificate (as a payment method).
+          items:
+            $ref: '#/components/schemas/checkoutGiftCertificates'
+        grandTotal:
           type: number
-          description: Shipping cost before any discounts are applied.
+          description: The total payable amount, before applying any store credit or gift certificate.
           format: float
         giftWrappingCostTotal:
           type: number
@@ -2340,44 +2357,52 @@ components:
           type: number
           description: Handling cost for all consignments including or excluding tax.
           format: float
-        taxTotal:
-          type: number
+        isStoreCreditApplied:
+          type: boolean
+          description: |
+            `true` value indicates StoreCredit has been applied.
+        orderId:
+          type: string
           description: ''
+          nullable: true
+        outstandingBalance:
+          type: number
+          description: |
+            `grandTotal` subtract the store-credit amount
+        payments: 
+          type: array
+          items:
+            type: object
+            properties: {}
+        promotions: 
+          type: array
+          items: 
+            type: object 
+            properties: {}
+        shippingCostBeforeDiscount:
+          type: number
+          description: The shipping cost before discounts are applied.
+        shippingCostTotal:
+          type: number
+          description: Shipping cost before any discounts are applied.
+          format: float
+        shouldExecuteSpamCheck: 
+          type: boolean
+        subtotal:
+          type: number
+          description: Subtotal of the checkout before applying item-level discounts. Tax inclusive based on the store settings.
           format: float
         taxes:
           type: array
           items:
             $ref: '#/components/schemas/checkoutTax'
-        subtotal:
+        taxTotal:
           type: number
-          description: Subtotal of the checkout before applying item-level discounts. Tax inclusive based on the store settings.
+          description: ''
           format: float
-        grandTotal:
-          type: number
-          description: The total payable amount, before applying any store credit or gift certificate.
-          format: float
-        giftCertificates:
-          type: array
-          description: Applied gift certificate (as a payment method).
-          items:
-            $ref: '#/components/schemas/checkoutGiftCertificates'
-        createdTime:
-          type: string
-          description: Time when the cart was created.
         updatedTime:
           type: string
           description: Time when the cart was last updated.
-        customerMessage:
-          type: string
-          description: Shopperʼs message provided as details for the order to be created from this cart
-        outstandingBalance:
-          type: number
-          description: |
-            `grandTotal` subtract the store-credit amount
-        isStoreCreditApplied:
-          type: boolean
-          description: |
-            `true` value indicates StoreCredit has been applied.
         version:
           type: integer
           description: The current version of the checkout.
@@ -2445,6 +2470,46 @@ components:
           description: The discounted amount applied within a given context.
           format: double
       x-internal: false
+    Customer: 
+      type: object
+      properties:
+        addresses: 
+          type: array
+          items:
+            type: object
+            properties: {}
+        customerGroup: 
+          type: object
+          properties:
+            id: 
+              type: integer
+              description: ID of the customer group.
+            name: 
+              type: string
+              description: Name of the customer group.
+        email: 
+          type: string
+          description: Customer email.
+        firstName:
+          type: string
+          description: Customer's first name.
+        fullName:
+          type: string
+          description: Customer's full name.
+        id:
+          type: integer
+          description: Customer ID.
+        isGuest: 
+          type: boolean 
+          description: Whether the shopper is a guest or a logged-in customer. 
+        lastName:
+          type: string
+          description: Customer's last name.
+        shouldEncourageSignIn:
+          type: boolean
+        storeCredit: 
+          type: number
+          description: The amount of store credit a customer has.  
     contactEntity:
       title: contactEntity
       type: object
@@ -2504,6 +2569,9 @@ components:
         stateOrProvinceCode:
           type: string
           description: ''
+        country:
+          type: string
+          description: Country name.
         countryCode:
           type: string
           description: 'ISO 3166-1 alpha-2 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
@@ -2551,7 +2619,8 @@ components:
         shippingAddress:
           type: object
           properties: {}
-          x-deprecated: true
+          deprecated: true
+          description: Use the `address` field instead.
         address:
           $ref: '#/components/schemas/address_Full'
         selectedPickupOption:
@@ -2663,858 +2732,6 @@ components:
           type: integer
           description: The expected version of the checkout.
           example: 1
-      x-internal: false
-    checkouts_Resp:
-      title: checkouts_Resp
-      type: object
-      properties:
-        id:
-          type: string
-          description: ''
-          format: uuid
-        cart:
-          title: Cart
-          type: object
-          properties:
-            id:
-              type: string
-              description: Cart ID, provided after creating a cart with a POST.
-              format: uuid
-            customerId:
-              type: integer
-              description: ID of the customer to which the cart belongs.
-              format: int32
-            email:
-              type: string
-              description: The cartʼs email. This is the same email that is used in the billing address
-            currency:
-              title: Currency
-              type: object
-              properties:
-                name:
-                  type: string
-                  description: The currency name.
-                code:
-                  type: string
-                  description: 'ISO-4217 currency code. (See: https://www.iso.org/iso-4217-currency-codes.html.)'
-                symbol:
-                  type: string
-                  description: The currency symbol.
-                decimalPlaces:
-                  type: number
-                  description: The number of decimal places for the currency. For example, the USD currency has two decimal places.
-                  format: double
-              description: The currency in which prices are displayed (the store default currency).
-            isTaxIncluded:
-              type: boolean
-              description: Boolean representing whether tax information is included.
-            baseAmount:
-              type: number
-              description: The cost of the cart’s contents, before applying discounts.
-              format: double
-            discountAmount:
-              type: number
-              description: Order-based discounted amount only - Excludes coupon discounts and product-based discounts.
-              format: double
-            cartAmount:
-              type: number
-              description: Sum of line-items amounts, minus cart-level discounts and coupons. This amount includes taxes, where applicable.
-              format: double
-            coupons:
-              type: array
-              description: ''
-              items:
-                title: Applied Coupon
-                required:
-                  - code
-                type: object
-                properties:
-                  id:
-                    type: string
-                    description: The coupon ID.
-                  code:
-                    type: string
-                    description: the coupon code
-                  displayName:
-                    type: string
-                    description: The coupon title based on different types provided in control panel section.
-                  couponType:
-                    type: string
-                    description: Key name to identify the type of coupon.
-                  discountedAmount:
-                    type: number
-                    description: The discounted amount applied within a given context.
-                    format: double
-            discounts:
-              type: array
-              description: ''
-              items:
-                title: Applied Discount
-                type: object
-                properties:
-                  id:
-                    type: integer
-                    description: Discount ID.
-                  discountedAmount:
-                    type: number
-                    description: The discounted amount applied within a given context.
-                    format: double
-            lineItems:
-              type: object
-              description: ''
-              title: Line Items
-              required:
-                - digitalItems
-                - physicalItems
-              properties:
-                  physicalItems:
-                    type: array
-                    description: ''
-                    items:
-                      title: Item Physical
-                      required:
-                        - quantity
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                          description: The line-item ID.
-                        categoryNames: 
-                          type: array
-                          items: 
-                            type: string
-                        comparisonPrice:
-                          type: number
-                        extendedComparisonPrice: 
-                          type: number
-                        options: 
-                          type: array
-                          items: 
-                            type: object
-                            properties:
-                              name: 
-                                type: string
-                                description: Option name.
-                              nameId:
-                                type: integer
-                                description: Option ID.
-                              value: 
-                                type: string
-                                description: Option value.
-                              valueId:
-                                type: string
-                                description: Option value ID.
-                        parentId:
-                          type: string
-                          description: The product is part of a bundle, such as a product pick list, then the parentId or the main product ID will populate.
-                        variantId:
-                          type: integer
-                          description: ID of the variant.
-                        productId:
-                          type: integer
-                          description: ID of the product.
-                        sku:
-                          type: string
-                          description: SKU of the variant.
-                        name:
-                          type: string
-                          description: The itemʼs product name.
-                        url:
-                          type: string
-                          description: The product URL.
-                        quantity:
-                          type: number
-                          description: Quantity of this item.
-                          format: double
-                        isTaxable:
-                          type: boolean
-                          description: Whether the item is taxable.
-                        imageUrl:
-                          type: string
-                          description: A publicly-accessible URL for an image of this item.
-                        discounts:
-                          type: array
-                          description: A list of discounts applied to this item, as an array of AppliedDiscount objects.
-                          items:
-                            title: Applied Discount
-                            type: object
-                            properties:
-                              id:
-                                type: integer
-                                description: Discount ID.
-                              discountedAmount:
-                                type: number
-                                description: The discounted amount applied within a given context.
-                                format: double
-                        discountAmount:
-                          type: number
-                          description: The total value of all discounts applied to this item (excluding coupon).
-                          format: double
-                        brand:
-                          type: string
-                          description: The product's brand.
-                        couponAmount:
-                          type: number
-                          description: The total value of all coupons applied to this item.
-                          format: double
-                        originalPrice:
-                          type: number
-                          description: The item’s original price is the same as the product’s default price.
-                        listPrice:
-                          type: number
-                          description: The item’s list price, as quoted by the manufacturer or distributor.
-                          format: double
-                        salePrice:
-                          type: number
-                          description: The itemʼs price after all discounts are applied. (The final price before tax calculation.)
-                          format: double
-                        extendedListPrice:
-                          type: number
-                          description: The itemʼs list price multiplied by the quantity.
-                          format: double
-                        extendedSalePrice:
-                          type: number
-                          description: The itemʼs sale price multiplied by the quantity.
-                          format: double
-                        type:
-                          type: string
-                          description: the product type - physical or digital
-                        addedByPromotion:
-                          type: boolean
-                          description: If the item was added automatically by a promotion, such as a coupon or buy one, get one.
-                        isShippingRequired:
-                          type: boolean
-                          description: Whether this item requires shipping to a physical address.
-                        isMutable:
-                          type: boolean
-                          description: ''
-                        giftWrapping:
-                          title: Gift Wrapping
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: ''
-                            message:
-                              type: string
-                              description: ''
-                            amount:
-                              type: number
-                              description: ''
-                              format: double
-                  digitalItems:
-                    type: array
-                    description: ''
-                    items:
-                      title: Item Digital
-                      required:
-                        - quantity
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                          description: The line-item ID.
-                        categoryNames: 
-                          type: array
-                          items: 
-                            type: string
-                        comparisonPrice:
-                          type: number
-                        extendedComparisonPrice: 
-                          type: number
-                        options: 
-                          type: array
-                          items: 
-                            type: object
-                            properties:
-                              name: 
-                                type: string
-                                description: Option name.
-                              nameId:
-                                type: integer
-                                description: Option ID.
-                              value: 
-                                type: string
-                                description: Option value.
-                              valueId:
-                                type: string
-                                description: Option value ID.
-                        parentId:
-                          type: string
-                          description: Bundled items will have their parentʼs item ID.
-                        variantId:
-                          type: number
-                          description: ID of the variant.
-                          format: double
-                        productId:
-                          type: number
-                          description: ID of the product.
-                          format: double
-                        sku:
-                          type: string
-                          description: SKU of the variant.
-                        name:
-                          type: string
-                          description: The itemʼs product name.
-                        url:
-                          type: string
-                          description: The product URL.
-                        quantity:
-                          type: number
-                          description: Quantity of this item.
-                          format: double
-                        brand:
-                          type: string
-                          description: The itemʼs brand.
-                        isTaxable:
-                          type: boolean
-                          description: Whether the item is taxable.
-                        imageUrl:
-                          type: string
-                          description: A publicly-accessible URL for an image of this item.
-                        discounts:
-                          type: array
-                          description: List of discounts applied to this item, as an array of AppliedDiscount objects.
-                          items:
-                            title: Applied Discount
-                            type: object
-                            properties:
-                              id:
-                                type: string
-                                description: Discount ID.
-                              discountedAmount:
-                                type: number
-                                description: The discounted amount applied within a given context.
-                                format: double
-                        discountAmount:
-                          type: number
-                          description: The total value of all discounts applied to this item (excluding coupon).
-                          format: double
-                        couponAmount:
-                          type: number
-                          description: The total value of all coupons applied to this item.
-                          format: double
-                        originalPrice:
-                          type: number
-                          description: The item’s original price is the same as the product’s default price.
-                        listPrice:
-                          type: number
-                          description: The item’s list price, as quoted by the manufacturer or distributor.
-                          format: double
-                        salePrice:
-                          type: number
-                          description: The itemʼs price after all discounts are applied. (The final price before tax calculation.)
-                          format: double
-                        extendedListPrice:
-                          type: number
-                          description: The itemʼs list price multiplied by the quantity.
-                          format: double
-                        extendedSalePrice:
-                          type: number
-                          description: The itemʼs sale price multiplied by the quantity.
-                          format: double
-                        type:
-                          type: string
-                          description: the product type - physical or digital
-                        isMutable:
-                          type: boolean
-                          description: ''
-                        isShippingRequired:
-                          type: boolean
-                          description: Whether this item requires shipping to a physical address.
-                  giftCertificates:
-                    type: array
-                    description: ''
-                    items:
-                      title: Item Gift Certificate
-                      required:
-                        - amount
-                        - recipient
-                        - sender
-                        - theme
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                          description: Gift certificate identifier
-                        name:
-                          type: string
-                          description: 'The name of the purchased gift certificate; for example, `$20 Gift Certificate`.'
-                        theme:
-                          type: string
-                          description: 'Currently supports `Birthday`, `Boy`, `Celebration`, `Christmas`, `General`, and `Girl`.'
-                        amount:
-                          type: number
-                          description: 'Value must be between $1.00 and $1,000.00.'
-                          format: double
-                        taxable:
-                          type: boolean
-                          description: ''
-                        sender:
-                          title: Contact Entity
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: ''
-                            email:
-                              type: string
-                              description: ''
-                        recipient:
-                          title: Contact Entity
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: ''
-                            email:
-                              type: string
-                              description: ''
-                        message:
-                          type: string
-                          description: Limited to 200 characters.
-                        type:
-                          type: string
-                          description: Explicitly specifying the gift certificate type.
-                  customItems:
-                    type: array
-                    items:
-                      title: Item Custom
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                          description: ID of the custom item
-                        sku:
-                          type: string
-                          description: Custom item SKU
-                        name:
-                          type: string
-                          description: Item name
-                        quantity:
-                          type: string
-                        listPrice:
-                          type: string
-                          description: Price of the item. With or without tax depending on your store setup.
-                      description: |-
-                        Add a custom item to the shoppers cart.
-                        * Custom items are not added to the catalog.
-                        * The price should be set to match the store settings for taxes.
-            createdTime:
-              type: string
-              description: Time when the cart was created.
-            locale: 
-              type: string
-              description: Shopper's locale.
-            updatedTime:
-              type: string
-              description: Time when the cart was last updated.
-            version: 
-              type: integer
-              description: Cart version.
-          description: A cart contains a collection of items, prices, discounts, etc. It does not contain customer-related data.
-        billingAddress:
-          title: Address Response
-          allOf:
-            - title: Address Properties
-              required:
-                - countryCode
-              type: object
-              properties:
-                firstName:
-                  type: string
-                  description: ''
-                lastName:
-                  type: string
-                  description: ''
-                email:
-                  type: string
-                  description: ''
-                company:
-                  type: string
-                  description: ''
-                address1:
-                  type: string
-                  description: ''
-                address2:
-                  type: string
-                  description: ''
-                city:
-                  type: string
-                  description: ''
-                stateOrProvince:
-                  type: string
-                  description: Represents state or province.
-                stateOrProvinceCode:
-                  type: string
-                  description: ''
-                country: 
-                  type: string
-                  description: Country name.
-                countryCode:
-                  type: string
-                  description: 'ISO 3166-1 alpha-2 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
-                postalCode:
-                  type: string
-                  description: ''
-                phone:
-                  pattern: '^\+?[1-9]\d{1,14}(x\d{1-5})?$'
-                  type: string
-                  description: ''
-                customFields:
-                  type: array
-                  description: ''
-                  items:
-                    title: CustomField
-                    type: object
-                    properties:
-                      fieldId:
-                        type: string
-                        description: ''
-                      fieldValue:
-                        type: string
-                        description: This can also be an array for fields that need to support list of values; for example, a set of checkboxes.
-            - type: object
-              properties:
-                id:
-                  type: string
-                  description: ''
-        channelId:
-          type: integer
-          description: Channel ID.
-        consignments:
-          type: array
-          description: This allows you to have multiple shipping addresses per checkout. Where there is only one shipping address, this array will contain only one value, with all the items.
-          items:
-            title: Consignment
-            type: object
-            properties:
-              id:
-                type: string
-                description: ''
-              shippingAddress:
-                type: object
-                properties: {}
-                description: Deprecated - Use `address` instead.
-                deprecated: true
-              address:
-                title: Address Response
-                allOf:
-                  - title: Address Properties
-                    required:
-                      - countryCode
-                    type: object
-                    properties:
-                      firstName:
-                        type: string
-                        description: ''
-                      lastName:
-                        type: string
-                        description: ''
-                      email:
-                        type: string
-                        description: ''
-                      company:
-                        type: string
-                        description: ''
-                      address1:
-                        type: string
-                        description: ''
-                      address2:
-                        type: string
-                        description: ''
-                      city:
-                        type: string
-                        description: ''
-                      stateOrProvince:
-                        type: string
-                        description: Represents state or province.
-                      stateOrProvinceCode:
-                        type: string
-                        description: ''
-                      country: 
-                        type: string 
-                        description: Country name.
-                      countryCode:
-                        type: string
-                        description: 'ISO 3166-1 alpha-2 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
-                      postalCode:
-                        type: string
-                        description: ''
-                      phone:
-                        pattern: '^\+?[1-9]\d{1,14}(x\d{1-5})?$'
-                        type: string
-                        description: ''
-                      customFields:
-                        type: array
-                        description: ''
-                        items:
-                          title: CustomField
-                          type: object
-                          properties:
-                            fieldId:
-                              type: string
-                              description: ''
-                            fieldValue:
-                              type: string
-                              description: This can also be an array for fields that need to support list of values; for example, a set of checkboxes.
-                  - type: object
-                    properties:
-                      id:
-                        type: string
-                        description: ''
-              availableShippingOptions:
-                type: array
-                description: This is available only when "include=consignments.availableShippingOptions" is presented in the URL.
-                items:
-                  title: Shipping Option Entity
-                  allOf:
-                    - title: Selected Shipping Option
-                      type: object
-                      properties:
-                        additionalDescription: 
-                          type: string
-                        description:
-                          type: string
-                          description: Read only.
-                          readOnly: true
-                        id:
-                          type: string
-                          description: ''
-                        type:
-                          type: string
-                          description: 'Specified the type of shipping option. Flat rate, UPS, etc.,'
-                        imageUrl:
-                          type: string
-                          description: ''
-                        cost:
-                          type: number
-                          description: ''
-                          format: double
-                        transitTime:
-                          type: string
-                          description: An estimate of the arrival time.
-                    - type: object
-                      properties:
-                        isRecommended:
-                          type: boolean
-                          description: Is this shipping method the recommended shipping option or not.
-              selectedShippingOption:
-                title: Selected Shipping Option
-                type: object
-                properties:
-                  additionalDescription: 
-                    type: string
-                  description:
-                    type: string
-                    description: Read only.
-                    readOnly: true
-                  id:
-                    type: string
-                    description: ''
-                  type:
-                    type: string
-                    description: Specifies the type of shipping option; for example, flat rate, UPS, etc.
-                  imageUrl:
-                    type: string
-                    description: ''
-                  cost:
-                    type: number
-                    description: ''
-                    format: double
-                  transitTime:
-                    type: string
-                    description: An estimate of the arrival time.
-              couponDiscounts:
-                type: array
-                description: List of consignment discounts applied through coupons
-                items:
-                  title: Consignment Coupon Discount
-                  type: object
-                  properties:
-                    code:
-                      type: string
-                      description: Coupon code that applied this discount
-                    amount:
-                      type: number
-                      description: ''
-                      format: double
-              discounts:
-                type: array
-                description: List of consignment discounts applied through cart level discounts.
-                items:
-                  title: Consignment Discount
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                      description: Discount rule ID that applied this discount
-              shippingCost:
-                type: number
-                description: The shipping cost for this consignment.
-                format: double
-              handlingCost:
-                type: number
-                description: The handling cost of shipping for this consignment.
-                format: double
-              lineItemIds:
-                type: array
-                description: ''
-                items:
-                  type: string
-            description: ''
-        coupons:
-          type: array
-          description: Coupons applied at checkout level.
-          items:
-            $ref: '#/components/schemas/CheckoutCoupon'
-        customer: 
-          type: object
-          properties:
-            addresses: 
-              type: array
-              items:
-                type: object
-                properties: {}
-            customerGroup: 
-              type: object
-              properties:
-                id: 
-                  type: integer
-                  description: ID of the customer group.
-                name: 
-                  type: string
-                  description: Name of the customer group.
-            email: 
-              type: string
-              description: Customer email.
-            firstName:
-              type: string
-              description: Customer's first name.
-            fullName:
-              type: string
-              description: Customer's full name.
-            id:
-              type: integer
-              description: Customer ID.
-            isGuest: 
-              type: boolean 
-              description: Whether the shopper is a guest or a logged-in customer. 
-            lastName:
-              type: string
-              description: Customer's last name.
-            shouldEncourageSignIn:
-              type: boolean
-            storeCredit: 
-              type: number
-              description: The amount of store credit a customer has.
-        orderId:
-          type: string
-          description: ''
-        payments: 
-          type: array
-          items:
-            type: object
-            properties: {}
-        promotions: 
-          type: array
-          items: 
-            type: object 
-            properties: {}
-        shippingCostBeforeDiscount:
-          type: number
-          description: The shipping cost before discounts are applied.
-        shippingCostTotal:
-          type: number
-          description: Shipping cost before any discounts are applied.
-          format: float
-        shouldExecuteSpamCheck: 
-          type: boolean
-        giftWrappingCostTotal:
-          type: number
-          description: Gift wrapping for all items, including or excluding tax.
-        handlingCostTotal:
-          type: number
-          description: Handling cost for all consignments including or excluding tax.
-          format: float
-        taxTotal:
-          type: number
-          description: ''
-          format: float
-        taxes:
-          type: array
-          items:
-            type: object
-            properties:
-              name:
-                type: string
-                description: Name of the tax charged. This is either the system default or the custom name created for the tax.
-                example: Texas Taxes
-              amount:
-                type: number
-                description: Amount of the tax.
-                format: float
-                example: 1.12
-        subtotal:
-          type: number
-          description: Subtotal of the checkout before applying item-level discounts. Tax inclusive based on the store settings.
-          format: float
-        fees: 
-          type: array
-          items:
-            type: object
-            properties: {}
-        grandTotal:
-          type: number
-          description: The total payable amount, before applying any store credit or gift certificate.
-          format: float
-        giftCertificates:
-          type: array
-          description: Applied gift certificate (as a payment method).
-          items:
-            title: Gift Certificate
-            type: object
-            properties:
-              balance:
-                type: number
-                description: ''
-                format: double
-              code:
-                type: string
-                description: ''
-              purchaseDate:
-                type: string
-                description: ''
-                format: date
-              remaining:
-                type: number
-                description: ''
-                format: double
-              used:
-                type: number
-                description: ''
-                format: double
-            description: The values presented here are projections of how much we would be using out of an existing gift certificate.
-        createdTime:
-          type: string
-          description: Time when the cart was created.
-        updatedTime:
-          type: string
-          description: Time when the cart was last updated.
-        customerMessage:
-          type: string
-          description: Shopperʼs message provided as details for the order to be created from this cart.
-        outstandingBalance:
-          type: number
-          description: |
-            `grandTotal` subtract the store-credit amount
-        isStoreCreditApplied:
-          type: boolean
-          description: |
-            `true` value indicates StoreCredit has been applied.
-        version:
-          type: integer
-          description: The current version of the checkout.
       x-internal: false
     cartLineItemPut:
       title: cartLineItemPut
@@ -3829,7 +3046,7 @@ components:
           type: string
           description: Cart ID, provided after creating a cart with a POST.
           format: uuid
-        customer_id:
+        customerId:
           type: integer
           description: ID of the customer to which the cart belongs.
           format: int32
@@ -3863,7 +3080,7 @@ components:
           format: double
         discountAmount:
           type: number
-          description: Discounted amount.
+          description: Order-based discounted amount only - Excludes coupon discounts and product-based discounts.
           format: double
         cartAmount:
           type: number
@@ -3881,9 +3098,9 @@ components:
             title: Applied Discount
             type: object
             properties:
-              name:
-                type: string
-                description: The name provided by the merchant.
+              id:
+                type: integer
+                description: Discount ID.
               discountedAmount:
                 type: number
                 description: The discounted amount applied within a given context.
@@ -3900,210 +3117,13 @@ components:
               type: array
               description: ''
               items:
-                title: Item Physical
-                required:
-                  - quantity
-                type: object
-                properties:
-                  id:
-                    type: string
-                    description: The line-item ID.
-                  parentId:
-                    type: string
-                    description: The product is part of a bundle such as a product pick list, then the parentId or the main product ID will populate.
-                  variantId:
-                    type: integer
-                    description: ID of the variant.
-                  productId:
-                    type: integer
-                    description: ID of the product.
-                  sku:
-                    type: string
-                    description: SKU of the variant.
-                  name:
-                    type: string
-                    description: The itemʼs product name.
-                  url:
-                    type: string
-                    description: The product URL.
-                  quantity:
-                    type: number
-                    description: Quantity of this item.
-                    format: double
-                  isTaxable:
-                    type: boolean
-                    description: Whether the item is taxable.
-                  imageUrl:
-                    type: string
-                    description: A publicly-accessible URL for an image of this item.
-                  discounts:
-                    type: array
-                    description: A list of discounts applied to this item, as an array of AppliedDiscount objects.
-                    items:
-                      title: Applied Discount
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                          description: The name provided by the merchant.
-                        discountedAmount:
-                          type: number
-                          description: The discounted amount applied within a given context.
-                          format: double
-                  discountAmount:
-                    type: number
-                    description: The total value of all discounts applied to this item (excluding coupon).
-                    format: double
-                  couponAmount:
-                    type: number
-                    description: The total value of all coupons applied to this item.
-                    format: double
-                  listPrice:
-                    type: number
-                    description: The item’s list price, as quoted by the manufacturer or distributor.
-                    format: double
-                  salePrice:
-                    type: number
-                    description: The itemʼs price after all discounts are applied. The final price before tax calculation.
-                    format: double
-                  extendedListPrice:
-                    type: number
-                    description: The itemʼs list price multiplied by the quantity.
-                    format: double
-                  extendedSalePrice:
-                    type: number
-                    description: The itemʼs sale price multiplied by the quantity.
-                    format: double
-                  comparisonPrice:
-                    type: number
-                    description: The itemʼs comparison price
-                  extendedComparisonPrice:
-                    type: number
-                    description: The itemʼs comparison price multiplied by the quantity.
-                  type:
-                    type: string
-                    description: the product type - physical or digital
-                  addedByPromotion:
-                    type: boolean
-                    description: If the item was added automatically by a promotion, such as a coupon or buy one, get one.
-                  isShippingRequired:
-                    type: boolean
-                    description: Whether this item requires shipping to a physical address.
-                  isMutable:
-                    type: boolean
-                    description: ''
-                  giftWrapping:
-                    title: Gift Wrapping
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                        description: ''
-                      message:
-                        type: string
-                        description: ''
-                      amount:
-                        type: number
-                        description: ''
-                        format: double
+                $ref: '#/components/schemas/lineItemPhysicalDigital'
             digitalItems:
               type: array
               description: ''
               items:
-                title: Item Digital
-                required:
-                  - quantity
-                type: object
-                properties:
-                  id:
-                    type: string
-                    description: The line-item ID.
-                  parentId:
-                    type: string
-                    description: Bundled items will have their parentʼs item ID.
-                  variantId:
-                    type: number
-                    description: ID of the variant.
-                    format: double
-                  productId:
-                    type: number
-                    description: ID of the product.
-                    format: double
-                  sku:
-                    type: string
-                    description: SKU of the variant.
-                  name:
-                    type: string
-                    description: The itemʼs product name.
-                  url:
-                    type: string
-                    description: The product URL.
-                  quantity:
-                    type: number
-                    description: Quantity of this item.
-                    format: double
-                  isTaxable:
-                    type: boolean
-                    description: Whether the item is taxable.
-                  imageUrl:
-                    type: string
-                    description: A publicly-accessible URL for an image of this item.
-                  discounts:
-                    type: array
-                    description: A list of discounts applied to this item, as an array of AppliedDiscount objects.
-                    items:
-                      title: Applied Discount
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                          description: The name provided by the merchant.
-                        discountedAmount:
-                          type: number
-                          description: The discounted amount applied within a given context.
-                          format: double
-                  discountAmount:
-                    type: number
-                    description: The total value of all discounts applied to this item (excluding coupon).
-                    format: double
-                  couponAmount:
-                    type: number
-                    description: The total value of all coupons applied to this item.
-                    format: double
-                  listPrice:
-                    type: number
-                    description: The item’s list price, as quoted by the manufacturer or distributor.
-                    format: double
-                  salePrice:
-                    type: number
-                    description: The itemʼs price after all discounts are applied. The final price before tax calculation.
-                    format: double
-                  extendedListPrice:
-                    type: number
-                    description: The itemʼs list price multiplied by the quantity.
-                    format: double
-                  extendedSalePrice:
-                    type: number
-                    description: The itemʼs sale price multiplied by the quantity.
-                    format: double
-                  type:
-                    type: string
-                    description: The product type - physical or digital.
-                  isShippingRequired:
-                    type: boolean
-                    description: Whether this item requires shipping to a physical address.
-                  downloadFileUrls:
-                    type: array
-                    description: URLs to download all product files.
-                    items:
-                      type: string
-                  downloadPageUrl:
-                    type: string
-                    description: The URL for the combined downloads page.
-                  downloadSize:
-                    type: string
-                    description: 'Specifies the combined download size in human-readable style; for example, `30MB`.'
-            giftCertificate:
+                $ref: '#/components/schemas/lineItemPhysicalDigital'
+            giftCertificates:
               type: array
               description: ''
               items:
@@ -4187,37 +3207,169 @@ components:
         updatedTime:
           type: string
           description: Time when the cart was last updated.
+        locale:
+          type: string
+          description: Shopper's locale.
+          example: "en"
+        version:
+          type: integer 
+          description: Cart version.
       description: A cart contains a collection of items, prices, discounts, etc. It does not contain customer-related data.
       x-internal: false
+    lineItemPhysicalDigital: 
+      type: object
+      required:
+        - quantity
+      properties:
+        id:
+          type: string
+          description: The line-item ID.
+        categoryNames: 
+          type: array
+          items: 
+            type: string
+        parentId:
+          type: string
+          description: The product is part of a bundle such as a product pick list, then the parentId or the main product ID will populate.
+        variantId:
+          type: integer
+          description: ID of the variant.
+        productId:
+          type: integer
+          description: ID of the product.
+        sku:
+          type: string
+          description: SKU of the variant.
+        name:
+          type: string
+          description: The itemʼs product name.
+        url:
+          type: string
+          description: The product URL.
+        quantity:
+          type: number
+          description: Quantity of this item.
+          format: double
+        isTaxable:
+          type: boolean
+          description: Whether the item is taxable.
+        imageUrl:
+          type: string
+          description: A publicly-accessible URL for an image of this item.
+        discounts:
+          type: array
+          description: A list of discounts applied to this item, as an array of AppliedDiscount objects.
+          items:
+            title: Applied Discount
+            type: object
+            properties:
+              id:
+                type: integer
+                description: Discount ID.
+              discountedAmount:
+                type: number
+                description: The discounted amount applied within a given context.
+                format: double
+        discountAmount:
+          type: number
+          description: The total value of all discounts applied to this item (excluding coupon).
+          format: double
+        couponAmount:
+          type: number
+          description: The total value of all coupons applied to this item.
+          format: double
+        listPrice:
+          type: number
+          description: The item’s list price, as quoted by the manufacturer or distributor.
+          format: double
+        originalPrice:
+          type: number
+          description: The item’s original price is the same as the product’s default price.
+        salePrice:
+          type: number
+          description: The itemʼs price after all discounts are applied. The final price before tax calculation.
+          format: double
+        extendedListPrice:
+          type: number
+          description: The itemʼs list price multiplied by the quantity.
+          format: double
+        extendedSalePrice:
+          type: number
+          description: The itemʼs sale price multiplied by the quantity.
+          format: double
+        comparisonPrice:
+          type: number
+          description: The itemʼs comparison price
+        extendedComparisonPrice:
+          type: number
+          description: The itemʼs comparison price multiplied by the quantity.
+        options: 
+          type: array
+          items: 
+            type: object
+            properties:
+              name: 
+                type: string
+                description: Option name.
+              nameId:
+                type: integer
+                description: Option ID.
+              value: 
+                type: string
+                description: Option value.
+              valueId:
+                type: string
+                description: Option value ID.
+        type:
+          type: string
+          description: the product type - physical or digital
+        addedByPromotion:
+          type: boolean
+          description: If the item was added automatically by a promotion, such as a coupon or buy one, get one.
+        isShippingRequired:
+          type: boolean
+          description: Whether this item requires shipping to a physical address.
+        isMutable:
+          type: boolean
+          description: ''
+        giftWrapping:
+          title: Gift Wrapping
+          type: object
+          properties:
+            name:
+              type: string
+              description: ''
+            message:
+              type: string
+              description: ''
+            amount:
+              type: number
+              description: ''
+              format: double
     checkoutGiftCertificates:
       title: checkoutGiftCertificates
-      type: array
       description: Applied gift certificate (as a payment method).
-      items:
-        title: Gift Certificate
-        type: object
-        properties:
-          balance:
-            type: number
-            description: ''
-            format: double
-          code:
-            type: string
-            description: ''
-          purchaseDate:
-            type: string
-            description: ''
-            format: date
-          remaining:
-            type: number
-            description: ''
-            format: double
-          used:
-            type: number
-            description: ''
-            format: double
-        description: The values presented here are projections of how much we would be using out of an existent gift certificate
-      x-internal: false
+      type: object
+      properties:
+        balance:
+          type: number
+          description: ''
+          format: double
+        code:
+          type: string
+          description: ''
+        purchaseDate:
+          type: string
+          description: ''
+          format: date
+        remaining:
+          type: number
+          description: ''
+          format: double
+        used:
+          type: number
+          description: ''
+          format: double
     consignmentShippingOption_Base:
       title: consignmentShippingOption_Base
       type: object
@@ -4274,7 +3426,7 @@ components:
               cartAmount: 7.95
               coupons: []
               discounts:
-                - id: 243c9ca2-22b4-417a-8b09-b3fc05778b52
+                - id: 1
                   discountedAmount: 0
               lineItems:
                 physicalItems:

--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -648,45 +648,41 @@ components:
   examples:
     CheckoutResp:
       value:
-        id: b6fbd994-61a8-4f25-9167-6ec10489c448
         billingAddress:
-          id: 5ba11e4a10fb5
-          firstName: Jane
-          lastName: Doe
-          email: janedoe@example.com
-          company: ''
           address1: 123 Main Street
           address2: ''
           city: Austin
-          stateOrProvince: Texas
-          stateOrProvinceCode: TX
+          company: ''
           country: United States
           countryCode: US
-          postalCode: '78751'
-          phone: '1234567890'
           customFields:
             - fieldId: field_25
               fieldValue: Leave in backyard
-        channelId: 1
-        cart:
-          id: b6fbd994-61a8-4f25-9167-6ec10489c448
-          customerId: 11
           email: janedoe@example.com
-          currency:
-            name: US Dollars
-            code: USD
-            symbol: $
-            decimalPlaces: 2
-          isTaxIncluded: false
+          firstName: Jane
+          id: 5ba11e4a10fb5
+          lastName: Doe
+          phone: '1234567890'
+          postalCode: '78751'
+          stateOrProvince: Texas
+          stateOrProvinceCode: TX
+        cart:
           baseAmount: 119.93
-          discountAmount: 0
           cartAmount: 112.93
+          createdTime: '2018-09-18T15:48:26+00:00'
           coupons:
             - id: 1
               code: S2549JM0Y
               displayName: $5.00 off the order total
               couponType: per_total_discount
               discountedAmount: 5
+          currency:
+            name: US Dollars
+            code: USD
+            symbol: $
+            decimalPlaces: 2          
+          customerId: 11
+          discountAmount: 0
           discounts:
             - id: 1
               discountedAmount: 2.59
@@ -698,156 +694,210 @@ components:
               discountedAmount: 0.8
             - id: 5
               discountedAmount: 0.43
+          email: janedoe@example.com
+          id: b6fbd994-61a8-4f25-9167-6ec10489c448
+          isTaxIncluded: false
           lineItems:
-            physicalItems:
-              - id: 69791a88-85c9-4c19-8042-e537621e8a55
-                categoryNames: ["Essentials", "Just arrived"]
-                parentId: ''
-                variantId: 364
-                productId: 184
-                sku: SMA-RED
-                name: Canvas Laundry Cart
-                url: 'https://{store_domain}/all/canvas-laundry-cart/'
-                quantity: 1
+            physicalItems: 
+              - addedByPromotion: false
                 brand: OFS
-                isTaxable: true
-                imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/184/images/445/naturalcanvascart2_1024x1024__92347__29648.1534344533.330.500.jpg?c=2'
+                categoryNames: ["Essentials", "Just arrived"]
+                comparisonPrice: 0
+                couponAmount: 0
+                discountAmount: 2
                 discounts:
                   - id: 1
                     discountedAmount: 0.59
                   - id: 2
                     discountedAmount: 2
-                discountAmount: 2
-                couponAmount: 0
-                originalPrice: 17.99
-                listPrice: 15.99
-                salePrice: 13.99
-                comparisonPrice: 0
                 extendedComparisonPrice: 0
                 extendedListPrice: 15.99
                 extendedSalePrice: 13.99
+                giftWrapping: {}
+                id: 69791a88-85c9-4c19-8042-e537621e8a55
+                imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/184/images/445/naturalcanvascart2_1024x1024__92347__29648.1534344533.330.500.jpg?c=2'
                 isShippingRequired: true
+                isTaxable: true
+                listPrice: 15.99
+                name: Canvas Laundry Cart
                 options: 
                 - name: "Color"
                   nameId: 1
                   value: "Red" 
                   valueId: "2"
-                giftWrapping: {}
-                addedByPromotion: false
-              - id: ba2c619d-e6b4-48c2-8809-d88e424ed450
-                categoryNames: ["Essentials", "Just arrived"]
+                originalPrice: 17.99
+                productId: 184
                 parentId: ''
-                variantId: 341
-                productId: 170
-                sku: ''
-                name: Ceramic Measuring Spoons
-                url: 'https://{store_domain}/all/ceramic-measuring-spoons/'
                 quantity: 1
+                variantId: 364
+                salePrice: 13.99
+                sku: SMA-RED
+                url: 'https://{store_domain}/all/canvas-laundry-cart/'
+              - addedByPromotion: false
                 brand: OFS
-                isTaxable: true
-                imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/170/images/411/measuringsquares2_1024x1024__07108__95421.1534344522.330.500.jpg?c=2'
-                discounts:
-                  - id: 1
-                    discountedAmount: 1.06
-                discountAmount: 0
-                couponAmount: 0
-                originalPrice: 25
-                listPrice: 25
-                salePrice: 25
+                categoryNames: ["Essentials", "Just arrived"]
                 comparisonPrice: 0
                 extendedComparisonPrice: 0
                 extendedListPrice: 25
                 extendedSalePrice: 25
+                couponAmount: 0
+                discountAmount: 0
+                discounts:
+                  - id: 1
+                    discountedAmount: 1.06
+                id: ba2c619d-e6b4-48c2-8809-d88e424ed450
+                imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/170/images/411/measuringsquares2_1024x1024__07108__95421.1534344522.330.500.jpg?c=2'
                 isShippingRequired: true
+                isTaxable: true
+                listPrice: 25
+                name: Ceramic Measuring Spoons
+                originalPrice: 25
+                parentId: ''
+                productId: 170 
+                quantity: 1
+                salePrice: 25
+                sku: ''
+                url: 'https://{store_domain}/all/ceramic-measuring-spoons/'
+                variantId: 341                
                 options: 
                 - name: "Color"
                   nameId: 1
                   value: "Red" 
                   valueId: "2"
                 giftWrapping: {}
-                addedByPromotion: false
-              - id: c72d6651-978d-45e5-881b-c2bb5f7ff1d5
-                categoryNames: ["Essentials", "Just arrived"]
-                parentId: ''
-                variantId: 376
-                productId: 158
-                sku: SKU-A0C8A203
-                name: Chambray Towel
-                url: 'https://{store_domain}/all/chambray-towel/'
-                quantity: 1
+              - addedByPromotion: false
                 brand: OFS
-                isTaxable: true
-                imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/158/images/382/foglinenbeigestripetowel1b_1024x1024__83011__60806.1534344511.330.500.jpg?c=2'
+                categoryNames: ["Essentials", "Just arrived"]
+                comparisonPrice: 0
+                couponAmount: 0
+                discountAmount: 0
                 discounts:
                   - id: 1
                     discountedAmount: 2.12
-                discountAmount: 0
-                couponAmount: 0
-                originalPrice: 49.99
-                listPrice: 49.99
-                salePrice: 49.99
-                comparisonPrice: 0
                 extendedComparisonPrice: 0
                 extendedListPrice: 49.99
                 extendedSalePrice: 49.99
+                giftWrapping: {}
+                id: c72d6651-978d-45e5-881b-c2bb5f7ff1d5
+                imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/158/images/382/foglinenbeigestripetowel1b_1024x1024__83011__60806.1534344511.330.500.jpg?c=2'
                 isShippingRequired: true
+                isTaxable: true
+                listPrice: 49.99
+                name: Chambray Towel
                 options: 
                 - name: "Color"
                   nameId: 1
                   value: "Red" 
                   valueId: "2"
-                giftWrapping: {}
-                addedByPromotion: false
-            digitalItems:
-              - id: 6477a4a1-02cf-4287-8bf2-fd043bdd5234
-                categoryNames: ["Essentials", "Just arrived"]
+                originalPrice: 49.99
                 parentId: ''
-                variantId: 360
-                productId: 189
-                name: Gather Journal Issue 7 - Digital
-                url: 'https://{store_domain}/all/gather-journal-issue-7/'
+                productId: 158
+                salePrice: 49.99
+                sku: SKU-A0C8A203
                 quantity: 1
+                url: 'https://{store_domain}/all/chambray-towel/'
+                variantId: 376
+            digitalItems:
+              - addedByPromotion: false
                 brand: OFS
-                isTaxable: true
-                imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/189/images/465/gather_1024x1024__17195__82620.1534344540.330.500.jpg?c=2'
+                categoryNames: ["Essentials", "Just arrived"]
+                comparisonPrice: 0
+                couponAmount: 0
+                discountAmount: 0
                 discounts:
                   - id: 1
                     discountedAmount: 0.8
-                discountAmount: 0
-                couponAmount: 0
-                originalPrice: 18.95
-                listPrice: 18.95
-                salePrice: 18.95
-                comparisonPrice: 0
                 extendedComparisonPrice: 0
                 extendedListPrice: 18.95
                 extendedSalePrice: 18.95
+                id: 6477a4a1-02cf-4287-8bf2-fd043bdd5234
+                imageUrl: 'https://cdn8.bigcommerce.com/s-id30h7ohwf/products/189/images/465/gather_1024x1024__17195__82620.1534344540.330.500.jpg?c=2'
+                isShippingRequired: false
+                isTaxable: true
+                listPrice: 18.95
+                name: Gather Journal Issue 7 - Digital
                 options: 
                 - name: "Color"
                   nameId: 1
                   value: "Red" 
                   valueId: "2"
-                isShippingRequired: false
+                originalPrice: 18.95
+                parentId: ''
+                productId: 189
+                quantity: 1
+                salePrice: 18.95
                 type: digital
+                variantId: 360
+                url: 'https://{store_domain}/all/gather-journal-issue-7/'        
             giftCertificates:
-              - id: 871f1f56-4c88-43c3-a6e5-0a647d83d6ac
+              - amount: 10
+                id: 871f1f56-4c88-43c3-a6e5-0a647d83d6ac
+                message: Thank you!
                 name: $10.00 Gift Certificate
-                theme: Celebration
-                amount: 10
-                taxable: false
-                sender:
-                  name: Jane Doe
-                  email: janedoe@example.com
                 recipient:
                   name: John Doe
                   email: johndoe@example.com
-                message: Thank you!
+                sender:
+                  name: Jane Doe
+                  email: janedoe@example.com
+                taxable: false
+                theme: Celebration
                 type: giftCertificate
             customItems: []
-          createdTime: '2018-09-18T15:48:26+00:00'
-          updatedTime: '2018-09-18T16:59:45+00:00'
           locale: "en"
+          updatedTime: '2018-09-18T16:59:45+00:00'
           version: 1
+        channelId: 1
+        createdTime: '2018-09-18T15:48:26+00:00'
+        consignments:
+          - address:
+              address1: 123 Main Street
+              address2: ''
+              city: Austin
+              company: ''
+              country: United States
+              countryCode: US
+              customFields:
+                - fieldId: field_25
+                  fieldValue: Leave in backyard
+              email: janedoe@example.com
+              firstName: Jane
+              lastName: Doe
+              phone: '1234567890'
+              postalCode: '78751'
+              stateOrProvince: Texas
+              stateOrProvinceCode: TX
+            availableShippingOptions:
+            - additionalDescription: Fragile items
+              cost: 8
+              description: Ship by Weight
+              id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
+              imageUrl: ''
+              transitTime: '' 
+              type: shipping_byweight       
+            couponDiscounts: []
+            discounts: []
+            handlingCost: 0
+            id: 5ba121929619b
+            lineItemIds:
+              - 69791a88-85c9-4c19-8042-e537621e8a55
+              - ba2c619d-e6b4-48c2-8809-d88e424ed450
+              - c72d6651-978d-45e5-881b-c2bb5f7ff1d5
+            selectedShippingOption:
+              additionalDescription: Fragile items
+              id: bb3c818f-17ce-46fe-9475-65933095da0d
+              type: shipping_upsready
+              description: UPS® (UPS Next Day Air®)
+              imageUrl: ''
+              cost: 69.94
+              transitTime: 1 business day
+            shippingCost: 69.94
+        coupons:
+          - code: S2549JM0Y
+            couponType: 2
+            discountedAmount: 5
+            displayName: $5.00 off the order total
+            id: 1
         customer: 
           addresses: [{}]
           customerGroup:
@@ -862,76 +912,30 @@ components:
           shouldEncourageSignIn: false 
           storeCredit: 1.00
         customerMessage: 'Thank you, BigCommerce'
-        consignments:
-          - id: 5ba121929619b
-            shippingCost: 69.94
-            handlingCost: 0
-            couponDiscounts: []
-            discounts: []
-            lineItemIds:
-              - 69791a88-85c9-4c19-8042-e537621e8a55
-              - ba2c619d-e6b4-48c2-8809-d88e424ed450
-              - c72d6651-978d-45e5-881b-c2bb5f7ff1d5
-            availableShippingOptions:
-            - id: d09e05c0-3788-44df-a1bb-b6d3afdf6841
-              type: shipping_byweight
-              description: Ship by Weight
-              additionalDescription: Fragile items
-              imageUrl: ''
-              cost: 8
-              transitTime: ''
-            selectedShippingOption:
-              additionalDescription: Fragile items
-              id: bb3c818f-17ce-46fe-9475-65933095da0d
-              type: shipping_upsready
-              description: UPS® (UPS Next Day Air®)
-              imageUrl: ''
-              cost: 69.94
-              transitTime: 1 business day
-            address:
-              firstName: Jane
-              lastName: Doe
-              email: janedoe@example.com
-              company: ''
-              address1: 123 Main Street
-              address2: ''
-              city: Austin
-              stateOrProvince: Texas
-              stateOrProvinceCode: TX
-              country: United States
-              countryCode: US
-              postalCode: '78751'
-              phone: '1234567890'
-              customFields:
-                - fieldId: field_25
-                  fieldValue: Leave in backyard
         fees: []
-        payments: [{}]
-        promotions: []
-        orderId: null
-        shippingCostTotal: 69.94
-        shippingCostBeforeDiscount: 69.94
-        shouldExecuteSpamCheck: false
-        handlingCostTotal: 0
-        taxTotal: 28.62
-        coupons:
-          - id: 1
-            code: S2549JM0Y
-            displayName: $5.00 off the order total
-            couponType: 2
-            discountedAmount: 5
-        taxes:
-          - name: Store Tax
-            amount: 28.62
-        subtotal: 117.93
-        grandTotal: 211.49
         giftCertificates:
         - balance: 4.00
           code: '1234ABC'
           purchaseDate: "string"
           remaining: 2.00
           used: 5.00
-        createdTime: '2018-09-18T15:48:26+00:00'
+        giftWrappingCostTotal: 0
+        grandTotal: 211.49
+        handlingCostTotal: 0
+        id: b6fbd994-61a8-4f25-9167-6ec10489c448
+        isStoreCreditApplied: false
+        orderId: null
+        outstandingBalance: 0
+        payments: [{}]
+        promotions: []
+        shippingCostBeforeDiscount: 69.94
+        shippingCostTotal: 69.94
+        shouldExecuteSpamCheck: false
+        subtotal: 117.93
+        taxTotal: 28.62
+        taxes:
+          - name: Store Tax
+            amount: 28.62
         updatedTime: '2018-09-18T16:59:45+00:00'
         version: 1
   schemas:

--- a/reference/inventory.v3.yml
+++ b/reference/inventory.v3.yml
@@ -590,6 +590,9 @@ components:
               type: integer
               description: ID of product.
               example: 120
+            sku_id: 
+              type: integer
+              description: Read-only reference to Catalog V2 API's SKU ID. `null` if the item is a base variant.
         locations:
           type: array
           items:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6025]

Relevant slack conversation https://bigcommerce.slack.com/archives/C0WC9CSJX/p1724366031941559

## What changed?
Update schema for Storefront API's Checkout endpoints
- added in missing fields (see the above slack conversation)
- updated the examples to use those fields

The all the endpoints for Storefront Checkout have the same response (now reference the same response & example)

## Release notes draft
Updated the schema for the Storefront Checkout endpoints

## Anything else?



[DEVDOCS-6025]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ