### PR TITLE
fix: STRF-12752 Product.id should integer instead of a string

### DIFF
--- a/docs/storefront/stencil/themes/context/object-reference/schemas/product.yml
+++ b/docs/storefront/stencil/themes/context/object-reference/schemas/product.yml
@@ -112,7 +112,7 @@ properties:
     type: string
   id:
     description: Unique ID for the product
-    type: string
+    type: integer
   images:
     description: 'List of all images for this product, in Stencil image format (as configured in config.json; used with the getImage Handlebars helper)'
     type: array


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [STRF-12752]


## What changed?
 * product.id in productdetails resources should be an int

## Release notes draft
We have inconsistency between MSF and non-MSF stores where product.id is int and string. PR to fix it got merged, so the docs should be updated as well


## Anything else?
https://github.com/bigcommerce/storefront/pull/3430

ping @bigcommerce/dev-docs 


[STRF-12752]: https://bigcommercecloud.atlassian.net/browse/STRF-12752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ