### PR TITLE
DEVDOCS-6175: [update] update order of operations

### DIFF
--- a/docs/store-operations/pricing/calculations.mdx
+++ b/docs/store-operations/pricing/calculations.mdx
@@ -14,8 +14,8 @@ The table below lists each price type available on a product. The table is read 
 | Price list variant product pick list | The product pick list overrides price list bulk pricing and allows you to change the price when a pick list item is selected. | 
 | Product option set (**Deprecated**)| A set of product option facets that may alter the variant price. (This feature is deprecated.) |
 | Product modifier | Available in fixed ($5) or percentage (%10) amount that is added or removed from the total product price and overrides the price list variant product pick list. A modifier includes choices such as adding $5 for insurance. |
-| Customer group discount | Available in fixed ($5), relative (-$2), or percentage (-25%) amount that overrides the variant sale price. Might apply to one product, category, subcategory, or the entire store's products. |
-| Product bulk pricing | Available in fixed ($5), relative (-$2), or percentage (-25%) amount that overrides the customer group discount. Dependent on the total quantity of products, including SKUs added to the cart. |
+| Customer group discount | Available in fixed ($5), relative (-$2), or percentage (-25%) amount that overrides the variant sale price. Might apply to one product, category, subcategory, or the entire store's products. Customer group discounts do not apply to price list prices. |
+| Product bulk pricing | Available in fixed ($5), relative (-$2), or percentage (-25%) amount that overrides the customer group discount. Dependent on the total quantity of a single product added to the cart. Product bulk pricing will not apply for SKUs that have price list prices. |
 | Product product pick list | If you configure the product pick list to change the price, it will update the price and override the product modifier when the option is selected. |
 Discounts | When a shopper meets certain criteria or takes certain actions to automatically modify the final product or cart price depending on the discount type. |
 | Coupons | Coupons require customer action to take effect and modify the final product or cart price depending on the coupon type. |

--- a/docs/store-operations/pricing/calculations.mdx
+++ b/docs/store-operations/pricing/calculations.mdx
@@ -8,7 +8,6 @@ The table below lists each price type available on a product. The table is read 
 | Product sale price | A product option that overrides the default price |  
 | Variant price | A product option that overrides the product sale price |
 | Variant sale price | A product option that overrides the variant price |
-| Customer group discount | Available in fixed ($5), relative (-$2), or percentage (-25%) amount that overrides the variant sale price. Might apply to one product, category, subcategory, or the entire store's products. |
 | Product bulk pricing | Available in fixed ($5), relative (-$2), or percentage (-25%) amount that overrides the customer group discount. Dependent on the total quantity of products, including SKUs added to the cart. |
 | Price list variants | A price list record requirement that overrides all previous pricing and excludes SKUs from the total number of items for product bulk pricing. 
 | Price list variant sale price | A product option that overrides price list pricing if variant pricing is set and selected. |
@@ -16,6 +15,7 @@ The table below lists each price type available on a product. The table is read 
 | Price list variant product pick list | The product pick list overrides price list bulk pricing and allows you to change the price when a pick list item is selected. | 
 | Product option set (**Deprecated**)| A set of product option facets that may alter the variant price. (This feature is deprecated.) |
 | Product modifier | Available in fixed ($5) or percentage (%10) amount that is added or removed from the total product price and overrides the price list variant product pick list. A modifier includes choices such as adding $5 for insurance. |
+| Customer group discount | Available in fixed ($5), relative (-$2), or percentage (-25%) amount that overrides the variant sale price. Might apply to one product, category, subcategory, or the entire store's products. |
 | Product product pick list | If you configure the product pick list to change the price, it will update the price and override the product modifier when the option is selected. |
 Discounts | When a shopper meets certain criteria or takes certain actions to automatically modify the final product or cart price depending on the discount type. |
 | Coupons | Coupons require customer action to take effect and modify the final product or cart price depending on the coupon type. |

--- a/docs/store-operations/pricing/calculations.mdx
+++ b/docs/store-operations/pricing/calculations.mdx
@@ -8,7 +8,6 @@ The table below lists each price type available on a product. The table is read 
 | Product sale price | A product option that overrides the default price |  
 | Variant price | A product option that overrides the product sale price |
 | Variant sale price | A product option that overrides the variant price |
-| Product bulk pricing | Available in fixed ($5), relative (-$2), or percentage (-25%) amount that overrides the customer group discount. Dependent on the total quantity of products, including SKUs added to the cart. |
 | Price list variants | A price list record requirement that overrides all previous pricing and excludes SKUs from the total number of items for product bulk pricing. 
 | Price list variant sale price | A product option that overrides price list pricing if variant pricing is set and selected. |
 | Price list variant bulk pricing | Available in fixed ($5), relative (-$2), or percentage (-25%) amount that overrides price list sale price on variants. It is dependent on the quantity added to a cart. | 
@@ -16,6 +15,7 @@ The table below lists each price type available on a product. The table is read 
 | Product option set (**Deprecated**)| A set of product option facets that may alter the variant price. (This feature is deprecated.) |
 | Product modifier | Available in fixed ($5) or percentage (%10) amount that is added or removed from the total product price and overrides the price list variant product pick list. A modifier includes choices such as adding $5 for insurance. |
 | Customer group discount | Available in fixed ($5), relative (-$2), or percentage (-25%) amount that overrides the variant sale price. Might apply to one product, category, subcategory, or the entire store's products. |
+| Product bulk pricing | Available in fixed ($5), relative (-$2), or percentage (-25%) amount that overrides the customer group discount. Dependent on the total quantity of products, including SKUs added to the cart. |
 | Product product pick list | If you configure the product pick list to change the price, it will update the price and override the product modifier when the option is selected. |
 Discounts | When a shopper meets certain criteria or takes certain actions to automatically modify the final product or cart price depending on the discount type. |
 | Coupons | Coupons require customer action to take effect and modify the final product or cart price depending on the coupon type. |


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6175]


## What changed?
Moved customer group discounts and bulk pricing after Product modifier in the table.

## Release notes draft

Bug fix: Moved customer group discounts because they are shown before modifier rules when they apply after, as does bulk pricing.  

<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6175]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ