### PR TITLE
DEVDOCS-6144: [update] Add examples to orders page

### DIFF
--- a/docs/storefront/graphql/orders.mdx
+++ b/docs/storefront/graphql/orders.mdx
@@ -316,6 +316,111 @@ In this example, the query is set up to get details for order #106. Use `entityI
   </Tab>
 </Tabs>
 
+### Get an order metafield
+In this example, the query is set up to get a metafield for order #1234000006. Use `entityId` to query by order.
+
+<Tabs items={[`Request`, `Response`]}>
+  <Tab>
+   ```graphql filename="Example query: Get order metafield" showLineNumbers copy
+    {
+        site {
+            order(filter: {entityId: 1234000006}) {
+                metafields(namespace: "namespace") {
+                    edges {
+                        node {
+                            key
+                            value
+                        }
+                    }
+                }
+            }
+        }
+    }
+```
+</Tab>
+    <Tab>
+   ``` graphQL filename="Example response: Get order metafield" showLineNumbers copy
+   {
+    "data": {
+        "site": {
+            "order": {
+                "metafields": {
+                    "edges": []
+                    }
+                }
+            }
+        }
+    }
+   ```
+ </Tab>
+</Tabs>
+
+### Get metafields for a customer
+In this example, the query is set up to get metafields for a customer. Ensure the customer is logged-in.
+
+<Tabs items={[`Request`, `Response`]}>
+  <Tab>
+   ```graphql filename="Example query: Get metafields" showLineNumbers copy
+   {
+     customer {
+       orders {
+         edges {
+           node {
+             entityId
+             metafields(namespace: "my-namespace") {
+               edges {
+                 node {
+                   value
+                 }
+               }
+             }
+           }
+         }
+       }
+     }
+   }
+```
+   </Tab>
+<Tab>
+  ```graphql filename="Example response: Get metafields" showLineNumbers copy
+   {
+    "data": {
+        "customer": {
+            "orders": {
+                "edges": [
+                    {
+                        "node": {
+                            "entityId": 1234000006,
+                            "metafields": {
+                                "edges": []
+                            }
+                        }
+                    },
+                    {
+                        "node": {
+                            "entityId": 1234000005,
+                            "metafields": {
+                                "edges": []
+                            }
+                        }
+                    },
+                    {
+                        "node": {
+                            "entityId": 1234000004,
+                            "metafields": {
+                                "edges": []
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+} 
+  ```
+</Tab>
+</Tabs>
+
 Join our [Developer community](/community) to share your feedback with us in the BigCommerceDevs Slack or on our Discord server.
 
 ## Resources

--- a/docs/storefront/graphql/orders.mdx
+++ b/docs/storefront/graphql/orders.mdx
@@ -317,40 +317,73 @@ In this example, the query is set up to get details for order #106. Use `entityI
 </Tabs>
 
 ### Get an order metafield
-In this example, the query is set up to get a metafield for order #1234000006. Use `entityId` to query by order.
+In this example, the query is set up to get a metafield for order #102. Use `entityId` to query by order.
 
 <Tabs items={[`Request`, `Response`]}>
   <Tab>
    ```graphql filename="Example query: Get order metafield" showLineNumbers copy
-    {
-        site {
-            order(filter: {entityId: 1234000006}) {
-                metafields(namespace: "namespace") {
-                    edges {
-                        node {
-                            key
-                            value
-                        }
+    query Order($namespace: String!) {
+    site {
+        order(filter: {entityId: 102}) {
+            id
+            entityId
+            billingAddress {
+                firstName
+            }
+            metafields(namespace: $namespace) {
+                edges {
+                    node {
+                        key
+                        value
                     }
                 }
             }
+            cartMetafields(namespace: $namespace) {
+                edges {
+                     node {
+                        key
+                        value
+                    }
+                }
+            }
+            
         }
     }
+    
+}
 ```
 </Tab>
     <Tab>
    ``` graphQL filename="Example response: Get order metafield" showLineNumbers copy
    {
-    "data": {
-        "site": {
-            "order": {
-                "metafields": {
-                    "edges": []
-                    }
-                }
+  "data": {
+    "site": {
+      "order": {
+        "entityId": 102,
+        "metafields": {
+          "edges": [
+            {
+              "node": {
+                "key": "Order metafield for order 102",
+                "value": "Order metafield for order 102"
+              }
             }
+          ]
+        },
+        "cartMetafields": {
+          "edges": [
+            {
+              "node": {
+                "key": "Cart metafield for order 102",
+                "value": "Cart metafield for order 102"
+              }
+            }
+          ]
         }
+      }
     }
+  }
+}
    ```
  </Tab>
 </Tabs>


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6144]


## What changed?
Add order metafield examples to orders page

## Release notes draft

* We're happy to announce order metafields are now available in the Storefront GraphQL API.

<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].

* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6144]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ