### PR TITLE
fix object error, option_values should be an array

### DIFF
--- a/reference/catalog/product-modifiers_catalog.v3.yml
+++ b/reference/catalog/product-modifiers_catalog.v3.yml
@@ -526,21 +526,22 @@ paths:
                         - package
                   description: The values for option config can vary based on the Modifier created.
                 option_values:
-                  allOf:
-                    - type: object
-                      properties:
-                        id:
-                          type: integer
-                          description: |
-                            The unique numeric ID of the value; increments sequentially.
-                        is_default:
-                          type: boolean
-                          description: |
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: integer
+                            description: |
+                              The unique numeric ID of the value; increments sequentially.
+                          is_default:
+                            type: boolean
+                            description: |
                               The flag for preselecting a value as the default on the storefront. This field is not supported for swatch options/modifiers.
-                                  example: false
-                        adjusters:
-                          type: object
-                          properties:
+                            example: false
+                          adjusters:
+                            type: object
+                            properties:
                                     price:
                                       type: object
                                       properties:
@@ -558,7 +559,7 @@ paths:
                                             The numeric amount by which the adjuster will change either the price or the weight of the variant, when the modifier value is selected on the storefront.
                                           example: 5
                                       description: Adjuster for Complex Rules.
-                  description: 'Part of Modifier Value Response '
+                      description: 'Part of Modifier Value Response '
                 display_name:
                   type: string
                   description: |


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-5908]


## What changed?
remove allOf and make option_values an array, not an object

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-5908]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ