### PR TITLE
DEVDOCS-6042: [update] add deprecated tag

### DIFF
--- a/docs/storefront/stencil/themes/context/object-reference/schemas/settings.yml
+++ b/docs/storefront/stencil/themes/context/object-reference/schemas/settings.yml
@@ -43,6 +43,7 @@ properties:
   client_ip_address:
     type: string
     description: IP address of the customer browsing the storefront.
+    deprecated: true
   country_code:
     type: string
     description: The country code corresponding to the IP.
@@ -154,6 +155,7 @@ properties:
   region_code:
     type: string
     description: The [ISO-3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) code is an international standard denomination for country subdivisions. The first part is the country's ISO 3166-1 alpha-2 code, and the second part is a string of up to three alphanumeric characters representing the country's subdivision (province or state). For example, Texas's ISO 3166-2 code is US-TX; therefore, the region code is TX.
+    deprecated: true
   request:
     type: object
     description: Object that contains details about the HTTP request.
@@ -167,6 +169,7 @@ properties:
       is_crawler:
         type: boolean
         description: Renders `true` if user agent is known crawler; otherwise, `false`.
+        deprecated: true
       locale:
         type: string
         description: The browserʼs locale. Allows for varying experience based on shopper locale.
@@ -179,6 +182,7 @@ properties:
       user_agent:
         type: string
         description: User agent string of the request.
+        deprecated: true
   returns_enabled:
     type: integer
     description: Boolean that indicates whether the control-panel setting for the returns system is enabled.

--- a/docs/storefront/stencil/themes/context/object-reference/schemas/settings.yml
+++ b/docs/storefront/stencil/themes/context/object-reference/schemas/settings.yml
@@ -42,7 +42,7 @@ properties:
     type: string
   client_ip_address:
     type: string
-    description: IP address of the customer browsing the storefront.
+    description: The IP address of the customer browsing the storefront. Use https://www.ipify.org/ as an alternative.
     deprecated: true
   country_code:
     type: string

--- a/docs/storefront/stencil/themes/context/object-reference/schemas/settings.yml
+++ b/docs/storefront/stencil/themes/context/object-reference/schemas/settings.yml
@@ -42,7 +42,7 @@ properties:
     type: string
   client_ip_address:
     type: string
-    description: The IP address of the customer browsing the storefront. An alternative to this deprecated field is  https://www.ipify.org/.
+    description: The IP address of the customer browsing the storefront. An alternative to this deprecated field is using https://www.ipify.org/.
     deprecated: true
   country_code:
     type: string

--- a/docs/storefront/stencil/themes/context/object-reference/schemas/settings.yml
+++ b/docs/storefront/stencil/themes/context/object-reference/schemas/settings.yml
@@ -42,7 +42,7 @@ properties:
     type: string
   client_ip_address:
     type: string
-    description: The IP address of the customer browsing the storefront. An alternative to this deprecated field is using https://www.ipify.org/.
+    description: The IP address of the customer browsing the storefront. An alternative to this deprecated field is using [ipify API](https://www.ipify.org/).
     deprecated: true
   country_code:
     type: string
@@ -77,7 +77,7 @@ properties:
     description: Site-wide boolean value that indicates whether to enable the gift certificate system for this store.
   is_eu_ip_address:
     type: boolean
-    description: A boolean value. Return true if the shoppers ip address is in the EU.
+    description: A boolean value. Return true if the shopper's IP address is in the EU. Alternatives to this deprecated field are solutions like the [IP Geolocation API](https://ipinfo.io/products/ip-geolocation-api), [IP Geolocation API Package](https://www.bigdatacloud.com/ip-geolocation), and others. While those solutions are not free, they offer a generous free tier, better data quality, and more data points than just the region.
     deprecated: true
   maintenance:
     type: object
@@ -155,7 +155,7 @@ properties:
     description: 'If enabled, a string containing merchant-customizable text for (European Union–required) cookie-setting notification; if disabled, a boolean with a value of false.'
   region_code:
     type: string
-    description: The [ISO-3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) code is an international standard denomination for country subdivisions. The first part is the country's ISO 3166-1 alpha-2 code, and the second part is a string of up to three alphanumeric characters representing the country's subdivision (province or state). For example, Texas's ISO 3166-2 code is US-TX; therefore, the region code is TX. The value is approximate as it is based on the IP address geolocation. Alternatives to this deprecated field are solutions like https://ipinfo.io/products/ip-geolocation-api and others. While those solutions are not free, they offer a generous free tier, better quality of the data, and more data points than just the region.
+    description: The [ISO-3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) code is an international standard denomination for country subdivisions. The first part is the country's ISO 3166-1 alpha-2 code, and the second part is a string of up to three alphanumeric characters representing the country's subdivision (province or state). For example, Texas's ISO 3166-2 code is US-TX; therefore, the region code is TX. The value is approximate as it is based on the IP address geolocation. Alternatives to this deprecated field are solutions like https://ipinfo.io/products/ip-geolocation-api and others. While those solutions are not free, they offer a generous free tier, better data quality, and more data points than just the region.
     deprecated: true
   request:
     type: object
@@ -169,7 +169,7 @@ properties:
         description: Hostname of the request.
       is_crawler:
         type: boolean
-        description: Renders `true` if user agent is known crawler; otherwise, `false`.
+        description: Renders `true` if the user agent is a known crawler; otherwise, `false`. NOTE: Serving different versions of the page to crawlers is considered detrimental to SEO [cloaking](https://developers.google.com/search/docs/essentials/spam-policies#cloaking) and is rarely needed. An alternative to this field is using a front-end bot detection like [isbot](https://github.com/omrilotan/isbot).
         deprecated: true
       locale:
         type: string
@@ -182,7 +182,7 @@ properties:
         description: Refer of the request.
       user_agent:
         type: string
-        description: User agent string of the request.
+        description: User agent string of the request. An alternative is using JavaScript detection ([Navigator: userAgent property](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent)).
         deprecated: true
   returns_enabled:
     type: integer

--- a/docs/storefront/stencil/themes/context/object-reference/schemas/settings.yml
+++ b/docs/storefront/stencil/themes/context/object-reference/schemas/settings.yml
@@ -78,6 +78,7 @@ properties:
   is_eu_ip_address:
     type: boolean
     description: A boolean value. Return true if the shoppers ip address is in the EU.
+    deprecated: true
   maintenance:
     type: object
     description: Object that manages information about the store when in maintenance (offline) mode.

--- a/docs/storefront/stencil/themes/context/object-reference/schemas/settings.yml
+++ b/docs/storefront/stencil/themes/context/object-reference/schemas/settings.yml
@@ -42,7 +42,7 @@ properties:
     type: string
   client_ip_address:
     type: string
-    description: The IP address of the customer browsing the storefront. Use https://www.ipify.org/ as an alternative.
+    description: The IP address of the customer browsing the storefront. An alternative to this deprecated field is  https://www.ipify.org/.
     deprecated: true
   country_code:
     type: string

--- a/docs/storefront/stencil/themes/context/object-reference/schemas/settings.yml
+++ b/docs/storefront/stencil/themes/context/object-reference/schemas/settings.yml
@@ -155,7 +155,7 @@ properties:
     description: 'If enabled, a string containing merchant-customizable text for (European Union–required) cookie-setting notification; if disabled, a boolean with a value of false.'
   region_code:
     type: string
-    description: The [ISO-3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) code is an international standard denomination for country subdivisions. The first part is the country's ISO 3166-1 alpha-2 code, and the second part is a string of up to three alphanumeric characters representing the country's subdivision (province or state). For example, Texas's ISO 3166-2 code is US-TX; therefore, the region code is TX.
+    description: The [ISO-3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) code is an international standard denomination for country subdivisions. The first part is the country's ISO 3166-1 alpha-2 code, and the second part is a string of up to three alphanumeric characters representing the country's subdivision (province or state). For example, Texas's ISO 3166-2 code is US-TX; therefore, the region code is TX. The value is approximate as it is based on the IP address geolocation. Alternatives to this deprecated field are solutions like https://ipinfo.io/products/ip-geolocation-api and others. While those solutions are not free, they offer a generous free tier, better quality of the data, and more data points than just the region.
     deprecated: true
   request:
     type: object


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6042]


## What changed?
added deprecated tags to the settings theme object

## Release notes draft

The following stencil attribute fields are deprecated:

- settings.request.is_crawler
- 
- settings.request.user_agent
- 
- settings.client_ip_address
- 
- settings.region_code


## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6042]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ