### PR TITLE
DEVDOCS-5701: [update] add notes about emails

### DIFF
--- a/docs/store-operations/orders/index.mdx
+++ b/docs/store-operations/orders/index.mdx
@@ -51,7 +51,7 @@ Accept: application/json
 <Callout type= "info">
   * The example above contains the minimum required fields for a [create order](/docs/rest-management/orders#create-an-order) request.
   * The product ordered is a *custom* product; custom products do not exist in the catalog.
-  * An email will not be sent for orders created with the v2 API. Developers should create a cart and then use the checkout API to create the order if they want an order notification to be sent.
+  * An email will not be sent for orders created with the Orders V2 API. Developers should create a cart and then use the checkout API to create the order if they want an order notification to be sent.
 </Callout>
 
 ## Changing order status

--- a/docs/store-operations/orders/index.mdx
+++ b/docs/store-operations/orders/index.mdx
@@ -51,6 +51,7 @@ Accept: application/json
 <Callout type= "info">
   * The example above contains the minimum required fields for a [create order](/docs/rest-management/orders#create-an-order) request.
   * The product ordered is a *custom* product; custom products do not exist in the catalog.
+  * An email will not be sent for orders created with the v2 API. Developers should create a cart and then use the checkout API to create the order if they want an order notification to be sent.
 </Callout>
 
 ## Changing order status
@@ -573,4 +574,4 @@ Not at this time. If you create an order either in the control panel or by API, 
 
 ### Webhooks
 
-* [Orders](/docs/integrations/webhooks/events#orders
+* [Orders](/docs/integrations/webhooks/events#orders)

--- a/docs/store-operations/orders/index.mdx
+++ b/docs/store-operations/orders/index.mdx
@@ -51,7 +51,7 @@ Accept: application/json
 <Callout type= "info">
   * The example above contains the minimum required fields for a [create order](/docs/rest-management/orders#create-an-order) request.
   * The product ordered is a *custom* product; custom products do not exist in the catalog.
-  * An email will not be sent for orders created with the Orders V2 API. Developers should create a cart and then use the checkout API to create the order if they want an order notification to be sent.
+  * The V2 Orders API will not trigger the typical [Order Email](https://support.bigcommerce.com/s/article/Customizing-Emails?language=en_US) when creating orders. To create an order that does trigger this email, you can instead [create a cart](/docs/rest-management/carts/carts-single#create-a-cart) and [convert that cart into an order](/docs/rest-management/checkouts/checkout-orders#create-an-order).
 </Callout>
 
 ## Changing order status

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -271,6 +271,9 @@ paths:
         This means that if the `consignments` array is present in the request, then _none_ of the following may be present and vice-versa:
         - `shipping_addresses`
         - `products`
+
+        An email will not be sent for orders created with the Orders V2 API. Developers should create a cart and then use the checkout API to create the order if they want an order notification to be sent.
+        
       summary: Create an Order
       tags:
         - Orders

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -272,7 +272,7 @@ paths:
         - `shipping_addresses`
         - `products`
 
-        An email will not be sent for orders created with the Orders V2 API. Developers should create a cart and then use the checkout API to create the order if they want an order notification to be sent.
+        The V2 Orders API will not trigger the typical [Order Email](https://support.bigcommerce.com/s/article/Customizing-Emails?language=en_US) when creating orders. To create an order that does trigger this email, you can instead [create a cart](/docs/rest-management/carts/carts-single#create-a-cart) and [convert that cart into an order](/docs/rest-management/checkouts/checkout-orders#create-an-order).
         
       summary: Create an Order
       tags:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-5701]


## What changed?
added a note 

## Release notes draft

Enhancement:
Added a note: orders created through the v2 Orders API will not result in an order notification email being sent to the customer.
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-5701]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ