### PR TITLE
ORDERS-6362: [add] is_tax_inclusive_pricing field in orders response 

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -3918,10 +3918,6 @@ components:
           description: Override value for the total, including tax. If specified, the field `total_ex_tax` is also required. The value can't be negative. (Float, Float-As-String, Integer)
           example: '225.0000'
           type: string
-        is_tax_inclusive_pricing:
-          description: Indicates whether the order total is inclusive of tax.
-          example: false
-          type: boolean
         wrapping_cost_ex_tax:
           description: The value of the wrapping cost, excluding tax. The value can't be negative. (Float, Float-As-String, Integer)
           example: '0.0000'
@@ -4137,7 +4133,12 @@ components:
           example: false
           type: boolean
         is_tax_inclusive_pricing:
-          description: Indicates whether the order total is inclusive of tax.
+          description: |-
+            Indicate whether the order's base prices include tax.
+
+            If true, the base prices are inclusive of tax, and the values of `subtotal_inc_tax`, `shipping_cost_inc_tax`, `handling_cost_inc_tax`, `wrapping_cost_inc_tax` and `total_inc_tax` are not estimated but actual values and can be reliable for accounting purposes.
+
+            If false, the base prices are exclusive of tax, and the values of `subtotal_ex_tax`, `shipping_cost_ex_tax`, `handling_cost_ex_tax`, `wrapping_cost_ex_tax` and `total_ex_tax` are not estimated but actual values and can be reliable for accounting purposes.
           example: false
           type: boolean
         is_email_opt_in:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
https://bigcommercecloud.atlassian.net/browse/ORDERS-6362

## What changed?
<!-- Provide a bulleted list in the present tense -->
* Added  is_tax_inclusive_pricing field in orders response


Swagger Proof:

https://github.com/user-attachments/assets/86560ebf-3fc7-482d-93b3-4190699b8c96

 

