### PR TITLE
DEVDOCS-6150: [update] change limit of customer widget templates per store

### DIFF
--- a/docs/storefront/widgets/index.mdx
+++ b/docs/storefront/widgets/index.mdx
@@ -326,7 +326,7 @@ Widgets are rendered on the storefront as a data tag in the HTML.
 | Name | Definition |
 |--|--|
 | Widgets | Widgets are the units of content to be placed on specific pages in a Stencil theme. Each widget is composed of a widget configuration and a widget template. *There is a limit of `10,000` widgets per store.* |
-| Widget templates | Widget templates are Handlebars-enabled HTML templates that define the widget’s structure on a page. These templates can include conditional logic as well as looping. *There is a limit of `1,000` total custom widget templates per store. This does not include templates pre-provided by BigCommerce.* |
+| Widget templates | Widget templates are Handlebars-enabled HTML templates that define the widget’s structure on a page. These templates can include conditional logic as well as looping. *There is a limit of `250` total custom widget templates per store. This does not include templates pre-provided by BigCommerce.* |
 | Placements | Placements determine the region where you place widgets and in what order. *There is a limit of `75` placements per template file and `10,000` total placements per store.* |
 | Regions | Regions are specific spots in a Stencil template file where you can place widgets. Regions are defined at the theme file level using the following syntax: `{{{region name="..."}}}`. Many widgets can reside within a given region, and these widgets can have an assigned sort order. |
 | Widget configuration | This is a JSON payload that contains data used when rendering the widget. Each widget has a configuration, and there is a 64kb limit on the JSON size. The widget configuration must be valid JSON, but we don’t enforce any additional configuration structure requirements. |


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6150]


## What changed?
Change the limit of customer widget templates per store from 1000 to 250.

## Release notes draft

Changed the limit of customer widget templates per store to 250.
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6150]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ