### PR TITLE
Update MSF and Catalog ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,12 @@
 # be identified in the format @org/team-name. Teams must have
 # explicit write access to the repository. In this example,
 # the octocats team in the octo-org organization owns all .md files.
+
+# @bigcommerce/team-catalog-ops
+reference/catalog @bigcommerce/team-catalog-ops
+archive/rest-catalog @bigcommerce/team-catalog-ops
+
+# @bigcommerce/team-multi-storefront
+docs/storefront/multi-storefront @bigcommerce/team-multi-storefront
+reference/channels.v3.yml @bigcommerce/team-multi-storefront
+reference/sites.v3.yml @bigcommerce/team-multi-storefront


### PR DESCRIPTION
## What changed?
<!-- Provide a bulleted list in the present tense -->
* In order to ensure that public documentation remains up-to-date with development, the Catalog and Multi-Storefront teams want to have more visibility over the updating process. This includes introducing code ownership through the CODEOWNERS file, allowing for better visibility and control over changes to documentation.

