### PR TITLE
DEVDOCS-6142: Shipping V2 API, update channel_ids field (part 2)

### DIFF
--- a/docs/store-operations/shipping/msf-international-enhancements.mdx
+++ b/docs/store-operations/shipping/msf-international-enhancements.mdx
@@ -15,7 +15,7 @@ We don't support multiple accounts of the same carrier (e.g., using distinct acc
 
 ## Settings
 
-Shipping methods have a `channels` setting. This setting determines which channels can display the shipping zone's method. Shipping methods are available on all channels by default.
+Shipping methods have a `channel_ids` setting. This setting determines which channels can display the shipping zone's method. Shipping methods are available on all channels by default.
 
 For reference, see the [Shipping method](/docs/rest-management/shipping-v2/shipping-method) endpoint of the REST Management API.
 
@@ -42,7 +42,7 @@ The following example creates a shipping method in a zone by sending a request t
     "handling_fees": {
       "fixed_surcharge": "3"
     },
-    "channels": [1, 3]
+    "channel_ids": [1, 3]
   }
   ```
 
@@ -61,7 +61,7 @@ The following example creates a shipping method in a zone by sending a request t
     "handling_fees": {
         "fixed_surcharge": "3"
     },
-    "channels": [1, 3]
+    "channel_ids": [1, 3]
   }
   ```
 

--- a/reference/shipping.v2.yml
+++ b/reference/shipping.v2.yml
@@ -1213,7 +1213,7 @@ paths:
 
         | Property | Type | Description |
         | - | - | - |
-        | channels | array | Channels associated with the method as an array of integers. |
+        | channel_ids | array | Channels associated with the method as an array of integers. |
       summary: Create a Shipping Method
       tags:
         - Shipping Method
@@ -1301,7 +1301,7 @@ paths:
             "settings": {
                 "rate": 7
             },
-            "channels": [1]
+            "channel_ids": [1]
         },
         ```
 
@@ -1358,7 +1358,7 @@ paths:
                     }
                 ]
             },
-            "channels": [1]
+            "channel_ids": [1]
         }
         ```
 
@@ -1411,7 +1411,7 @@ paths:
                     }
                 ]
             },
-            "channels": [1]
+            "channel_ids": [1]
         }
         ```
 
@@ -1452,7 +1452,7 @@ paths:
 
         | Property | Type | Description |
         | - | - | - |
-        | channels | array | Channels associated with the method as an array of integers. |
+        | channel_ids | array | Channels associated with the method as an array of integers. |
       summary: Get a Shipping Method
       tags:
         - Shipping Method
@@ -1717,7 +1717,7 @@ paths:
 
         | Property | Type | Description |
         | - | - | - |
-        | channels | array | Channels associated with the method as an array of integers. |
+        | channel_ids | array | Channels associated with the method as an array of integers. |
       summary: Update a Shipping Method
       tags:
         - Shipping Method


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6142]

This PR fixes the `channel_ids` fields that were missed in [PR 632](https://github.com/bigcommerce/docs/pull/632)

## What changed?
- Fix incorrect field in Shipping V2 API documentation.

## Release notes draft
(will use release note draft from https://github.com/bigcommerce/docs/pull/556, since that will go in the next changelog)

## Anything else?

Related PRs:
- [PR 632](https://github.com/bigcommerce/docs/pull/632)
- [PR 554](https://github.com/bigcommerce/docs/pull/554)
- [PR 556](https://github.com/bigcommerce/docs/pull/556)

[DEVDOCS-6142]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ