### PR TITLE
Clarify the role of is_fallback in shipping methods API

### DIFF
--- a/reference/shipping.v2.yml
+++ b/reference/shipping.v2.yml
@@ -2334,7 +2334,7 @@ components:
                   description: Percentage handling fee applied to shipping cost.
                   example: 0
         is_fallback:
-          description: Whether or not this shipping zone is the fallback if all others are not valid for the order.
+          description: Whether or not this shipping method is a fallback method used when advanced shipping rules are unavailable.
           example: false
           type: boolean
     ShippingResponse:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
is_fallback is used when advanced shipping rules (ShipperHQ) is unavailable. This change clarifies the role of fallback shipping methods.

## What changed?
<!-- Provide a bulleted list in the present tense -->
* Update the documentation of the is_fallback property of shipping methods

## Release notes draft

The meaning of the is_fallback property of shipping methods has been clarified.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

