### PR TITLE
Add infrastructure_region to V2 Store API

### DIFF
--- a/reference/store_information.v2.yml
+++ b/reference/store_information.v2.yml
@@ -204,6 +204,10 @@ components:
           type: string
           example: AU
           description: Two-letter ISO 3166-1 country code
+        infrastructure_region:
+          type: string
+          example: us-central1
+          description: The infrastructure region where the store is located. Use this to determine where to place supporting infrastructure for minimum latency to the store. Compare against GCP regions on https://cloud.google.com/compute/docs/regions-zones
         phone:
           description: Display phone number.
           type: string


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6100](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6100)


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Added infrastructure_region to V2 Store API

## Release notes draft
The Store Information API now includes the `infrastructure_region` of the store so you can determine where the store is hosted geographically. This is helpful when you are deploying supporting infrastructure for the store so you can deploy it nearby (or in the same GCP region) to minimize latency.
## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @bc-traciporter 


[DEVDOCS-6100]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ