### PR TITLE
ORDERS-5733: [add] Order Fees to Refund documentation

### DIFF
--- a/docs/store-operations/orders/refunds.mdx
+++ b/docs/store-operations/orders/refunds.mdx
@@ -51,6 +51,11 @@ To [create a refund quote](/docs/rest-management/transactions/payment-actions#cr
           "item_type": "ORDER",    // Tax-exempt order level refund
           "item_id": 9,            // Order ID
           "amount": 1,             // Amount to refund
+        },
+        {
+          "item_type": "FEE",     // Refund a fee
+          "item_id": 11,          // Fee ID
+          "amount": 1,            // Amount to refund
         }
       ]
     }
@@ -118,6 +123,11 @@ Use the `provider_id`, the `amount`, and `items` from the [refund quote](#creati
         {
           "item_type": "ORDER",   // Tax-exempt order level refund
           "item_id": 123,         // Order ID
+          "amount": 1,            // Amount to refund
+        },
+        {
+          "item_type": "FEE",     // Refund a fee
+          "item_id": 11,          // Fee ID
           "amount": 1,            // Amount to refund
         }
       ],

--- a/reference/orders.v3.yml
+++ b/reference/orders.v3.yml
@@ -2499,10 +2499,11 @@ components:
                       - SHIPPING
                       - HANDLING
                       - ORDER
+                      - FEE
                   item_id:
                     type: integer
                     description: |
-                      `order_product.id` corresponding to the item_types of PRODUCT, GIFT_WRAPPING. `order_address.id` corresponding to the item_types of SHIPPING, HANDLING. `order.id` corresponding to the item_type of ORDER.
+                      `order_product.id` corresponding to the item_types of PRODUCT, GIFT_WRAPPING. `order_address.id` corresponding to the item_types of SHIPPING, HANDLING. `order.id` corresponding to the item_type of ORDER, FEE.
                   quantity:
                     type: integer
                     description: |
@@ -2548,6 +2549,7 @@ components:
         - $ref: '#/components/schemas/AmountBoundItem'
         - $ref: '#/components/schemas/QuantityBoundItem'
         - $ref: '#/components/schemas/TaxExemptItem'
+        - $ref: '#/components/schemas/FeeItem'
     PaymentRequest:
       type: object
       properties:
@@ -2585,6 +2587,7 @@ components:
         * `SHIPPING`
         * `HANDLING`
         * `TAX`
+        * `FEE`
       properties:
         item_type:
           type: string
@@ -2596,6 +2599,7 @@ components:
             - SHIPPING
             - HANDLING
             - TAX
+            - FEE
           description: Type of refund.
         item_id:
           type: integer
@@ -2635,6 +2639,30 @@ components:
           minLength: 0
           maxLength: 255
           example: 'Service fee'
+    FeeItem:
+      type: object
+      title: Fee
+      description: 'Use this field to refund a custom fee at the order level.'
+      x-internal: false
+      properties:
+        item_type:
+          type: string
+          description: 'The type of refund.'
+          example: FEE
+          enum:
+            - FEE
+        item_id:
+          type: number
+          description: Numeric ID of the fee in the order.
+          example: 1
+        amount:
+          $ref: '#/components/schemas/Amount'
+        reason:
+          type: string
+          description: Reason for the refund.
+          minLength: 0
+          maxLength: 1000
+          example: Customer requested refund
     TaxExemptItem:
       type: object
       title: Tax Exempt (Order Level)
@@ -2671,6 +2699,7 @@ components:
         * `SHIPPING`
         * `HANDLING`
         * `TAX`
+        * `FEE`
       x-internal: false
       properties:
         item_type:
@@ -2682,6 +2711,7 @@ components:
             - SHIPPING
             - HANDLING
             - TAX
+            - FEE
           example: SHIPPING
           description: Type of refund.
         item_id:
@@ -2777,6 +2807,7 @@ components:
             - SHIPPING
             - HANDLING
             - ORDER
+            - FEE
         item_id:
           type: integer
           description: 'order_product.id corresponding to the item_types of PRODUCT, GIFT_WRAPPING. order_address.id corresponding to the item_types of SHIPPING, HANDLING. order.id corresponding to the item_type of ORDER.'


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [
[ORDERS-5733](https://bigcommercecloud.atlassian.net/browse/ORDERS-5733)
## What changed?
<!-- Provide a bulleted list in the present tense -->
* Added `fee` item type to refund API documentation

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Proof
<img width="708" alt="image" src="https://github.com/user-attachments/assets/30001840-1ccf-41f8-990c-8f53792cb0d5">



[ORDERS-5733]: https://bigcommercecloud.atlassian.net/browse/ORDERS-5733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ