### PR TITLE
ORDERS-6362: [add] is_tax_inclusive_pricing field in orders response

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -1429,6 +1429,7 @@ components:
                   total_ex_tax: '361.9500'
                   total_inc_tax: '361.9500'
                   total_tax: '0.0000'
+                  is_tax_inclusive_pricing: false
                   items_total: 17
                   items_shipped: 0
                   payment_method: Credit Card
@@ -1643,6 +1644,7 @@ components:
                 total_ex_tax: '64.5300'
                 total_inc_tax: '69.8400'
                 total_tax: '5.3100'
+                is_tax_inclusive_pricing: false
                 items_total: 4
                 items_shipped: 0
                 payment_method: Cash
@@ -1736,6 +1738,7 @@ components:
                 total_ex_tax: '931.86'
                 total_inc_tax: '1008.74'
                 total_tax: 76.88
+                is_tax_inclusive_pricing: false
                 items_total: 11
                 items_shipped: 0
                 payment_method: Test Payment Gateway
@@ -3915,6 +3918,10 @@ components:
           description: Override value for the total, including tax. If specified, the field `total_ex_tax` is also required. (Float, Float-As-String, Integer)
           example: '225.0000'
           type: string
+        is_tax_inclusive_pricing:
+          description: Indicates whether the order total is inclusive of tax.
+          example: false
+          type: boolean
         wrapping_cost_ex_tax:
           description: The value of the wrapping cost, excluding tax. (Float, Float-As-String, Integer)
           example: '0.0000'
@@ -4127,6 +4134,10 @@ components:
           description: The number of shipping addresses associated with this transaction. A read-only value. Do not pass in a POST or PUT.
         is_deleted:
           description: Indicates whether the order is deleted/archived. When set to true in a PUT request, it has the same result as the DELETE an order request.
+          example: false
+          type: boolean
+        is_tax_inclusive_pricing:
+          description: Indicates whether the order total is inclusive of tax.
           example: false
           type: boolean
         is_email_opt_in:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
https://bigcommercecloud.atlassian.net/browse/ORDERS-6362

## What changed?
<!-- Provide a bulleted list in the present tense -->
* Added  is_tax_inclusive_pricing field in orders response


Swagger Proof:

https://github.com/user-attachments/assets/86560ebf-3fc7-482d-93b3-4190699b8c96

 

