### PR TITLE
DEVDOCS-6099 [new]: Channel Menus, add localization into protected UI section

### DIFF
--- a/docs/integrations/channels/guide/storefronts.mdx
+++ b/docs/integrations/channels/guide/storefronts.mdx
@@ -99,6 +99,7 @@ BigCommerce allows the developer to toggle the location and scope of the followi
 | Domains | `domains` | Renders channel-specific domain settings. |
 | Notifications | `notifications` | Renders channel-specific notification settings. |
 | Social | `social` | Renders channel-specific social media settings. |
+| Localization | `localization` | Renders channel-specific localization settings. |
 
 The term _protected section_ refers to the settings on the corresponding menu pages. Settings in protected sections override the default settings configured at the storewide level. Include these protected sections in requests to the [Create channel menus](/docs/rest-management/channels/channel-menus#create-channel-menus) endpoint to display BigCommerce-provided, channel-specific settings pages and corresponding menu items. Enabled protected sections precede custom sections in a channel's menu.
 

--- a/reference/channels.v3.yml
+++ b/reference/channels.v3.yml
@@ -3504,6 +3504,7 @@ components:
           - domains
           - currencies
           - notifications
+          - localization
     channel_menus_Post:
       type: object
       properties:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6099]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Add `localization` to protected UI section (Channel Menus endpoint)

## Release notes draft

We're happy to announce that `localization` settings are now a [protected UI section](https://developer.bigcommerce.com/docs/integrations/channels/guide/storefronts#protected-ui-sections) when you [create a channel menu](https://developer.bigcommerce.com/docs/rest-management/channels/menus#create-channel-menus).

## Anything else?
@bigcommerce/team-multi-storefront 

[DEVDOCS-6099]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ