### PR TITLE
Update babel dependency in stencil react foundation doc

### DIFF
--- a/docs/storefront/stencil/themes/foundations/react.mdx
+++ b/docs/storefront/stencil/themes/foundations/react.mdx
@@ -35,7 +35,7 @@ Navigate into the root Cornerstone theme folder, then install the following npm 
 cd ~/path/to/theme/dir
 
 # install dependencies
-npm install --save-dev @material-ui/core react react-dom babel-plugin-transform-object-assign @babel/preset-react
+npm install --save-dev @material-ui/core react react-dom @babel/plugin-transform-object-assign @babel/preset-react
 ```
 
 ### Update webpack.common.js
@@ -46,7 +46,7 @@ Update` webpack.common.js` with the new presets and plugins.
 ...
 plugins: [
   ...
-   'transform-object-assign',
+   '@babel/plugin-transform-object-assign',
  ],
 ```
 


### PR DESCRIPTION
## What changed?
* Updated the Babel plugin dependency that's recommended in the React foundation doc for Stencil, since it has moved into a new package since the doc was original created

## Release notes draft
* Stencil React foundation doc has been updated to work with the latest Babel plugin packages. Now the guidance works for React 18.
