### PR TITLE
DEVDOCS-6098: [update] added_by_promotion field

### DIFF
--- a/reference/carts.v3.yml
+++ b/reference/carts.v3.yml
@@ -2245,6 +2245,10 @@ components:
               type: boolean
               example: true
               description: Whether or not you can change or remove the item from the cart. Items that are immutable include those added automatically by promotions.
+            added_by_promotion:
+              type: boolean
+              example: false
+              description: Whether or not a promotion added an additional item.
             download_file_urls:
               description: URLs to download all product files.
               type: array
@@ -3288,6 +3292,10 @@ components:
               type: boolean
               example: true
               description: Whether or not you can change or remove the item from the cart. Items that are immutable include those added automatically by promotions.
+            added_by_promotion:
+              type: boolean
+              example: false
+              description: Whether or not a promotion added an additional item.
             gift_wrapping:
               description: The gift wrapping details for this item.
               type: object

--- a/reference/checkouts.v3.yml
+++ b/reference/checkouts.v3.yml
@@ -8178,6 +8178,10 @@ components:
                       is_mutable:
                         type: boolean
                         description: ''
+                      added_by_promotion:
+                        type: boolean
+                        example: false
+                        description: Whether or not a promotion added an additional item.
                       parent_id:
                         type: number
                         description: ''
@@ -8244,6 +8248,10 @@ components:
                       is_require_shipping:
                         type: boolean
                         description: ''
+                      added_by_promotion:
+                        type: boolean
+                        example: false
+                        description: Whether or not a promotion added an additional item.
                       is_taxable:
                         type: boolean
                         description: ''


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6098]


## What changed?
Added new field to physical and digital products. (added_by_promotion)

## Release notes draft

We recently exposed the added_by_promotion field in the v3 cart and checkout endpoints. 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6098]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ