### PR TITLE
DEVDOCS-6142: Shipping V2 API, update channel_ids field

### DIFF
--- a/reference/shipping.v2.yml
+++ b/reference/shipping.v2.yml
@@ -733,7 +733,7 @@ paths:
                       handling_fees:
                         fixed_surcharge: "0"
                       is_fallback: false
-                      channels: [2, 3]
+                      channel_ids: [2, 3]
                     - id: 2
                       name: Pickup In Store
                       type: total
@@ -742,7 +742,7 @@ paths:
                       handling_fees:
                         fixed_surcharge: "0"
                       is_fallback: false
-                      channels: [1, 3]
+                      channel_ids: [1, 3]
                     - id: 3
                       name: Ship by Weight
                       type: weight
@@ -766,7 +766,7 @@ paths:
                       handling_fees:
                         fixed_surcharge: "0"
                       is_fallback: false
-                      channels: [1]
+                      channel_ids: [1]
                     - id: 4
                       name: UPS®
                       type: upsready
@@ -788,7 +788,7 @@ paths:
                       handling_fees:
                         fixed_surcharge: "0"
                       is_fallback: false
-                      channels: [1]
+                      channel_ids: [1]
                 Example 2:
                   value:
                     - id: 23225205
@@ -799,7 +799,7 @@ paths:
                       handling_fees:
                         fixed_surcharge: "0"
                       is_fallback: false
-                      channels: [1, 2]
+                      channel_ids: [1, 2]
                     - id: 35889344
                       name: Lorem Excepteur esse
                       type: canadapost
@@ -808,7 +808,7 @@ paths:
                       handling_fees:
                         percentage_surcharge: "0"
                       is_fallback: false
-                      channels: [1]
+                      channel_ids: [1]
       operationId: getShippingZoneMethods
     post:
       description: |-
@@ -1207,7 +1207,7 @@ paths:
           "settings": {
             "rate": 5
           },
-          channels: [1, 3]
+          channel_ids: [1, 3]
         }
         ```
 
@@ -1232,7 +1232,7 @@ paths:
               enabled: true
               handling_fees:
                 fixed_surcharge: "3"
-              channels: [1]
+              channel_ids: [1]
         required: true
       responses:
         '200':
@@ -1252,7 +1252,7 @@ paths:
                     enabled: true
                     handling_fees:
                       fixed_surcharge: "3"
-                    channels: [1]
+                    channel_ids: [1]
                 Example 2:
                   value:
                     id: 19609616
@@ -1263,7 +1263,7 @@ paths:
                     handling_fees:
                       fixed_surcharge: "0"
                     is_fallback: false
-                    channels: [1]
+                    channel_ids: [1]
       operationId: createShippingMethod
     parameters:
       - $ref: '#/components/parameters/Accept'
@@ -1322,7 +1322,7 @@ paths:
             "settings": {
                 "rate": 8
             },
-            "channels: [1]
+            "channel_ids: [1]
         },
         ```
 
@@ -1446,7 +1446,7 @@ paths:
           "settings": {
             "rate": 5
           },
-          channels: [1, 3]
+          channel_ids: [1, 3]
         }
         ```
 
@@ -1505,7 +1505,7 @@ paths:
                     description: Whether or not this shipping zone is the fallback if all others are not valid for the order.
                     example: false
                     type: boolean
-                  channels:
+                  channel_ids:
                     description: List of channels associated to a method. When creating a new method, all available channels are associated by default. (Optional)
                     example: [1, 3]
                     type: array
@@ -1523,7 +1523,7 @@ paths:
                     handling_fees:
                       fixed_surcharge: "0"
                     is_fallback: false
-                    channels: [1]
+                    channel_ids: [1]
                 Example 2:
                   value:
                     id: 71711609
@@ -1534,7 +1534,7 @@ paths:
                     handling_fees:
                       percentage_surcharge: "0"
                     is_fallback: false
-                    channels: [2, 4]
+                    channel_ids: [2, 4]
       x-unitTests: []
       x-operation-settings:
         CollectParameters: false
@@ -1711,7 +1711,7 @@ paths:
           "settings": {
           "rate": 5
           },
-          channels: [1, 3]
+          channel_ids: [1, 3]
         }
         ```
 
@@ -1733,7 +1733,7 @@ paths:
                 rate: 11
               handling_fees:
                 fixed_surcharge: "0"
-              channels: [2, 3]
+              channel_ids: [2, 3]
         required: true
       responses:
         '200':
@@ -1753,7 +1753,7 @@ paths:
                     enabled: true
                     handling_fees:
                       fixed_surcharge: "0"
-                    channels: [2, 3]
+                    channel_ids: [2, 3]
                 Example 2:
                   value:
                     id: 8176684
@@ -1764,7 +1764,7 @@ paths:
                     handling_fees:
                       fixed_surcharge: "0"
                     is_fallback: false
-                    channels: [1]
+                    channel_ids: [1]
       x-unitTests: []
       x-operation-settings:
         CollectParameters: false
@@ -2418,7 +2418,7 @@ components:
           description: Whether or not this shipping method is a fallback method used when advanced shipping rules are unavailable.
           example: false
           type: boolean
-        channels:
+        channel_ids:
           description: List of channels associated to a method. When creating a new method, all available channels are associated by default. (Optional)
           example: [1, 3]
           type: array


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6142]

Relates to [PR 554](https://github.com/bigcommerce/docs/pull/554)

## What changed?
- Fix incorrect field in Shipping V2 API documentation.

![channels](https://github.com/user-attachments/assets/15982306-22e7-4cc2-a396-892d88c7d4de)


## Release notes draft
(will use release note draft from [PR 556](https://github.com/bigcommerce/docs/pull/556), since that will go in the next changelog) 
 

## Anything else?


@bigcommerce/team-shipping 


[DEVDOCS-6142]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ