### PR TITLE
Add channels to Get all Products and Get a Product

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -70,6 +70,7 @@ paths:
           schema:
             type: integer
         - $ref: '#/components/parameters/IdInParam'
+        - $ref: '#/components/parameters/ChannelIdInParam'
         - $ref: '#/components/parameters/IdNotInParam'
         - $ref: '#/components/parameters/IncludeParam'
         - $ref: '#/components/parameters/IncludeFieldsParam'
@@ -9543,6 +9544,7 @@ components:
             - options
             - parent_relations
             - custom_fields
+            - channels
     IdMinParam:
       name: 'id:min'
       in: query

--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -130,7 +130,15 @@ paths:
                   data:
                     type: array
                     items:
-                      $ref: '#/components/schemas/product_Full'
+                      allOf:
+                      - $ref: '#/components/schemas/product_Full'
+                      - type: object
+                        properties:
+                          channels: 
+                            type: array
+                            items: 
+                              type: integer
+                            description: 'The channels that are assigned the product. This field only appears in the response if you include `channels` in the `include` query parameter.'
                   meta:
                     $ref: '#/components/schemas/metaCollection_Full'
     put:
@@ -695,7 +703,15 @@ paths:
                 type: object
                 properties:
                   data:
-                    $ref: '#/components/schemas/product_Full'
+                    allOf:
+                    - $ref: '#/components/schemas/product_Full'
+                    - type: object
+                      properties:
+                        channels: 
+                          type: array
+                          items: 
+                            type: integer
+                          description: 'The channels that are assigned the product. This field only appears in the response if you include `channels` in the `include` query parameter.'
                   meta:
                     $ref: '#/components/schemas/metaEmpty_Full'
               example:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->



## What changed?
<!-- Provide a bulleted list in the present tense -->
* Add `channels_id:in` query parameter to Get All Products endpoint 
* Add `channels` to `include` query parameter for Get All Products and Get a Product endpoint
* Add `channels` array to response for Get All Products and Get a Product endpoint

The POST and PUT endpoints are not affected.

## Release notes draft
We're happy to announce that you can now retrieve the channels are assigned to a product when you get a product through the Catalog API. You can also filter products by the channel when you Get All Products.

## Screenshot testing

![Get a Product](https://github.com/user-attachments/assets/bb556fe8-6770-4130-9ecf-e29338b827af)
![Get all Products](https://github.com/user-attachments/assets/f969f068-7ceb-4c40-ad60-2832e3e084d6)

Get all Products endpoint:
![Screenshot 2024-12-03 at 5 25 07 PM](https://github.com/user-attachments/assets/235bd5ef-a4f6-46df-8bf4-861d69b2cc7e)
![Screenshot 2024-12-03 at 5 27 41 PM](https://github.com/user-attachments/assets/79af3b39-a6b0-4558-a81a-f2f1be5c8280)


## Anything else?
cc @bigcommerce/multi-catalog-storefront-team , @kristinapototska 
