### PR TITLE
DEVDOCS-6025: SF Form Fields, add requirements field for password field

### DIFF
--- a/reference/form_fields.sf.yml
+++ b/reference/form_fields.sf.yml
@@ -123,10 +123,29 @@ components:
           description: The minimum valid value for the field (integer and date type only).
         maxLength:
           type: integer
-          description: The maximum length for the value (string type only)
+          description: The maximum length for the value (string type only).
         secret:
           type: boolean
-          description: Whether the field represents a password field
+          description: Whether the field represents a password field (password field type only).
+        requirements: 
+          type: object
+          description: Password requirements (password field type only).  
+          properties:
+            alpha: 
+              type: string
+              description: Regex expression for the required alpha characters.
+              example: '[A-Za-z]'
+            description:
+              type: string 
+              description: Description for the password requirements. 
+              example: Passwords must be at least 7 characters and contain both alphabetic and numeric characters. 
+            minlength: 
+              type: integer 
+              description: Minimum password length. 
+            numeric: 
+              type: string
+              description: Regex expression for the required numeric characters.
+              example: '[0-9]'
         options:
           type: object
           properties:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6025]

Relevant slack conversation https://bigcommerce.slack.com/archives/C9LNQDWKX/p1724860197700219

## What changed?
<!-- Provide a bulleted list in the present tense -->
*  add `requirements` field for password field types

## Release notes draft
Updated Storefront Form Fields API Spec

## Anything else?


[DEVDOCS-6025]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ