### PR TITLE
feat(checkout): CHECKOUT-8746 Update usage notes for S2S Redirect Urls endpoint

### DIFF
--- a/reference/carts.v3.yml
+++ b/reference/carts.v3.yml
@@ -353,6 +353,7 @@ paths:
 
         **Usage Notes**
 
+        * To use redirect URLs, first create the cart using the REST Management API or GraphQL Storefront API
         * Redirect URLs can also be created with **Create a Cart** requests by appending `include=redirect_urls`.
         * A **Carts** redirect URL is valid for 30 days and may only be used once.
         * Redirect URLs point to either a shared checkout domain or a channel-specific domain, depending on the storefront configuration.


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
[CHECKOUT-8746](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-8746)

By design, the links from the v3/cart/redirect_urls endpoint only works for carts created via REST management cart api or the SF GQL api. But we don’t mention it in the public API doc.
So we are updating this doc to make it clearer to developers that  the v3/carts/{cartId}/redirect_urls  endpoint is only supported for carts created using the REST management API or SF GQL API. 

## What changed?
Below the title Usage Notes for Redirects URLs endpoint we added the following bullet point:
- To use redirect URLs, first create the cart using the REST Management API or GraphQL Storefront API

## Release notes draft
* Added extra information regarding the redirect urls endpoint about it's usage


ping @bc-charlesho  @bc-traciporter 
