### PR TITLE
DEVDOCS-6148: [update] add pagination to GET product sort order

### DIFF
--- a/reference/catalog/categories_catalog.v3.yml
+++ b/reference/catalog/categories_catalog.v3.yml
@@ -1447,9 +1447,14 @@ paths:
             application/json:
               schema:
                 title: Product Sort Order Response
-                type: array
-                items:
-                  $ref: '#/components/schemas/productSortOrder'
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/productSortOrder'
+                  meta:
+                      $ref: '#/components/schemas/metaCollection_Full'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -1514,6 +1519,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/Accept'
       - $ref: '#/components/parameters/CategoryIdParam'
+      - $ref: '#/components/parameters/PageParam'
   '/catalog/categories/metafields':
     get:
       summary: Get All Category Metafields


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6148]


## What changed?
Added the page query parameter.
Added meta> pagination fields to the response for products sort order query

![Screenshot 2024-11-12 at 12 54 32 PM](https://github.com/user-attachments/assets/3c27be63-ac2c-4741-b1b1-1d258a1aa46e)


## Release notes draft

Bug Fix
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6148]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ