### PR TITLE
DEVDOCS-6111: [update] deprecate upsert form fields

### DIFF
--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -1483,11 +1483,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-      summary: Upsert Customer Form Field Values
+      summary: Upsert Customer Form Field Values (Deprecated)
       description: |-
-        Updates form field values on the Customer or Customer Address objects. Multiple form field values can be updated in one call.
-
-        Upsert checks for an existing record, if there is none it creates the record, if there is a matching record it updates that record.
+        This endpoint is deprecated. Use [Update a Customer Address](/docs/rest-management/customers/addresses#update-a-customer-address) and [Update Customers](/docs/rest-management/customers#update-customers) endpoints instead.
 
         To learn more about editing form fields, see [Adding and Editing Fields in the Account Signup Form](https://support.bigcommerce.com/s/article/Editing-Form-Fields).
 


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6111]


## What changed?
deprecated the customer form fields endpoint

## Release notes draft

The Upsert Customer Form Field Values endpoint is deprecated. Use [Update a Customer Address](/docs/rest-management/customers/addresses#update-a-customer-address) and [Update Customers](/docs/rest-management/customers#update-customers) endpoints instead.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6111]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ