### PR TITLE
Add company attachment endpoints to B2B Edition API specs

### DIFF
--- a/docs/b2b-edition/specs/api-v3/company/company.yaml
+++ b/docs/b2b-edition/specs/api-v3/company/company.yaml
@@ -1,24 +1,30 @@
 openapi: 3.0.1
 info:
   title: Company
-  description: 'The company of BigCommerce B2B Edition corresponds to the customer group of BigCommerce one by one, and the mapping is done through field of bc_group_id. The established corresponding relationship cannot be changed and can only be deleted together. Different customer groups do not support merging in BigCommerce. The same is true for different BigCommerce B2B Edition Company. This is a simple entity diagram of customer groups and company. ![Company entity diagram](https://user-images.githubusercontent.com/81215728/124566045-424fd480-de75-11eb-8268-a15ae40fb579.jpg) The best practices to use company OpenAPI is maintaining unidirectional data flow. The operation of BigCommerce customer groups data update (add, update and delete) is completed by BigCommerce B2B Editionʼs OpenAPI operation company.'
+  description: |-
+    A company in B2B Edition corresponds one-to-one with a customer group in BigCommerce. The mapping is done through the bc_group_id field. Once established, this corresponding relationship cannot be changed and can only be deleted. Note that neither BigCommerce customer groups nor B2B Edition companies can be merged.
+
+    This is a simple entity diagram of customer groups and companies:
+
+    ![Company entity diagram](https://user-images.githubusercontent.com/81215728/124566045-424fd480-de75-11eb-8268-a15ae40fb579.jpg)
+
+    The best practice for using these Company APIs is to maintain unidirectional data flow, with B2B Edition endpoints as the primary touchpoint. The operation of modifying linked BigCommerce customer group data (add, update, and delete) is completed by B2B Edition's company operations.
   contact: {}
   version: v3
 servers:
-  - url: 'https://api-b2b.bigcommerce.com/api/v3/io'
+  - url: "https://api-b2b.bigcommerce.com/api/v3/io"
 security:
   - authToken: []
 tags:
   - name: Company
-    description: New version company docs
   - name: Company Roles and Permissions
 paths:
   /companies:
     get:
       tags:
         - Company
-      summary: Get Companies
-      description: Get all companies list
+      summary: Get All Companies
+      description: Get a list of all companies
       operationId: get-companies
       parameters:
         - name: limit
@@ -60,7 +66,7 @@ paths:
             type: number
         - name: sortBy
           in: query
-          description: The response sorted by which field
+          description: Sort the result by a specific company field
           schema:
             type: string
             default: updatedAt
@@ -80,16 +86,16 @@ paths:
             example: DESC
         - name: isIncludeExtraFields
           in: query
-          description: Is show extra fields in the response
+          description: Should extra fields be shown in the response
           schema:
             type: string
-            default: '0'
+            default: "0"
             enum:
-              - '0'
-              - '1'
+              - "0"
+              - "1"
         - name: companyStatus
           in: query
-          description: '0: PENDING 1: APPROVED 2: REJECTED 3: INACTIVE'
+          description: "0: PENDING 1: APPROVED 2: REJECTED 3: INACTIVE"
           schema:
             type: integer
             enum:
@@ -104,7 +110,15 @@ paths:
             type: string
         - name: extraFields
           in: query
-          description: 'Company query extra fields, you can use this value to filter the company list.(include extraInt1 ~ extraInt5, extraStr1 ~ extraStr5 and other customizable)  This value may be passed into the custom extra field configured by the B3 team when you create the company. If you clearly know the correspondence between the custom extra field and the default extra field, you can use the default extra field filter to obtain data, Of course, you can also filter by key-value pairs passed into custom fields.  eg. https://api-b2b.bigcommerce.com/api/v2/io/companies/?extraFields=extraInt1:1&extraFields=companyTax:un42'
+          description: |-
+            Filter the company list on extra fields. (include extraInt1 ~ extraInt5, extraStr1 ~ extraStr5 and other customizable)
+
+            This value may be passed into the custom extra field configured by the B3 team when you create the company.
+
+            If you clearly know the correspondence between the custom extra field and the default extra field, you can use the default extra field filter to obtain data.
+
+            You can also filter by key-value pairs passed into custom fields:
+            https://api-b2b.bigcommerce.com/api/v2/io/companies/?extraFields=extraInt1:1&extraFields=companyTax:un42
           style: form
           explode: false
           schema:
@@ -114,7 +128,7 @@ paths:
             example: 2
           in: query
           name: bcOrderId
-          description: 'Company purchase bc order id, allow you found company by bc order id'
+          description: "Company purchase bc order id, allow you found company by bc order id"
         - schema:
             type: string
           in: query
@@ -129,7 +143,7 @@ paths:
             type: integer
           in: query
           name: customerId
-          description: 'BigCommerce customer id, this customer should be a B2B company user'
+          description: "BigCommerce customer id, this customer should be a B2B company user"
         - schema:
             type: string
             enum:
@@ -138,9 +152,9 @@ paths:
             default: search
           in: query
           name: extraFieldFilterType
-          description: 'extra field filter type. The search filter type allows for partial matches, while the exact-match filter type only returns results that exactly match the specified criteria.'
+          description: "extra field filter type. The search filter type allows for partial matches, while the exact-match filter type only returns results that exactly match the specified criteria."
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -169,10 +183,10 @@ paths:
                           minLength: 1
                           type: string
                           enum:
-                            - '0'
-                            - '1'
-                            - '2'
-                            - '3'
+                            - "0"
+                            - "1"
+                            - "2"
+                            - "3"
                           description: Status of a company
                         companyEmail:
                           type: string
@@ -211,21 +225,21 @@ paths:
                                 description: Field label name
                               isRequired:
                                 type: string
-                                description: 'Is field required or not, 0=not required, 1=required'
+                                description: "Is field required or not, 0=not required, 1=required"
                                 enum:
-                                  - '0'
-                                  - '1'
+                                  - "0"
+                                  - "1"
                               dataType:
                                 type: string
-                                description: 'Field data type, 0=text, 1=number, 2=textarea, 3=dropdown'
+                                description: "Field data type, 0=text, 1=number, 2=textarea, 3=dropdown"
                                 enum:
-                                  - '0'
-                                  - '1'
-                                  - '2'
-                                  - '3'
+                                  - "0"
+                                  - "1"
+                                  - "2"
+                                  - "3"
                               fieldType:
                                 type: number
-                                description: 'Field data type, 0=text, 1=number, 2=textarea, 3=dropdown'
+                                description: "Field data type, 0=text, 1=number, 2=textarea, 3=dropdown"
                                 enum:
                                   - 0
                                   - 1
@@ -329,23 +343,23 @@ paths:
                   value:
                     code: 200
                     data:
-                      - companyId: '147340'
+                      - companyId: "147340"
                         companyName: Glam Squad Hair and Makeup Artistry
                         bcGroupName: Glam Squad Hair and Makeup Artistry
                         companyEmail: support@bundleb2b.net
-                        companyPhone: '123456789'
-                        companyStatus: '1'
-                        uuid: ''
-                        catalogId: ''
-                        catalogName: ''
-                        updatedAt: '1618794615'
-                        createdAt: '1618787774'
+                        companyPhone: "123456789"
+                        companyStatus: "1"
+                        uuid: ""
+                        catalogId: ""
+                        catalogName: ""
+                        updatedAt: "1618794615"
+                        createdAt: "1618787774"
                         extraFields:
-                          - dataType: '2'
+                          - dataType: "2"
                             fieldType: 2
                             fieldName: extraStr1
                             fieldValue: extra_text
-                            isRequired: '0'
+                            isRequired: "0"
                             labelName: Enter your license
                         extraInt1: 42
                         extraInt2: 42
@@ -368,17 +382,17 @@ paths:
                   value:
                     code: 200
                     data:
-                      - companyId: '147340'
+                      - companyId: "147340"
                         companyName: Glam Squad Hair and Makeup Artistry
                         bcGroupName: Glam Squad Hair and Makeup Artistry
                         companyEmail: support@bundleb2b.net
-                        companyPhone: '123456789'
-                        companyStatus: '1'
-                        uuid: ''
-                        catalogId: ''
-                        catalogName: ''
-                        updatedAt: '1618794615'
-                        createdAt: '1618787774'
+                        companyPhone: "123456789"
+                        companyStatus: "1"
+                        uuid: ""
+                        catalogId: ""
+                        catalogName: ""
+                        updatedAt: "1618794615"
+                        createdAt: "1618787774"
                         bcGroupId: 0
                     meta:
                       message: SUCCESS
@@ -390,19 +404,19 @@ paths:
               example:
                 code: 200
                 data:
-                  - companyId: '147340'
+                  - companyId: "147340"
                     companyName: Glam Squad Hair and Makeup Artistry
-                    companyStatus: '1'
-                    uuid: ''
-                    catalogId: ''
-                    catalogName: ''
-                    updatedAt: '1618794615'
-                    createdAt: '1618787774'
+                    companyStatus: "1"
+                    uuid: ""
+                    catalogId: ""
+                    catalogName: ""
+                    updatedAt: "1618794615"
+                    createdAt: "1618787774"
                     extraFields:
-                      - dataType: '2'
+                      - dataType: "2"
                         fieldName: extraStr1
                         fieldValue: extra_text
-                        isRequired: '0'
+                        isRequired: "0"
                         labelName: Enter your license
                 meta:
                   message: SUCCESS
@@ -414,14 +428,14 @@ paths:
               example:
                 code: 200
                 data:
-                  - companyId: '147340'
+                  - companyId: "147340"
                     companyName: Glam Squad Hair and Makeup Artistry
-                    companyStatus: '1'
-                    uuid: ''
-                    catalogId: ''
-                    catalogName: ''
-                    updatedAt: '1618794615'
-                    createdAt: '1618787774'
+                    companyStatus: "1"
+                    uuid: ""
+                    catalogId: ""
+                    catalogName: ""
+                    updatedAt: "1618794615"
+                    createdAt: "1618787774"
                 meta:
                   message: SUCCESS
                   pagination:
@@ -445,13 +459,13 @@ paths:
                 - $ref: https://raw.githubusercontent.com/bigcommerce/docs/main/docs/b2b-edition/models/extra_fields/user_extra_field_values.yaml
                 - type: object
                   required:
-                  - companyName
-                  - companyPhone
-                  - companyEmail
-                  - country
-                  - adminFirstName
-                  - adminLastName
-                  - adminEmail
+                    - companyName
+                    - companyPhone
+                    - companyEmail
+                    - country
+                    - adminFirstName
+                    - adminLastName
+                    - adminEmail
                   properties:
                     companyName:
                       minLength: 1
@@ -507,7 +521,7 @@ paths:
                       description: BC price list Id that company related
                     acceptCreationEmail:
                       type: boolean
-                      description: 'True: Will send email company creation notification to admin user; False: Will not send'
+                      description: "True: Will send email company creation notification to admin user; False: Will not send"
                       default: false
                     channelIds:
                       type: array
@@ -516,7 +530,7 @@ paths:
                         type: integer
                     originChannelId:
                       type: integer
-                      description: 'BigCommerce channel id, used for BigCommerce customer origin channel id. This field takes effect only when the store default b2b channel is not configured'
+                      description: "BigCommerce channel id, used for BigCommerce customer origin channel id. This field takes effect only when the store default b2b channel is not configured"
             examples:
               example-1:
                 value:
@@ -544,12 +558,12 @@ paths:
                     - 2
                   originChannelId: 1
       responses:
-        '200':
+        "200":
           description: Created
           content:
             application/json:
               schema:
-                description: ''
+                description: ""
                 type: object
                 properties:
                   code:
@@ -589,12 +603,12 @@ paths:
                       customerGroupId: 1
                     meta:
                       message: SUCCESS
-        '400':
+        "400":
           description: Bad Request
           content:
             application/json:
               schema:
-                description: ''
+                description: ""
                 type: object
                 properties:
                   code:
@@ -620,12 +634,12 @@ paths:
                     data: {}
                     meta:
                       message: Create BC customer group failed
-        '422':
-          description: 'Company was not valid. This is the result of missing required fields, or of invalid data. See the response for more details'
+        "422":
+          description: "Company was not valid. This is the result of missing required fields, or of invalid data. See the response for more details"
           content:
             application/json:
               schema:
-                description: ''
+                description: ""
                 type: object
                 properties:
                   code:
@@ -654,12 +668,12 @@ paths:
       security:
         - authToken: []
       x-codegen-request-body-name: body
-  '/companies/{companyId}':
+  "/companies/{companyId}":
     get:
       tags:
         - Company
-      summary: Get a Company Detail
-      description: Get a company detail
+      summary: Get a Company
+      description: Get details about a specific company
       operationId: get-companies-companyId
       parameters:
         - name: companyId
@@ -668,7 +682,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -788,27 +802,27 @@ paths:
                   value:
                     code: 200
                     data:
-                      companyId: '147340'
+                      companyId: "147340"
                       companyName: Glam Squad Hair and Makeup Artistry
                       companyEmail: support@bundleb2b.net
-                      companyPhone: '123456789'
-                      companyStatus: '1'
-                      uuid: ''
-                      catalogId: ''
-                      catalogName: ''
-                      updatedAt: '1618794615'
-                      createdAt: '1618787774'
+                      companyPhone: "123456789"
+                      companyStatus: "1"
+                      uuid: ""
+                      catalogId: ""
+                      catalogName: ""
+                      updatedAt: "1618794615"
+                      createdAt: "1618787774"
                       extraFields:
-                        - dataType: '2'
+                        - dataType: "2"
                           fieldName: extraStr1
                           fieldValue: extra_text
-                          isRequired: '0'
+                          isRequired: "0"
                           labelName: Enter your license
-                      bcGroupId: '1'
+                      bcGroupId: "1"
                       bcGroupName: salons
                     meta:
                       message: SUCCESS
-        '404':
+        "404":
           description: Not Found
           content:
             application/json:
@@ -832,7 +846,7 @@ paths:
                       message:
                         minLength: 1
                         type: string
-                description: ''
+                description: ""
               examples:
                 example-1:
                   value:
@@ -931,12 +945,12 @@ paths:
                         description: BC price list ID
         required: false
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                description: ''
+                description: ""
                 type: object
                 properties:
                   code:
@@ -966,7 +980,7 @@ paths:
                       companyId: 12
                     meta:
                       message: SUCCESS
-        '404':
+        "404":
           description: Not Found
           content:
             application/json:
@@ -990,7 +1004,7 @@ paths:
                       message:
                         minLength: 1
                         type: string
-                description: ''
+                description: ""
               examples:
                 example-1:
                   value:
@@ -1024,12 +1038,12 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                description: ''
+                description: ""
                 type: object
                 properties:
                   code:
@@ -1052,13 +1066,13 @@ paths:
                     data: {}
                     meta:
                       message: SUCCESS
-        '404':
+        "404":
           description: Not Found
           content:
             application/json:
               schema:
                 type: object
-                description: ''
+                description: ""
                 properties:
                   code:
                     type: integer
@@ -1092,8 +1106,8 @@ paths:
       security:
         - authToken: []
     parameters:
-      - $ref: '#/components/parameters/companyId'
-  '/customer-groups/{customerGroupId}/companies':
+      - $ref: "#/components/parameters/companyId"
+  "/customer-groups/{customerGroupId}/companies":
     post:
       tags:
         - Company
@@ -1194,7 +1208,7 @@ paths:
                     - fieldName: string
                       fieldValue: string
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -1223,23 +1237,23 @@ paths:
                       message:
                         minLength: 1
                         type: string
-                description: ''
+                description: ""
               examples:
                 example-1:
                   value:
                     code: 200
                     data:
-                      companyId: '12'
+                      companyId: "12"
                     meta:
                       message: SUCCESS
             example-1:
               example:
                 code: 200
                 data:
-                  companyId: '147340'
+                  companyId: "147340"
                 meta:
                   message: SUCCESS
-        '400':
+        "400":
           description: Bad Request
           content:
             application/json:
@@ -1268,13 +1282,13 @@ paths:
                       message:
                         minLength: 1
                         type: string
-                description: ''
+                description: ""
               examples:
                 example-1:
                   value:
                     code: 200
                     data:
-                      companyId: '12'
+                      companyId: "12"
                     meta:
                       message: SUCCESS
             example-1:
@@ -1283,7 +1297,7 @@ paths:
                 data: {}
                 meta:
                   message: Convert failed for the API call.
-        '404':
+        "404":
           description: Not Found
           content:
             application/json:
@@ -1307,7 +1321,7 @@ paths:
                       message:
                         minLength: 1
                         type: string
-                description: ''
+                description: ""
               examples:
                 example-1:
                   value:
@@ -1329,12 +1343,12 @@ paths:
       summary: Bulk Create Companies
       operationId: post-companies-bulk
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                description: ''
+                description: ""
                 type: object
                 properties:
                   code:
@@ -1367,12 +1381,12 @@ paths:
                       - companyId: 1
                     data:
                       id: string
-        '400':
-          description: 'Bad Request, some companies created failed.'
+        "400":
+          description: "Bad Request, some companies created failed."
           content:
             application/json:
               schema:
-                description: ''
+                description: ""
                 type: object
                 x-examples:
                   example-1:
@@ -1430,17 +1444,17 @@ paths:
                 code: 400
                 data:
                   errors:
-                    - id: '42'
-                      detail: ''
+                    - id: "42"
+                      detail: ""
                 meta:
-                  message: 'Some companies updated failed, you can see these in errors'
-        '409':
-          description: 'Company was in conflict with another company. This is the result of duplicate unique values; A missing or invalid `companyEmail`, `phoneNumber` or other extraFields'
+                  message: "Some companies updated failed, you can see these in errors"
+        "409":
+          description: "Company was in conflict with another company. This is the result of duplicate unique values; A missing or invalid `companyEmail`, `phoneNumber` or other extraFields"
           content:
             application/json:
               schema:
                 type: object
-                description: ''
+                description: ""
                 properties:
                   code:
                     type: number
@@ -1491,12 +1505,12 @@ paths:
                 code: 409
                 data:
                   errors:
-                    - id: '42'
-                      detail: ''
+                    - id: "42"
+                      detail: ""
                 meta:
                   message: Company was in conflict with another company
-        '413':
-          description: 'Request Entity Too Large. In normal conditions, bulk create or update method support 10 entity in once request. Another case, some fields of entity over limit.'
+        "413":
+          description: "Request Entity Too Large. In normal conditions, bulk create or update method support 10 entity in once request. Another case, some fields of entity over limit."
           content:
             application/json:
               schema:
@@ -1508,12 +1522,12 @@ paths:
                     meta:
                       message: Request Entity Too Large
                     data: {}
-        '422':
+        "422":
           description: Company was not valid. This is the result of missing required fields or invalid data. See the response for more details.
           content:
             application/json:
               schema:
-                description: ''
+                description: ""
                 type: object
                 properties:
                   code:
@@ -1595,7 +1609,7 @@ paths:
                           type: integer
                       originChannelId:
                         type: integer
-                        description: 'BigCommerce channel id, used for BigCommerce customer origin channel id. This field takes effect only when the store default b2b channel is not configured'
+                        description: "BigCommerce channel id, used for BigCommerce customer origin channel id. This field takes effect only when the store default b2b channel is not configured"
                   - $ref: https://raw.githubusercontent.com/bigcommerce/docs/main/docs/b2b-edition/models/extra_fields/user_extra_field_values.yaml
             examples:
               example-1:
@@ -1709,7 +1723,7 @@ paths:
                         fieldValue: string
         required: false
       responses:
-        '200':
+        "200":
           description: Company Update Success
           content:
             application/json:
@@ -1738,7 +1752,7 @@ paths:
                       message:
                         minLength: 1
                         type: string
-                description: ''
+                description: ""
               examples:
                 example-1:
                   value:
@@ -1751,10 +1765,10 @@ paths:
               example:
                 code: 200
                 data:
-                  companyId: '147340'
+                  companyId: "147340"
                 meta:
                   message: SUCCESS
-        '400':
+        "400":
           description: Bad Request
           content:
             application/json:
@@ -1778,7 +1792,7 @@ paths:
                       message:
                         minLength: 1
                         type: string
-                description: ''
+                description: ""
               examples:
                 example-1:
                   value:
@@ -1792,7 +1806,7 @@ paths:
                 data: {}
                 meta:
                   message: Convert failed for the API call.
-        '404':
+        "404":
           description: Not Found
           content:
             application/json:
@@ -1816,7 +1830,7 @@ paths:
                       message:
                         minLength: 1
                         type: string
-                description: ''
+                description: ""
               examples:
                 example-1:
                   value:
@@ -1830,7 +1844,7 @@ paths:
                 data: {}
                 meta:
                   message: This resource is not found
-        '413':
+        "413":
           description: Request Entity Too Large
           content:
             application/json:
@@ -1839,19 +1853,19 @@ paths:
       security:
         - authToken: []
       x-codegen-request-body-name: body
-  '/companies/{companyId}/catalogs':
+  "/companies/{companyId}/catalogs":
     parameters:
-      - $ref: '#/components/parameters/companyId'
+      - $ref: "#/components/parameters/companyId"
     put:
       summary: Update a Company's Catalog
       operationId: put-companies-companyId-catalog
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                description: ''
+                description: ""
                 type: object
                 properties:
                   code:
@@ -1881,7 +1895,7 @@ paths:
                   value:
                     code: 200
                     data:
-                      companyId: '147340'
+                      companyId: "147340"
                     meta:
                       message: SUCCESS
       security:
@@ -1890,7 +1904,7 @@ paths:
         content:
           application/json:
             schema:
-              description: ''
+              description: ""
               type: object
               properties:
                 catalogId:
@@ -1903,23 +1917,23 @@ paths:
               example-1:
                 value:
                   catalogId: string
-        description: ''
+        description: ""
       description: Update a company's catalog.
       tags:
         - Company
-  '/companies/{companyId}/status':
+  "/companies/{companyId}/status":
     parameters:
-      - $ref: '#/components/parameters/companyId'
+      - $ref: "#/components/parameters/companyId"
     put:
       summary: Update a Company's Status
       operationId: put-companies-companyId-status
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                description: ''
+                description: ""
                 type: object
                 properties:
                   code:
@@ -1949,7 +1963,7 @@ paths:
                   value:
                     code: 200
                     data:
-                      companyId: '147340'
+                      companyId: "147340"
                     meta:
                       message: SUCCESS
       security:
@@ -1958,7 +1972,7 @@ paths:
         content:
           application/json:
             schema:
-              description: ''
+              description: ""
               type: object
               properties:
                 companyStatus:
@@ -1981,7 +1995,7 @@ paths:
       tags:
         - Company
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2018,12 +2032,12 @@ paths:
                                 exclusiveMaximum: true
                                 minimum: 1
                                 exclusiveMinimum: true
-                                description: 'Pagination limit default: 10'
+                                description: "Pagination limit default: 10"
                                 example: 10
                               offset:
                                 type: integer
                                 minimum: 0
-                                description: 'Pagination offset default: 0'
+                                description: "Pagination offset default: 0"
                                 example: 0
                               totalCount:
                                 type: integer
@@ -2110,11 +2124,11 @@ paths:
             type: number
           in: query
           name: offset
-          description: 'Pagination offset default: 0'
+          description: "Pagination offset default: 0"
         - schema:
             type: string
           in: query
-          description: 'Pagination limit default: 10'
+          description: "Pagination limit default: 10"
           name: limit
       security:
         - authToken: []
@@ -2132,7 +2146,7 @@ paths:
             type: string
           description: search by permission name
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2141,56 +2155,34 @@ paths:
                 properties:
                   code:
                     type: integer
-                    x-stoplight:
-                      id: tkd806l6sp85s
                     default: 200
                   data:
                     type: array
-                    x-stoplight:
-                      id: dvelk7dyckvfv
                     items:
-                      x-stoplight:
-                        id: cpxubh8agzme4
                       type: object
                       properties:
                         id:
                           type: integer
-                          x-stoplight:
-                            id: pdf1h2175djxl
                         name:
                           type: string
-                          x-stoplight:
-                            id: lsuhr6erkvbfv
                           description: The permission name
                         description:
                           type: string
-                          x-stoplight:
-                            id: qrc23ecrewfpf
                           description: The permission description
                         code:
                           type: string
-                          x-stoplight:
-                            id: 5ufcc4xw8b7la
                           description: The permission code
                         isCustom:
                           type: boolean
-                          x-stoplight:
-                            id: pyaz088347b77
                           description: Whether the permission is custom
                         moduleName:
                           type: string
-                          x-stoplight:
-                            id: 45o1bg3ohj24b
                           description: The name of the module to which the permission belongs
                   meta:
                     type: object
-                    x-stoplight:
-                      id: oswkodks6amvb
                     properties:
                       message:
                         type: string
-                        x-stoplight:
-                          id: g9anf5jqggjek
                         default: SUCCESS
               examples:
                 Example 1:
@@ -2213,7 +2205,7 @@ paths:
       summary: Create Company Permission
       operationId: post-stores-companies-permissions
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2222,52 +2214,32 @@ paths:
                 properties:
                   code:
                     type: integer
-                    x-stoplight:
-                      id: kpwn27gg4b1p9
                     default: 200
                   data:
                     type: object
-                    x-stoplight:
-                      id: ex611ljl6wjuq
                     properties:
                       id:
                         type: integer
-                        x-stoplight:
-                          id: vve44fhaf7hxg
                       name:
                         type: string
-                        x-stoplight:
-                          id: v30li7i8gyjp0
                         description: The permission name
                       code:
                         type: string
-                        x-stoplight:
-                          id: azfgdyoaoxpyr
                         description: The permission code
                       description:
                         type: string
-                        x-stoplight:
-                          id: mds3aym61yosm
                         description: The permission description
                       isCustom:
                         type: boolean
-                        x-stoplight:
-                          id: cufks4wx0eou0
                         description: Whether the permission is custom
                       moduleName:
                         type: string
-                        x-stoplight:
-                          id: epupvi81hu557
                         description: The name of the module to which the permission belongs
                   meta:
                     type: object
-                    x-stoplight:
-                      id: 0hp7h2t89sq46
                     properties:
                       message:
                         type: string
-                        x-stoplight:
-                          id: 4uxj69e5kd4er
                         default: SUCCESS
               examples:
                 Example 1:
@@ -2293,26 +2265,18 @@ paths:
               properties:
                 name:
                   type: string
-                  x-stoplight:
-                    id: 3ltunpilse743
                   maxLength: 200
                   description: The permission name
                 code:
                   type: string
-                  x-stoplight:
-                    id: ah108y3oezb1g
                   maxLength: 50
                   description: The permission code
                 description:
                   type: string
-                  x-stoplight:
-                    id: owp1xr3y95h1c
                   maxLength: 512
                   description: The permission description
                 moduleName:
                   type: string
-                  x-stoplight:
-                    id: reqdo1j6gglrv
                   maxLength: 50
                   description: The permission module name
               required:
@@ -2326,12 +2290,12 @@ paths:
                   description: Get addresses
                   code: get_addresses
                   moduleName: address
-        description: 'name, code are unique in the same store.'
+        description: "name, code are unique in the same store."
       parameters: []
       tags:
         - Company Roles and Permissions
       x-internal: false
-  '/companies/permissions/{permissionId}':
+  "/companies/permissions/{permissionId}":
     parameters:
       - schema:
           type: integer
@@ -2342,7 +2306,7 @@ paths:
       summary: Update Company Permission
       operationId: put-stores-companies-permissions-permissionId
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2351,52 +2315,32 @@ paths:
                 properties:
                   code:
                     type: integer
-                    x-stoplight:
-                      id: 8ahlss6wl3sve
                     default: 200
                   data:
                     type: object
-                    x-stoplight:
-                      id: yetu7glqovsyo
                     properties:
                       id:
                         type: integer
-                        x-stoplight:
-                          id: dykkmywtg1z99
                       name:
                         type: string
-                        x-stoplight:
-                          id: 1tdhj5ncsj41p
                         description: The permission name
                       code:
                         type: string
-                        x-stoplight:
-                          id: d4yn8rbpnfu1e
                         description: The permission code
                       description:
                         type: string
-                        x-stoplight:
-                          id: 6olj9c38mv9w4
                         description: The permission description
                       isCustom:
                         type: boolean
-                        x-stoplight:
-                          id: ctjv4ta4ljhru
                         description: Whether the permission is custom
                       moduleName:
                         type: string
-                        x-stoplight:
-                          id: 4s42w6xufbxjc
                         description: The name of the module to which the permission belongs
                   meta:
                     type: object
-                    x-stoplight:
-                      id: khawlr3n42cht
                     properties:
                       message:
                         type: string
-                        x-stoplight:
-                          id: ok1w3txjw1tkg
                         default: SUCCESS
               examples:
                 Example 1:
@@ -2425,26 +2369,18 @@ paths:
               properties:
                 name:
                   type: string
-                  x-stoplight:
-                    id: raqpw87cjfe39
                   maxLength: 200
                   description: The permission name
                 code:
                   type: string
-                  x-stoplight:
-                    id: 3uusi0a7hl6fs
                   maxLength: 50
                   description: The permission code
                 description:
                   type: string
-                  x-stoplight:
-                    id: ni669xyrv247k
                   maxLength: 512
                   description: The permission description
                 moduleName:
                   type: string
-                  x-stoplight:
-                    id: bor0fn2a4h0uy
                   maxLength: 50
               required:
                 - name
@@ -2457,7 +2393,7 @@ paths:
                   description: Get addresses
                   code: get_addresses
                   moduleName: address
-        description: 'name, code are unique in the same store'
+        description: "name, code are unique in the same store"
       tags:
         - Company Roles and Permissions
       x-internal: false
@@ -2465,7 +2401,7 @@ paths:
       summary: Delete Company Permission
       operationId: delete-stores-companies-permissions-permissionId
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2474,21 +2410,13 @@ paths:
                 properties:
                   data:
                     type: object
-                    x-stoplight:
-                      id: k8kb5ihx9sfha
                   code:
                     type: integer
-                    x-stoplight:
-                      id: c06mjoj73dvht
                   meta:
                     type: object
-                    x-stoplight:
-                      id: g8uoxxlbsq54j
                     properties:
                       message:
                         type: string
-                        x-stoplight:
-                          id: sgiuz09vwior0
               examples:
                 Example 1:
                   value:
@@ -2511,7 +2439,7 @@ paths:
       tags:
         - Company Roles and Permissions
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2520,39 +2448,25 @@ paths:
                 properties:
                   code:
                     type: integer
-                    x-stoplight:
-                      id: vnwpw3r1kh6ly
                   data:
                     type: array
-                    x-stoplight:
-                      id: fosrawav0as0t
                     items:
-                      x-stoplight:
-                        id: 7jenbzn4473yy
                       type: object
                       properties:
                         id:
                           type: integer
-                          x-stoplight:
-                            id: z3h3px20ik8ka
                           description: The role id
                         name:
                           type: string
-                          x-stoplight:
-                            id: rg90cavwle2bg
                           description: The role name
                         roleType:
                           type: integer
-                          x-stoplight:
-                            id: 42d1k3govhksj
                           enum:
                             - 1 - predefined
                             - 2 - custom
                           description: The role type
                         roleLevel:
                           type: integer
-                          x-stoplight:
-                            id: 1qnm8vdepubsn
                           enum:
                             - 1 - store level
                           description: The role level
@@ -2563,30 +2477,18 @@ paths:
                         - roleLevel
                   meta:
                     type: object
-                    x-stoplight:
-                      id: xxekbl89ndgip
                     properties:
                       message:
                         type: string
-                        x-stoplight:
-                          id: 2bfod2z2pdb62
                       pagination:
                         type: object
-                        x-stoplight:
-                          id: za17np2r45s1i
                         properties:
                           totalCount:
                             type: integer
-                            x-stoplight:
-                              id: 4384bp8xa7oz0
                           limit:
                             type: integer
-                            x-stoplight:
-                              id: gl1ohwz0ef3ic
                           offset:
                             type: integer
-                            x-stoplight:
-                              id: z9v82ygqfz3sy
               examples:
                 Example 1:
                   value:
@@ -2629,7 +2531,7 @@ paths:
       summary: Create Company Role
       operationId: post-stores-companies-roles
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2638,74 +2540,48 @@ paths:
                 properties:
                   code:
                     type: integer
-                    x-stoplight:
-                      id: 2u18iq217751m
                   data:
                     type: object
-                    x-stoplight:
-                      id: k9rdl02d0ntii
                     properties:
                       id:
                         type: integer
-                        x-stoplight:
-                          id: vteez52i917gg
                         description: The role id
                       name:
                         type: string
-                        x-stoplight:
-                          id: 9kk7z7qt6pf20
                         description: The role name
                       roleType:
                         type: integer
-                        x-stoplight:
-                          id: q4gom706sxank
                         enum:
                           - 1 - predefined
                           - 2 - custom
                         description: The role type
                       roleLevel:
                         type: integer
-                        x-stoplight:
-                          id: k2bxlt88j8djm
                         description: The role level
                         enum:
                           - 1 - store level
                       permissions:
                         type: array
-                        x-stoplight:
-                          id: ff23hduj62asz
                         items:
-                          x-stoplight:
-                            id: 3q87taf5es29c
                           type: object
                           properties:
                             id:
                               type: integer
-                              x-stoplight:
-                                id: wytt7embn9dpp
                               description: The permission id
                             code:
                               type: string
-                              x-stoplight:
-                                id: hl73qdbtivoiv
                               description: The permission code
                             permissionLevel:
                               type: integer
-                              x-stoplight:
-                                id: ajbrfm6bu8hne
                               description: The permission level
                               enum:
                                 - 1 - user level
                                 - 2 - company level
                   meta:
                     type: object
-                    x-stoplight:
-                      id: r6eo53t14b5r2
                     properties:
                       message:
                         type: string
-                        x-stoplight:
-                          id: n6884ldx3bjqv
               examples:
                 Example 1:
                   value:
@@ -2733,28 +2609,18 @@ paths:
               properties:
                 name:
                   type: string
-                  x-stoplight:
-                    id: c5ywvchzer3od
                   description: The role name
                   maxLength: 200
                 permissions:
                   type: array
-                  x-stoplight:
-                    id: h4zvhyamkjskx
                   items:
-                    x-stoplight:
-                      id: nrk86m71slqq0
                     type: object
                     properties:
                       code:
                         type: string
-                        x-stoplight:
-                          id: keysbujgwj3q7
                         description: The permission code
                       permissionLevel:
                         type: integer
-                        x-stoplight:
-                          id: tw1314yueke8b
                         description: The permission level
                         enum:
                           - 1 - user level
@@ -2776,7 +2642,7 @@ paths:
         - Company Roles and Permissions
       x-internal: false
     parameters: []
-  '/companies/roles/{roleId}':
+  "/companies/roles/{roleId}":
     parameters:
       - schema:
           type: integer
@@ -2788,7 +2654,7 @@ paths:
       tags:
         - Company Roles and Permissions
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2797,74 +2663,48 @@ paths:
                 properties:
                   code:
                     type: integer
-                    x-stoplight:
-                      id: hx0qsyehm1wzc
                   data:
                     type: object
-                    x-stoplight:
-                      id: pgneaszohuxj2
                     properties:
                       id:
                         type: integer
-                        x-stoplight:
-                          id: k0u84z6h2f3n5
                         description: The role id
                       name:
                         type: string
-                        x-stoplight:
-                          id: iaia723439udo
                         description: The role name
                       roleType:
                         type: integer
-                        x-stoplight:
-                          id: qek4b7xgecqmh
                         description: The role type
                         enum:
                           - 1 - predefined
                           - 2 - custom
                       roleLevel:
                         type: integer
-                        x-stoplight:
-                          id: g3qzopa3lhbbr
                         enum:
                           - 1 - store level
                         description: The role level
                       permissions:
                         type: array
-                        x-stoplight:
-                          id: 3urwsajlu34um
                         items:
-                          x-stoplight:
-                            id: p3s1pt7dn14sl
                           type: object
                           properties:
                             id:
                               type: integer
-                              x-stoplight:
-                                id: 3lsw2ehdsuv6p
                               description: The permission id
                             code:
                               type: string
-                              x-stoplight:
-                                id: grkdr749q868t
                               description: The permission code
                             permissionLevel:
                               type: integer
-                              x-stoplight:
-                                id: e60xsjrybid95
                               description: The permission level
                               enum:
                                 - 1 - user level
                                 - 2 - company level
                   meta:
                     type: object
-                    x-stoplight:
-                      id: a6311k64rpbj0
                     properties:
                       message:
                         type: string
-                        x-stoplight:
-                          id: ep3wt4vsinoma
               examples:
                 Example 1:
                   value:
@@ -2880,7 +2720,7 @@ paths:
                           permissionLevel: 2
                     meta:
                       message: SUCCESS
-      operationId: 'get-stores-companies-roles-int:roleId'
+      operationId: "get-stores-companies-roles-int:roleId"
       description: Get company role detail
       security:
         - authToken: []
@@ -2890,7 +2730,7 @@ paths:
       summary: Update Company Role
       operationId: put-stores-companies-roles-roleId
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2899,12 +2739,8 @@ paths:
                 properties:
                   code:
                     type: integer
-                    x-stoplight:
-                      id: 9x2nutwg143w2
                   data:
                     type: object
-                    x-stoplight:
-                      id: v41nr6bz2brso
                     properties:
                       id:
                         type: integer
@@ -2942,13 +2778,9 @@ paths:
                                 - 2 - company level
                   meta:
                     type: object
-                    x-stoplight:
-                      id: qz7b2k46oetyl
                     properties:
                       message:
                         type: string
-                        x-stoplight:
-                          id: a74ssono1wggh
               examples:
                 Example 1:
                   value:
@@ -2979,28 +2811,18 @@ paths:
               properties:
                 name:
                   type: string
-                  x-stoplight:
-                    id: zzmc8ckjnqt7h
                   maxLength: 200
                 permissions:
                   type: array
-                  x-stoplight:
-                    id: 7x2n3ou22dfs1
                   description: permission only support full update
                   items:
-                    x-stoplight:
-                      id: 5i5ykudn167t5
                     type: object
                     properties:
                       code:
                         type: string
-                        x-stoplight:
-                          id: 8evqzvawzsghi
                         description: The permission code
                       permissionLevel:
                         type: integer
-                        x-stoplight:
-                          id: poeycbgyot4qv
                         description: The ermission level
                         enum:
                           - 1 - user level
@@ -3025,7 +2847,7 @@ paths:
       summary: Delete Company Role
       operationId: delete-stores-companies-roles-roleId
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -3034,21 +2856,13 @@ paths:
                 properties:
                   code:
                     type: integer
-                    x-stoplight:
-                      id: mp78kz0m6y8rd
                   data:
                     type: object
-                    x-stoplight:
-                      id: nlkj2dhwb4y39
                   meta:
                     type: object
-                    x-stoplight:
-                      id: 6ii0tzes2zxvr
                     properties:
                       message:
                         type: string
-                        x-stoplight:
-                          id: x9ee1ak53kzzk
               examples:
                 Example 1:
                   value:
@@ -3067,6 +2881,171 @@ paths:
       tags:
         - Company Roles and Permissions
       x-internal: false
+  "/companies/{companyId}/attachments":
+    parameters:
+      - schema:
+          type: number
+        name: companyId
+        in: path
+        required: true
+        description: company Id
+    get:
+      summary: Get Company Attachments
+      tags:
+        - Company
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: number
+                    example: 200
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        attachmentUrl:
+                          type: string
+                  meta:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                        default: SUCCESS
+              examples:
+                Example 1:
+                  value:
+                    code: 200
+                    data:
+                      - id: f593d7c8-078e-4bb6-af6b-688ef8df1ijn
+                        attachmentUrl: "https://xxx.com/xxx.csv"
+                    meta:
+                      message: SUCCESS
+      operationId: get-companies-companyId-attachments
+      description: Get company attachments
+      security:
+        - authToken: []
+    post:
+      summary: Add Company Attachment
+      operationId: post-companies-companyId-attachments
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: number
+                    default: 200
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      attachmentFile:
+                        type: string
+                  meta:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                        default: SUCCESS
+              examples:
+                Example 1:
+                  value:
+                    code: 200
+                    data:
+                      id: 497f6eca-6276-4993-bfeb-53cbbbba6f08
+                      attachmentFile: "https://xxx.com/xxx.csv"
+                    meta:
+                      message: SUCCESS
+      description: |-
+        Each company can upload a maximum of 10 attachments.
+
+        The API rate limit is 15/min per store.
+
+        The attachments support the following file types:
+        - Images, including bmp, gif, ico, jpeg, jpg, png, svg, tif, tiff, webp, wbmp, xbm.
+        - PDF
+        - DOC, DOCX
+        - XLS, XLSX
+        - CSV
+      security:
+        - authToken: []
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                attachmentFile:
+                  type: string
+                  format: binary
+                  description: The size of each attachment must not exceed 10MB.
+              required:
+                - attachmentFile
+        description: ""
+      tags:
+        - Company
+  "/companies/{companyId}/attachments/{attachmentId}":
+    parameters:
+      - schema:
+          type: number
+        name: companyId
+        in: path
+        required: true
+        description: company Id
+      - schema:
+          type: string
+          format: uuid
+        name: attachmentId
+        in: path
+        required: true
+        description: attachment Id
+    delete:
+      summary: Delete Company Attachment
+      operationId: delete-companies-companyId-attachments-attachmentId
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: number
+                    default: 200
+                  data:
+                    type: object
+                  meta:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                        default: SUCCESS
+              examples:
+                Example 1:
+                  value:
+                    code: 200
+                    data: {}
+                    meta:
+                      message: SUCCESS
+      security:
+        - authToken: []
+      tags:
+        - Company
 components:
   securitySchemes:
     authToken:

--- a/docs/b2b-edition/specs/api-v3/company/company.yaml
+++ b/docs/b2b-edition/specs/api-v3/company/company.yaml
@@ -2,13 +2,13 @@ openapi: 3.0.1
 info:
   title: Company
   description: |-
-    A company in B2B Edition corresponds one-to-one with a customer group in BigCommerce. The mapping is done through the bc_group_id field. Once established, this corresponding relationship cannot be changed and can only be deleted. Note that neither BigCommerce customer groups nor B2B Edition companies can be merged.
+    A company in B2B Edition corresponds one-to-one with a customer group in BigCommerce. You can do the mapping through the `bc_group_id` field. Once established, you cannot change this corresponding relationship. You can only delete it. Note that you cannot merge BigCommerce customer groups or B2B Edition companies.
 
-    This is a simple entity diagram of customer groups and companies:
+    This diagram details the relation between customer groups and companies:
 
     ![Company entity diagram](https://user-images.githubusercontent.com/81215728/124566045-424fd480-de75-11eb-8268-a15ae40fb579.jpg)
 
-    The best practice for using these Company APIs is to maintain unidirectional data flow, with B2B Edition endpoints as the primary touchpoint. The operation of modifying linked BigCommerce customer group data (add, update, and delete) is completed by B2B Edition's company operations.
+    The best practice for using these Company APIs is to maintain unidirectional data flow, with B2B Edition endpoints as the primary touchpoint. By default B2B Edition's company operations handle modifying linked BigCommerce customer group data (add, update, and delete).
   contact: {}
   version: v3
 servers:
@@ -24,7 +24,7 @@ paths:
       tags:
         - Company
       summary: Get All Companies
-      description: Get a list of all companies
+      description: Get a list of all companies.
       operationId: get-companies
       parameters:
         - name: limit
@@ -66,7 +66,7 @@ paths:
             type: number
         - name: sortBy
           in: query
-          description: Sort the result by a specific company field
+          description: Sort the result by a specific company field.
           schema:
             type: string
             default: updatedAt
@@ -86,7 +86,7 @@ paths:
             example: DESC
         - name: isIncludeExtraFields
           in: query
-          description: Should extra fields be shown in the response
+          description: Whether the response will include extra fields.
           schema:
             type: string
             default: "0"
@@ -113,9 +113,9 @@ paths:
           description: |-
             Filter the company list on extra fields. (include extraInt1 ~ extraInt5, extraStr1 ~ extraStr5 and other customizable)
 
-            This value may be passed into the custom extra field configured by the B3 team when you create the company.
+            When you create the company, you can pass a value into the custom extra field configured by the B3 team.
 
-            If you clearly know the correspondence between the custom extra field and the default extra field, you can use the default extra field filter to obtain data.
+            If you know the correspondence between the custom extra field and the default extra field, you can use the default extra field filter to obtain data.
 
             You can also filter by key-value pairs passed into custom fields:
             https://api-b2b.bigcommerce.com/api/v2/io/companies/?extraFields=extraInt1:1&extraFields=companyTax:un42
@@ -128,7 +128,7 @@ paths:
             example: 2
           in: query
           name: bcOrderId
-          description: "Company purchase bc order id, allow you found company by bc order id"
+          description: "A company purchases a BigCommerce order ID, which allows you to find the company by BigCommerce order ID."
         - schema:
             type: string
           in: query
@@ -143,7 +143,7 @@ paths:
             type: integer
           in: query
           name: customerId
-          description: "BigCommerce customer id, this customer should be a B2B company user"
+          description: "BigCommerce customer ID. This customer should be a B2B company user."
         - schema:
             type: string
             enum:
@@ -152,7 +152,7 @@ paths:
             default: search
           in: query
           name: extraFieldFilterType
-          description: "extra field filter type. The search filter type allows for partial matches, while the exact-match filter type only returns results that exactly match the specified criteria."
+          description: "Extra field filter type. The search filter type allows for partial matches, while the exact-match filter type only returns results that exactly match the specified criteria."
       responses:
         "200":
           description: OK
@@ -521,7 +521,7 @@ paths:
                       description: BC price list Id that company related
                     acceptCreationEmail:
                       type: boolean
-                      description: "True: Will send email company creation notification to admin user; False: Will not send"
+                      description: "True: Sends an email notification about the company creation to the admin user; False: Does not send the notification."
                       default: false
                     channelIds:
                       type: array
@@ -530,7 +530,7 @@ paths:
                         type: integer
                     originChannelId:
                       type: integer
-                      description: "BigCommerce channel id, used for BigCommerce customer origin channel id. This field takes effect only when the store default b2b channel is not configured"
+                      description: "BigCommerce channel ID, used for BigCommerce customer origin channel ID. This field takes effect only when you do not configure the store default B2B channel."
             examples:
               example-1:
                 value:
@@ -635,7 +635,7 @@ paths:
                     meta:
                       message: Create BC customer group failed
         "422":
-          description: "Company was not valid. This is the result of missing required fields, or of invalid data. See the response for more details"
+          description: "Company was not valid. This is the result of missing required fields, or of invalid data. See the response for more details."
           content:
             application/json:
               schema:
@@ -673,7 +673,7 @@ paths:
       tags:
         - Company
       summary: Get a Company
-      description: Get details about a specific company
+      description: Get details about a specific company.
       operationId: get-companies-companyId
       parameters:
         - name: companyId
@@ -1447,9 +1447,9 @@ paths:
                     - id: "42"
                       detail: ""
                 meta:
-                  message: "Some companies updated failed, you can see these in errors"
+                  message: "Some companies updated failed, you can see these in errors."
         "409":
-          description: "Company was in conflict with another company. This is the result of duplicate unique values; A missing or invalid `companyEmail`, `phoneNumber` or other extraFields"
+          description: "Company was in conflict with another company. This is the result of duplicate unique values; A missing or invalid `companyEmail`, `phoneNumber` or other extraFields."
           content:
             application/json:
               schema:
@@ -1609,7 +1609,7 @@ paths:
                           type: integer
                       originChannelId:
                         type: integer
-                        description: "BigCommerce channel id, used for BigCommerce customer origin channel id. This field takes effect only when the store default b2b channel is not configured"
+                        description: "BigCommerce channel ID, used for BigCommerce customer origin channel ID. This field takes effect only when you do not configure the store default b2b channel."
                   - $ref: https://raw.githubusercontent.com/bigcommerce/docs/main/docs/b2b-edition/models/extra_fields/user_extra_field_values.yaml
             examples:
               example-1:
@@ -2290,7 +2290,7 @@ paths:
                   description: Get addresses
                   code: get_addresses
                   moduleName: address
-        description: "name, code are unique in the same store."
+        description: "name, code is unique in the same store."
       parameters: []
       tags:
         - Company Roles and Permissions
@@ -2393,7 +2393,7 @@ paths:
                   description: Get addresses
                   code: get_addresses
                   moduleName: address
-        description: "name, code are unique in the same store"
+        description: "The name and code are unique within the same store."
       tags:
         - Company Roles and Permissions
       x-internal: false


### PR DESCRIPTION
## What changed?
- Moved over B2B endpoints for Company Attachments that launched since the initial docs transfer into our dev center
- Improved some of the descriptions in the spec
- Removed unnecessary x-stoplight references

ping @bigcommerce/dev-docs-team @bigcommerce/team-b2b 
