### PR TITLE
Issue-538

### DIFF
--- a/docs/storefront/stencil/utils/events.mdx
+++ b/docs/storefront/stencil/utils/events.mdx
@@ -106,8 +106,3 @@ searchEvents() {
 | data-faceted-search-facet | click | facetedSearch-facet-clicked | event |
 | data-faceted-search-range | submit | facetedSearch-range-submitted | event |
 
-
-## Resources
-
-### Additional Resources
-* [cookieNotification.js](https://github.com/bigcommerce/cornerstone/blob/637ef1b0ff130333aea128663daa6d1a4d37fb78/assets/js/theme/global/cookieNotification.js) (BigCommerce GitHub)


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [Issue-538](https://github.com/bigcommerce/docs/issues/538)


## What changed?
removed Resources and Additional resources because the one reference is outdated. See slack conversation: https://bigcommerce.slack.com/archives/C05CZVCC23Z/p1727273685497769

## Release notes draft

Bug Fix: legacy references that has been replaced by the native shopper consent functionality


## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}
