### PR TITLE
LOCAL-2603 Fix geo swagger definition

### DIFF
--- a/reference/geography.v2.yml
+++ b/reference/geography.v2.yml
@@ -137,12 +137,14 @@ paths:
           description: ''
           schema:
             type: string
+            default: application/json
         - name: Content-Type
           in: header
           required: true
           description: ''
           schema:
             type: string
+            default: application/json
         - name: state
           in: query
           required: false
@@ -239,7 +241,7 @@ paths:
         in: path
         required: true
         schema:
-          type: string
+          type: integer
 
       - schema:
           type: string
@@ -302,7 +304,7 @@ paths:
         in: path
         required: true
         schema:
-          type: string
+          type: integer
 components:
   responses:
     countriesResponse:


### PR DESCRIPTION

## What changed?

1. Set default value for accept and content-type. Make swagger file consistent
2. When using autogenerated TS library we have an issue with types inconsistency. `country_id` is integer. Int is convertable to string, so there should be no issues

## Release notes draft
None


## Anything else?
None
