### PR TITLE
doc(customers): CUST-3450 Add account created notification to v3 customers POST endpoint

### DIFF
--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -3451,7 +3451,7 @@ components:
             $ref: "#/components/schemas/formFieldValue"    
         trigger_account_created_notification:
           type: boolean
-          description: Send a customer registered welcome email    
+          description: Indicates whether to send a customer registered welcome email.
       required:
         - email
         - first_name

--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -275,6 +275,7 @@ paths:
                       force_password_reset: true
                       new_password: string123
                     accepts_product_review_abandoned_cart_emails: true
+                    trigger_account_created_notification: true
                     store_credit_amounts:
                       - amount: 43.15
                     origin_channel_id: 1
@@ -3448,6 +3449,9 @@ components:
             Array of form fields. Controlled by formfields parameter.
           items:
             $ref: "#/components/schemas/formFieldValue"    
+        trigger_account_created_notification:
+          type: boolean
+          description: Send a customer registered welcome email    
       required:
         - email
         - first_name


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [CUST-3450]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Addition of `trigger_account_created_notification` as a request parameter for Customer [POST](https://developer.bigcommerce.com/docs/rest-management/customers#create-customers)


## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature. -->
* Addition of `trigger_account_created_notification` as a request parameter for Customer [POST](https://developer.bigcommerce.com/docs/rest-management/customers#create-customers)

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->
https://bigcommercecloud.atlassian.net/browse/PROJECT-6641

ping @bc-tgomez @bigcommerce/team-customers 

[CUST-3450]: https://bigcommercecloud.atlassian.net/browse/CUST-3450
