### PR TITLE
DEVDOCS-6025 [update]: Order Transactions, remove duplicate field

### DIFF
--- a/reference/orders.v3.yml
+++ b/reference/orders.v3.yml
@@ -1783,11 +1783,6 @@ components:
               description: |
                 The transaction ID returned by the payment gateway for this transaction item.
               type: string
-            date_created:
-              description: |
-                The date/time of the transaction.
-              type: string
-              format: date-time
             test:
               type: boolean
               description: |


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6025]



## What changed?

There were 2 `date_created` fields in the response ([line 1786](https://github.com/bigcommerce/docs/pull/479/files#diff-9ead9bf906bd7b06c5133a2a772bc9c0495649ea31de58edf24e9ce085fb6569L1786) & [line 1845](https://github.com/bigcommerce/docs/pull/479/files#diff-9ead9bf906bd7b06c5133a2a772bc9c0495649ea31de58edf24e9ce085fb6569R1845)). Line 1845 has a better description, so this PR removes line 1786. 


## Release notes draft
N / A

## Anything else?
Continuation of [PR 453](https://github.com/bigcommerce/docs/pull/453) where the description for `date_created` was changed


[DEVDOCS-6025]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ