### PR TITLE
Update b2b bearer token to follow OAS spec

### DIFF
--- a/docs/b2b-edition/specs/storefront/storefront/catalog.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/catalog.yaml
@@ -397,13 +397,12 @@ components:
   schemas: {}
   securitySchemes:
     BearerToken:
-      name: BearerToken
       description: |-
         ### Authentication header
         | Header | Argument | Description |
         |:-------|:---------|:------------|
         |`Authorization`|`Bearer {{B2B_JWT_TOKEN}}`| You can obtain this token using the steps described in the [REST Storefront API](/b2b-edition/docs/authentication#rest-storefront-api) section of the [Authentication for hosted storefront](https://developer.bigcommerce.com/b2b-edition/docs/authentication) article. |
-      type: apiKey
-      in: header
+      type: http
+      scheme: bearer
 tags:
   - name: Catalog

--- a/docs/b2b-edition/specs/storefront/storefront/company.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/company.yaml
@@ -5010,14 +5010,13 @@ components:
   schemas: {}
   securitySchemes:
     BearerToken:
-      name: BearerToken
       description: |-
         ### Authentication header
         | Header | Argument | Description |
         |:-------|:---------|:------------|
         |`Authorization`|`Bearer {{B2B_JWT_TOKEN}}`| You can obtain this token using the steps described in the [REST Storefront API](/b2b-edition/docs/authentication#rest-storefront-api) section of the [Authentication for hosted storefront](https://developer.bigcommerce.com/b2b-edition/docs/authentication) article. |
-      type: apiKey
-      in: header
+      type: http
+      scheme: bearer
 tags:
   - name: Company
   - name: User

--- a/docs/b2b-edition/specs/storefront/storefront/order.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/order.yaml
@@ -2067,13 +2067,12 @@ components:
   schemas: {}
   securitySchemes:
     BearerToken:
-      name: BearerToken
       description: |-
         ### Authentication header
         | Header | Argument | Description |
         |:-------|:---------|:------------|
         |`Authorization`|`Bearer {{B2B_JWT_TOKEN}}`| You can obtain this token using the steps described in the [REST Storefront API](/b2b-edition/docs/authentication#rest-storefront-api) section of the [Authentication for hosted storefront](https://developer.bigcommerce.com/b2b-edition/docs/authentication) article. |
-      type: apiKey
-      in: header
+      type: http
+      scheme: bearer
 tags:
   - name: Order

--- a/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
@@ -2112,14 +2112,13 @@ components:
   schemas: {}
   securitySchemes:
     BearerToken:
-      name: BearerToken
       description: |-
         ### Authentication header
         | Header | Argument | Description |
         |:-------|:---------|:------------|
         |`Authorization`|`Bearer {{B2B_JWT_TOKEN}}`| You can obtain this token using the steps described in the [REST Storefront API](/b2b-edition/docs/authentication#rest-storefront-api) section of the [Authentication for hosted storefront](https://developer.bigcommerce.com/b2b-edition/docs/authentication) article. |
-      type: apiKey
-      in: header
+      type: http
+      scheme: bearer
 tags:
   - name: RFQ
 x-internal: false

--- a/docs/b2b-edition/specs/storefront/storefront/sales-rep.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/sales-rep.yaml
@@ -488,13 +488,12 @@ components:
   schemas: {}
   securitySchemes:
     BearerToken:
-      name: BearerToken
       description: |-
         ### Authentication header
         | Header | Argument | Description |
         |:-------|:---------|:------------|
         |`Authorization`|`Bearer {{B2B_JWT_TOKEN}}`| You can obtain this token using the steps described in the [REST Storefront API](/b2b-edition/docs/authentication#rest-storefront-api) section of the [Authentication for hosted storefront](https://developer.bigcommerce.com/b2b-edition/docs/authentication) article. |
-      type: apiKey
-      in: header
+      type: http
+      scheme: bearer
 tags:
   - name: Super Admin

--- a/docs/b2b-edition/specs/storefront/storefront/shopping.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/shopping.yaml
@@ -1117,13 +1117,12 @@ components:
   schemas: {}
   securitySchemes:
     BearerToken:
-      name: BearerToken
       description: |-
         ### Authentication header
         | Header | Argument | Description |
         |:-------|:---------|:------------|
         |`Authorization`|`Bearer {{B2B_JWT_TOKEN}}`| You can obtain this token using the steps described in the [REST Storefront API](/b2b-edition/docs/authentication#rest-storefront-api) section of the [Authentication for hosted storefront](https://developer.bigcommerce.com/b2b-edition/docs/authentication) article. |
-      type: apiKey
-      in: header
+      type: http
+      scheme: bearer
 tags:
   - name: Shopping

--- a/docs/b2b-edition/specs/storefront/storefront/store.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/store.yaml
@@ -409,13 +409,12 @@ components:
   schemas: {}
   securitySchemes:
     BearerToken:
-      name: BearerToken
       description: |-
         ### Authentication header
         | Header | Argument | Description |
         |:-------|:---------|:------------|
         |`Authorization`|`Bearer {{B2B_JWT_TOKEN}}`| You can obtain this token using the steps described in the [REST Storefront API](/b2b-edition/docs/authentication#rest-storefront-api) section of the [Authentication for hosted storefront](https://developer.bigcommerce.com/b2b-edition/docs/authentication) article. |
-      type: apiKey
-      in: header
+      type: http
+      scheme: bearer
 tags:
   - name: Store


### PR DESCRIPTION

## What changed?
Updated BearerToken security scheme for B2B storefront specs to follow OAS spec. This is needed so they render under the Authorization section in the right way.

