### PR TITLE
DEVDOCS-6105 [revise]: MSF International Enhancements, clarify custom fields

### DIFF
--- a/docs/integrations/webhooks/events/index.mdx
+++ b/docs/integrations/webhooks/events/index.mdx
@@ -885,6 +885,9 @@ A change to any of the following fields triggers a `store/product/updated` event
 * Thumbnail - new images only*
 * Visibility
 * Warranty
+
+A change to the following field triggers the `store/product/updated` event only if the change is made for a _channel locale_. For more information, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.  
+
 * Custom field's name or value
 
 <Callout type="info">


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6105]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Clarified statement about custom fields (`store/product/updated` webhook triggers only for the channel locale, not the global store)

## Release notes draft
 N / A

## Anything else?
@bigcommerce/team-multi-storefront 


[DEVDOCS-6105]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ