### PR TITLE
SHIPPING-2884 add mention of platform limit for 'zip' type shipping zone locations

### DIFF
--- a/reference/shipping.v2.yml
+++ b/reference/shipping.v2.yml
@@ -214,7 +214,7 @@ paths:
                     - state
                     - global
                 locations:
-                  description: Array of zone locations.
+                  description: Array of zone locations. BigCommerce has a platform limit of 40000 `zip` type locations.
                   type: array
                   items:
                     title: Shipping Zone Locations
@@ -396,7 +396,7 @@ paths:
   '/shipping/zones/{id}':
     get:
       description: Returns a single *Shipping Zone*.
-      summary: Get a Shipping Zones
+      summary: Get a Shipping Zone
       tags:
         - Shipping Zones
       responses:
@@ -525,7 +525,7 @@ paths:
                     - state
                     - global
                 locations:
-                  description: Array of zone locations.
+                  description: Array of zone locations. BigCommerce has a platform limit of 40000 `zip` type locations.
                   type: array
                   items:
                     title: Shipping Zone Locations


### PR DESCRIPTION
Also fixes a typo

# [SHIPPING-2884]


## What changed?
* Added mention of the platform limit for `zip` type shipping zone location
* Fix a typo for `Get a shipping zones` to `Get a shipping zone`

## Release notes 
* There is now a platform limit of 40000 zip type shipping locations per store. Users can no longer add more than 40000 zip type locations on their store.
* Fixed a typo on the `Get a shipping zone` section.

## Anything else?

Work done in PR: https://github.com/bigcommerce/bigcommerce/pull/60942

ping @bigcommerce/team-shipping 

[SHIPPING-2884]: https://bigcommercecloud.atlassian.net/browse/SHIPPING-2884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ