### PR TITLE
DEVDOCS-6141: BODL, update line_items fields

### DIFF
--- a/docs/integrations/hosted-analytics.mdx
+++ b/docs/integrations/hosted-analytics.mdx
@@ -208,8 +208,9 @@ The `line_item` object has many common fields for browser events, including the 
 | `base_price` | number | Price of product. Default price in the control panel. The price should include or exclude tax, based on the store settings. | [Get a product](/docs/rest-catalog/products#get-a-product) <br /> `data.price` |
 | `brand_name` | string | Brand name. | [Get a product](/docs/rest-catalog/products#get-a-product) <br /> `data.brand_name` |
 | `category_names[]` | array of strings | Category names. | [Get a product](/docs/rest-catalog/products#get-a-product) <br /> `data.categories[]` |
+| `coupon_amount` | number | The total value of all coupons applied to this item. | [Get a checkout](/docs/rest-storefront/checkouts#get-a-checkout) <br /> `cart.lineItems.physicalItems.couponAmount` or `cart.lineItems.digitalItems.couponAmount` |  
 | `currency` | string | [ISO-4217 currency code](https://www.iso.org/iso-4217-currency-codes.html) for the transaction. | [Get a checkout](/docs/rest-management/checkouts#get-a-checkout) <br />  `data.cart.currency.code`  |
-| `discount` | number | Discount applied to the purchase. | [Get a checkout](/docs/rest-storefront/checkouts#get-a-checkout) <br /> `data.cart.discountAmount` |
+| `discount` | number | Discount applied to the purchase. | [Get a checkout](/docs/rest-storefront/checkouts#get-a-checkout) <br /> `cart.lineItems.physicalItems.discountAmount` or `cart.lineItems.digitallItems.discountAmount` |
 | `gift_certificate_id` | string | ID of gift certificate. | [Get a cart](/docs/rest-storefront/carts#get-a-cart) <br /> `lineItems.giftCertificates.id` |
 | `gift_certificate_name` | string | Name of gift certificate that appears in the control panel. | [Get a Cart](/docs/rest-storefront/carts#get-a-cart) <br /> `lineItems.giftCertificates.name` |
 | `gift_certificate_theme` | string | Theme of gift certificate. | [Get a cart](/docs/rest-storefront/carts#get-a-cart) <br /> `lineItems.giftCertificates.theme` |

--- a/docs/integrations/hosted-analytics.mdx
+++ b/docs/integrations/hosted-analytics.mdx
@@ -210,7 +210,7 @@ The `line_item` object has many common fields for browser events, including the 
 | `category_names[]` | array of strings | Category names. | [Get a product](/docs/rest-catalog/products#get-a-product) <br /> `data.categories[]` |
 | `coupon_amount` | number | The total value of all coupons applied to this item. | [Get a checkout](/docs/rest-storefront/checkouts#get-a-checkout) <br /> `cart.lineItems.physicalItems.couponAmount` or `cart.lineItems.digitalItems.couponAmount` |  
 | `currency` | string | [ISO-4217 currency code](https://www.iso.org/iso-4217-currency-codes.html) for the transaction. | [Get a checkout](/docs/rest-management/checkouts#get-a-checkout) <br />  `data.cart.currency.code`  |
-| `discount` | number | Discount applied to the purchase. | [Get a checkout](/docs/rest-storefront/checkouts#get-a-checkout) <br /> `cart.lineItems.physicalItems.discountAmount` or `cart.lineItems.digitallItems.discountAmount` |
+| `discount` | number | Discount applied to the purchase. | [Get a checkout](/docs/rest-storefront/checkouts#get-a-checkout) <br /> `cart.lineItems.physicalItems.discountAmount` or `cart.lineItems.digitalItems.discountAmount` |
 | `gift_certificate_id` | string | ID of gift certificate. | [Get a cart](/docs/rest-storefront/carts#get-a-cart) <br /> `lineItems.giftCertificates.id` |
 | `gift_certificate_name` | string | Name of gift certificate that appears in the control panel. | [Get a Cart](/docs/rest-storefront/carts#get-a-cart) <br /> `lineItems.giftCertificates.name` |
 | `gift_certificate_theme` | string | Theme of gift certificate. | [Get a cart](/docs/rest-storefront/carts#get-a-cart) <br /> `lineItems.giftCertificates.theme` |


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6141]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Update BODL documentation's `line_items` field

## Release notes draft

* We're happy to announce the new `line_items.coupon_amount` field in Big Open Data Layer for hosted storefronts, which indicates the coupon amount for a line item in a cart.
* Fixed a bug in the Big Open Data Layer documentation regarding which BigCommerce API field to which the `line_items.discount` maps.

## Anything else?
@bigcommerce/team-data


[DEVDOCS-6141]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ