### PR TITLE
fix: STRF-12861 Update stencil cli installation docs

### DIFF
--- a/docs/storefront/stencil/cli/install.mdx
+++ b/docs/storefront/stencil/cli/install.mdx
@@ -16,47 +16,25 @@ This article contains detailed instructions on installing and configuring Stenci
 
 There are different options for installing Stencil CLI and its dependencies on a Mac.
 
-### Option 1: ARM based macs
+
+### Requirements
+* Python 3+ 
+* Node.js 20+ (Stencil CLI supported version)
+
+Note: if Python version is more than 3.12, then distutils should be installed using the following command:
+    ```pip install setuptools```
 
 To install Stencil CLI and its dependencies on Mac, open a terminal and run the following commands. For the latest `node` version supported, refer to [Stencil CLI README.MD](https://github.com/bigcommerce/stencil-cli). 
 
 ```shell showLineNumbers copy
-# For ARM based macs
-arch -x86_64 /bin/zsh
 
-# Install Node Version Manager (nvm)
-curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh | bash
+# Install Node Version Manager ([nvm](https://github.com/nvm-sh/nvm?tab=readme-ov-file#installing-and-updating) or any other version manager of your flavor)
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 
 # Install Stencil CLI supported version of Node.js
 nvm install 20.16.0
 
 # Switch to Stencil CLI supported version of Node.js:
-nvm use 20.16.0
-
-# Install Stencil CLI
-npm install -g @bigcommerce/stencil-cli
-```
-
-### Option 2: Macs with M1 chip
-
-Installing Stencil CLI and its dependencies on Macs that use Apple silicon, such as the M1 chip, requires Rosetta. Rosetta allows a Mac with Apple silicon to use apps built for a Mac with an Intel processor.
-
-To open the Rosetta terminal:
-
-1. Open **Finder**.
-2. Go to **Applications** > **Utilities** > **Terminal**.
-3. Right-click **Terminal** and select **Get Info**.
-4. Check the **Open using Rosetta** checkbox.
-5. Close the window and quit all terminal instances.
-6. Start a new terminal, and install Rosetta if prompted.
-
-Run the following commands:
-
-```shell showLineNumbers copy
-# Install Stencil CLI supported version of Node.js
-nvm install 20.16.0
-
-# Switch to Stencil CLI supported version of Node.js
 nvm use 20.16.0
 
 # Install Stencil CLI
@@ -135,11 +113,6 @@ nvm use 20.16.0
 # Install stencil
 npm install -g @bigcommerce/stencil-cli
 ```
-
-**Depending on the distro, you may also need to install:**
-* g++
-* [libsass](https://sass-lang.com/libsass)
-* git
 
 <Callout type="info">
  * These instructions have been tested on **Ubuntu 18.04**.

--- a/docs/storefront/stencil/cli/install.mdx
+++ b/docs/storefront/stencil/cli/install.mdx
@@ -21,7 +21,7 @@ There are different options for installing Stencil CLI and its dependencies on a
 * Python 3+ 
 * Node.js 20+ (Stencil CLI supported version)
 
-Note: if Python version is more than 3.12, then distutils should be installed using the following command:
+Note: If the Python version is more than 3.12, then you should install distutils using the following command:
     ```pip install setuptools```
 
 To install Stencil CLI and its dependencies on Mac, open a terminal and run the following commands. For the latest `node` version supported, refer to [Stencil CLI README.MD](https://github.com/bigcommerce/stencil-cli). 


### PR DESCRIPTION
# [[STRF-12861](https://bigcommercecloud.atlassian.net/browse/STRF-12861)]


## What changed?
* Rosetta mode is not really required for Stencil CLI. TLDR: I received a new laptop with Mac M2 and was able to reproduce some edges cases and found the easiest way how to resolve them

## Release notes draft

Examples:
* Updated Stencil CLI installations docs for Mac 

## Anything else?
[<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->](https://github.com/bigcommerce/stencil-cli/issues/995#issuecomment-2520835069)

ping @bc-traciporter 


[STRF-12861]: https://bigcommercecloud.atlassian.net/browse/STRF-12861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ