### PR TITLE
DEVDOC-6114 [update]: Channel Menus, add UI sections

### DIFF
--- a/docs/integrations/channels/guide/storefronts.mdx
+++ b/docs/integrations/channels/guide/storefronts.mdx
@@ -93,17 +93,17 @@ BigCommerce allows the developer to toggle the location and scope of the followi
 
 | Menu item / settings page | API Argument | Description |
 |:------|:------|:------------|
+| Overview | `overview` | Renders a channel-specific overview page. |
 | Storefront Settings | `storefront_settings` | Renders channel-specific storefront settings. |
+| Localization | `localization` | Renders channel-specific localization settings. |
 | Carousel | `carousel` | Renders channel-specific carousel settings. |
+| Script Manager | `script_manager` | Renders channel-specific script manager settings. |
 | Currencies | `currencies` | Renders channel-specific currency settings. |
+| Payments | `payments` | Renders channel-specific payments settings. |
+| Checkout | `checkout` | Renders channel-specific checkout settings. |
 | Domains | `domains` | Renders channel-specific domain settings. |
 | Notifications | `notifications` | Renders channel-specific notification settings. |
 | Social | `social` | Renders channel-specific social media settings. |
-| Localization | `localization` | Renders channel-specific localization settings. |
-| Overview | `overview` | Renders a channel-specific overview page. |
-| Script Manager | `script_manager` | Renders channel-specific script manager settings. |
-| Payments | `payments` | Renders channel-specific payments settings. |
-| Checkout | `checkout` | Renders channel-specific checkout settings. |
 | Web pages | `pages` | Renders channel-specific pages settings. |
 | Data solutions | `data_solutions` | Renders channel-specific data solutions settings. |
 

--- a/docs/integrations/channels/guide/storefronts.mdx
+++ b/docs/integrations/channels/guide/storefronts.mdx
@@ -100,6 +100,12 @@ BigCommerce allows the developer to toggle the location and scope of the followi
 | Notifications | `notifications` | Renders channel-specific notification settings. |
 | Social | `social` | Renders channel-specific social media settings. |
 | Localization | `localization` | Renders channel-specific localization settings. |
+| Overview | `overview` | Renders a channel-specific overview page. |
+| Script Manager | `script_manager` | Renders channel-specific script manager settings. |
+| Payments | `payments` | Renders channel-specific payments settings. |
+| Checkout | `checkout` | Renders channel-specific checkout settings. |
+| Web pages | `pages` | Renders channel-specific pages settings. |
+| Data solutions | `data_solutions` | Renders channel-specific data solutions settings. |
 
 The term _protected section_ refers to the settings on the corresponding menu pages. Settings in protected sections override the default settings configured at the storewide level. Include these protected sections in requests to the [Create channel menus](/docs/rest-management/channels/channel-menus#create-channel-menus) endpoint to display BigCommerce-provided, channel-specific settings pages and corresponding menu items. Enabled protected sections precede custom sections in a channel's menu.
 

--- a/reference/channels.v3.yml
+++ b/reference/channels.v3.yml
@@ -3498,17 +3498,17 @@ components:
       items:
         type: string
         enum:
-          - storefront_settings
-          - social
-          - carousel
-          - domains
-          - currencies
-          - notifications
-          - localization
           - overview
+          - storefront_settings
+          - localization
+          - carousel
           - script_manager
+          - currencies
           - payments
-          - checkout 
+          - checkout
+          - domains
+          - notifications 
+          - social       
           - pages
           - data_solutions
     channel_menus_Post:

--- a/reference/channels.v3.yml
+++ b/reference/channels.v3.yml
@@ -3505,6 +3505,12 @@ components:
           - currencies
           - notifications
           - localization
+          - overview
+          - script_manager
+          - payments
+          - checkout 
+          - pages
+          - data_solutions
     channel_menus_Post:
       type: object
       properties:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6114]


## What changed?
<!-- Provide a bulleted list in the present tense -->

- Updated the protected UI section and Channels API reference to include settings for: Overview, Script Manager, Payments, Checkout, Web pages, and Data solutions.

## Release notes draft

* We're happy to announce that we've added the following [protected UI sections](https://developer.bigcommerce.com/docs/integrations/channels/guide/storefronts#protected-ui-sections) when you build a storefront channel. You can now include these settings when you [create a channel menu](https://developer.bigcommerce.com/docs/rest-management/channels/menus#create-channel-menus): Overview, Script Manager, Payments, Checkout, Web pages, Data solutions. 

## Anything else?
@bigcommerce/team-multi-storefront 


[DEVDOCS-6114]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ