### PR TITLE
Update references in B2B API overview to point to DevCenter references

### DIFF
--- a/docs/b2b-edition/about/index.mdx
+++ b/docs/b2b-edition/about/index.mdx
@@ -7,24 +7,20 @@ Make BigCommerce B2B Edition API requests in the context of the storefront or se
 | API | Base URL |
 |:--|:--|
 | GraphQL Storefront API | `https://api-b2b.bigcommerce.com/graphql` |
-| REST Storefront API | See [endpoint reference](https://bundleb2b.stoplight.io/docs/openapi/rest-storefront/catalog) |
+| REST Storefront API | See [endpoint reference](https://developer.bigcommerce.com/b2b-edition/apis/rest-storefront/auth) |
 | REST Management V3 | `https://api-b2b.bigcommerce.com/api/v3/io/`|
 | REST Management V2 | `https://api-b2b.bigcommerce.com/api/v2/io/`|
-
-<Callout type="info">
-  Note: some B2B Edition APIs rely on BigCommerce APIs, so there may be latency in data synchronization.
-</Callout>
 
 ## Key resources
 
 | Resource | Description |
 |:--|:--|
-| [Company](https://bundleb2b.stoplight.io/docs/openapi/rest-management/company/operations/create-a-company#request-body) | Set client company info, administrator, and more. |
-| [Address](https://bundleb2b.stoplight.io/docs/openapi/rest-management/address/operations/list-addresses#response-body) | Associate one or more addresses with a company. |
-| [Order](https://bundleb2b.stoplight.io/docs/openapi/rest-management/orders/operations/get-a-order#response-body) | Extend the BigCommerce order object with B2B-specific information, such as purchase order number. |
-| [Payment](https://bundleb2b.stoplight.io/docs/openapi/rest-management/payment/operations/list-company-payments#response-body) | Manage company payment methods. |
-| [Sales staff](https://bundleb2b.stoplight.io/docs/openapi/rest-management/sales-staff/schemas/sales-staff) and [super admin](https://bundleb2b.stoplight.io/docs/openapi/rest-management/super-admin/operations/list-company-super-admins#response-body) | Manage sales staff and admin access privileges. |
-| [Quote](https://bundleb2b.stoplight.io/docs/openapi/rest-management/quote) | Manage quotes. |
+| [Company](https://developer.bigcommerce.com/b2b-edition/apis/rest-management/v3/company#create-a-company) | Set client company info, administrator, and more. |
+| [Address](https://developer.bigcommerce.com/b2b-edition/apis/rest-management/v3/address#get-an-address) | Associate one or more addresses with a company. |
+| [Order](https://developer.bigcommerce.com/b2b-edition/apis/rest-management/v3/orders/order#get-an-order) | Extend the BigCommerce order object with B2B-specific information, such as purchase order number. |
+| [Payment](https://developer.bigcommerce.com/b2b-edition/apis/rest-management/v3/payment#update-company-payments) | Manage company payment methods. |
+| [Sales staff](https://developer.bigcommerce.com/b2b-edition/apis/rest-management/v3/sales-staff#update-a-sales-staff) and [super admin](https://developer.bigcommerce.com/b2b-edition/apis/rest-management/v3/super-admin#update-company-&-super-admins-relationship) | Manage sales staff and admin access privileges. |
+| [Quote](https://developer.bigcommerce.com/b2b-edition/apis/rest-management/v3/quote#get-quote-form-list) | Manage quotes. |
 | [Proxy](https://bundleb2b.stoplight.io/docs/openapi/rest-management/v2/operations/create-a-proxy) | Create a third-party proxy. |
 
 ## Request headers
@@ -43,9 +39,3 @@ Use the `limit` and `offset` query parameters together to paginate responses.
 The `limit` value determines the number of records to return per page. The `offset` value is the number of results to skip before returning the first result.
 
 For example, passing the following query param string returns the 11th through 20th results: `offset=10&limit=10`.
-
-## Why do some API endpoints reference BundleB2B?
-
-BundleB2B was a purpose-built application that powered BigCommerce's original B2B Edition offering.
-
-In 2021, BigCommerce acquired BundleB2B. Since that time, we've been integrating the BundleB2B API and features into our core product offerings. We continue to use the BundleB2B domain to prevent breaking changes for existing integrations. Our roadmap includes plans to use a new core BigCommerce domain to host our B2B Edition APIs. `{*Does this need updating?*}`


### PR DESCRIPTION
## What changed?
* Updated links in the B2B overview section to point to developer center docs instead of Stoplight.
* Removed out of date blurb about Bundle B2B endpoints being seen, since we've already moved them to sit within a bigcommerce.com endpoint

## Release notes draft
* B2B Edition's API reference documentation has now been moved into our Developer Center, to provide a faster, more consistent experience for developers creating future B2B experiences. If you run into anything that can be improved, let us know!

ping @bigcommerce/dev-docs 
