### PR TITLE
DEVDOCS-5966: [update] correct contentType

### DIFF
--- a/reference/catalog/brands_catalog.v3.yml
+++ b/reference/catalog/brands_catalog.v3.yml
@@ -1320,8 +1320,6 @@ paths:
 
         Only one image at a time can be created. To update a brand image, use the [Update a brand](/docs/rest-catalog/brands#update-a-brand) endpoint and an `image_url`.
       operationId: createBrandImage
-      parameters:
-        - $ref: '#/components/parameters/MultipartContentType'
       requestBody:
         content:
           multipart/form-data:
@@ -2658,14 +2656,6 @@ components:
       schema:
         type: string
         default: 'application/json'
-    MultipartContentType:
-      name: Content-Type
-      in: header
-      required: true
-      description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body.'
-      schema:
-        type: string
-        default: 'mutipart/form-data'
   responses:
     Error:
       description: ''

--- a/reference/catalog/brands_catalog.v3.yml
+++ b/reference/catalog/brands_catalog.v3.yml
@@ -1321,7 +1321,7 @@ paths:
         Only one image at a time can be created. To update a brand image, use the [Update a brand](/docs/rest-catalog/brands#update-a-brand) endpoint and an `image_url`.
       operationId: createBrandImage
       parameters:
-        - $ref: '#/components/parameters/ContentType'
+        - $ref: '#/components/parameters/MultipartContentType'
       requestBody:
         content:
           multipart/form-data:
@@ -2658,6 +2658,14 @@ components:
       schema:
         type: string
         default: 'application/json'
+    MultipartContentType:
+      name: Content-Type
+      in: header
+      required: true
+      description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body.'
+      schema:
+        type: string
+        default: 'mutipart/form-data'
   responses:
     Error:
       description: ''

--- a/reference/catalog/categories_catalog.v3.yml
+++ b/reference/catalog/categories_catalog.v3.yml
@@ -1298,7 +1298,7 @@ paths:
         To update a *Category Image*, use the [Update categories](/docs/rest-catalog/category-trees/categories#update-categories) endpoint and an `image_url`.
       operationId: createCategoryImage
       parameters:
-        - $ref: '#/components/parameters/ContentType'
+        - $ref: '#/components/parameters/MultipartContentType'
       requestBody:
         content:
           multipart/form-data:
@@ -2710,6 +2710,14 @@ components:
       schema:
         type: string
         default: 'application/json'
+    MultipartContentType:
+      name: Content-Type
+      in: header
+      required: true
+      description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body.'
+      schema:
+        type: string
+        default: 'mutipart/form-data'
     ContentType:
       name: Content-Type
       in: header

--- a/reference/catalog/categories_catalog.v3.yml
+++ b/reference/catalog/categories_catalog.v3.yml
@@ -1297,8 +1297,6 @@ paths:
         Limit image size to `8MB`.
         To update a *Category Image*, use the [Update categories](/docs/rest-catalog/category-trees/categories#update-categories) endpoint and an `image_url`.
       operationId: createCategoryImage
-      parameters:
-        - $ref: '#/components/parameters/MultipartContentType'
       requestBody:
         content:
           multipart/form-data:
@@ -2710,14 +2708,6 @@ components:
       schema:
         type: string
         default: 'application/json'
-    MultipartContentType:
-      name: Content-Type
-      in: header
-      required: true
-      description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body.'
-      schema:
-        type: string
-        default: 'mutipart/form-data'
     ContentType:
       name: Content-Type
       in: header

--- a/reference/catalog/product-modifiers_catalog.v3.yml
+++ b/reference/catalog/product-modifiers_catalog.v3.yml
@@ -1623,8 +1623,6 @@ paths:
          **Required Fields**
         - image_file: Form posts are the only accepted upload option.
       operationId: createProductModifierImage
-      parameters:
-        - $ref: '#/components/parameters/MultipartContentType'
       requestBody:
         content:
           multipart/form-data:
@@ -2187,14 +2185,6 @@ components:
       schema:
         type: string
         default: 'application/json'
-    MultipartContentType:
-      name: Content-Type
-      in: header
-      required: true
-      description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body.'
-      schema:
-        type: string
-        default: 'mutipart/form-data'
     PageParam:
       name: page
       description: |

--- a/reference/catalog/product-modifiers_catalog.v3.yml
+++ b/reference/catalog/product-modifiers_catalog.v3.yml
@@ -1624,7 +1624,7 @@ paths:
         - image_file: Form posts are the only accepted upload option.
       operationId: createProductModifierImage
       parameters:
-        - $ref: '#/components/parameters/ContentType'
+        - $ref: '#/components/parameters/MultipartContentType'
       requestBody:
         content:
           multipart/form-data:
@@ -2187,6 +2187,14 @@ components:
       schema:
         type: string
         default: 'application/json'
+    MultipartContentType:
+      name: Content-Type
+      in: header
+      required: true
+      description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body.'
+      schema:
+        type: string
+        default: 'mutipart/form-data'
     PageParam:
       name: page
       description: |

--- a/reference/catalog/product-variants_catalog.v3.yml
+++ b/reference/catalog/product-variants_catalog.v3.yml
@@ -887,7 +887,7 @@ paths:
         - image_url: Any publicly available URL
       operationId: createProductVariantImage
       parameters:
-        - $ref: '#/components/parameters/ContentType'
+        - $ref: '#/components/parameters/MultipartContentType'
       requestBody:
         content:
           application/json:
@@ -2991,6 +2991,14 @@ components:
       schema:
         type: string
         default: 'application/json'
+    MultipartContentType:
+      name: Content-Type
+      in: header
+      required: true
+      description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body.'
+      schema:
+        type: string
+        default: 'mutipart/form-data'
     PageParam:
       name: page
       description: |

--- a/reference/catalog/product-variants_catalog.v3.yml
+++ b/reference/catalog/product-variants_catalog.v3.yml
@@ -886,8 +886,6 @@ paths:
         - image_file: Form posts. Files larger than 1 MB are not accepted
         - image_url: Any publicly available URL
       operationId: createProductVariantImage
-      parameters:
-        - $ref: '#/components/parameters/MultipartContentType'
       requestBody:
         content:
           application/json:
@@ -2991,14 +2989,6 @@ components:
       schema:
         type: string
         default: 'application/json'
-    MultipartContentType:
-      name: Content-Type
-      in: header
-      required: true
-      description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body.'
-      schema:
-        type: string
-        default: 'mutipart/form-data'
     PageParam:
       name: page
       description: |

--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -1285,7 +1285,7 @@ paths:
         - Each image file or image uploaded by URL can be up to 8 MB.
       operationId: createProductImage
       parameters:
-        - $ref: '#/components/parameters/ContentType'
+        - $ref: '#/components/parameters/MultipartContentType'
       requestBody:
         content:
           application/json:
@@ -8801,6 +8801,14 @@ components:
       schema:
         type: string
         default: 'application/json'
+    MultipartContentType:
+      name: Content-Type
+      in: header
+      required: true
+      description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body.'
+      schema:
+        type: string
+        default: 'mutipart/form-data'
     PageParam:
       name: page
       description: |

--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -1277,7 +1277,7 @@ paths:
 
         **Usage Notes**
         - `image_url` - `255` character limit
-        - `Content-Type` - For `image_file`, use the `multipart/form-data` media type. For `image_url`, use the application/json type. See [Adding product images](/docs/store-operations/catalog#adding-product-images) for more information.
+        - `Content-Type` - For `image_file`, use the `multipart/form-data` media type. For `image_url`, use the `application/json` type. See [Adding product images](/docs/store-operations/catalog#adding-product-images) for more information.
         - You can create only one image at a time. A product can have up to 1000 images.
         - Supported image file types are BMP, GIF, JPEG, PNG, WBMP, XBM, and WEBP.
         - Each image file or image uploaded by URL can be up to 8 MB.

--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -1279,13 +1279,19 @@ paths:
 
         **Usage Notes**
         - `image_url` - `255` character limit
-        - For file uploads, use the `multipart/form-data` media type. See [Adding product images](/docs/store-operations/catalog#adding-product-images) for more information.
+        - `Content-Type` - For `image_file`, use the `multipart/form-data` media type. For `image_url`, use the application/json type. See [Adding product images](/docs/store-operations/catalog#adding-product-images) for more information.
         - You can create only one image at a time. A product can have up to 1000 images.
         - Supported image file types are BMP, GIF, JPEG, PNG, WBMP, XBM, and WEBP.
         - Each image file or image uploaded by URL can be up to 8 MB.
       operationId: createProductImage
       parameters:
-        - $ref: '#/components/parameters/MultipartContentType'
+        name: Content-Type
+        in: header
+        required: true
+        description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body.'
+        schema:
+          type: string
+          enum: [application/json, multipart/form-data]
       requestBody:
         content:
           application/json:
@@ -8802,7 +8808,7 @@ components:
         type: string
         default: 'application/json'
     MultipartContentType:
-      name: Content-Type
+      name: MultipartContent-Type
       in: header
       required: true
       description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body.'

--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -1285,7 +1285,7 @@ paths:
         - Each image file or image uploaded by URL can be up to 8 MB.
       operationId: createProductImage
       parameters:
-        name: Content-Type
+      - name: Content-Type
         in: header
         required: true
         description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body.'

--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -1282,14 +1282,6 @@ paths:
         - Supported image file types are BMP, GIF, JPEG, PNG, WBMP, XBM, and WEBP.
         - Each image file or image uploaded by URL can be up to 8 MB.
       operationId: createProductImage
-      parameters:
-      - name: Content-Type
-        in: header
-        required: true
-        description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body.'
-        schema:
-          type: string
-          enum: [application/json, multipart/form-data]
       requestBody:
         content:
           application/json:
@@ -8787,14 +8779,6 @@ components:
       schema:
         type: string
         default: 'application/json'
-    MultipartContentType:
-      name: MultipartContent-Type
-      in: header
-      required: true
-      description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body.'
-      schema:
-        type: string
-        default: 'mutipart/form-data'
     PageParam:
       name: page
       description: |


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-5966]


## What changed?
Added new contentType for the image endpoints

## Release notes draft

Bug Fix: corrected invalid Content-Type for image upload endpoints

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-5966]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ