### PR TITLE
Add target field object (with country_codes, subdivision_codes) to Tax Provider Connection API docs

### DIFF
--- a/reference/tax.v3.yml
+++ b/reference/tax.v3.yml
@@ -207,4 +207,20 @@ components:
                 Describes whether the stored credentials are considered complete and configured, ready to be used for Tax Provider API requests.
 
                 Merchants may enable any **configured** tax provider for storefront tax quotation.
+            target:
+              type: object
+              description: The countries and subdivisions in which this tax provider connection is active.
+              properties:
+                country_codes:
+                  type: array
+                  items:
+                    type: string
+                  description: The list of country codes where the tax provider connection is active. ISO 3166-1 alpha-2.
+                  example: ['AU', 'US']
+                subdivision_codes:
+                  type: array
+                  items:
+                    type: string
+                  description: The list of subdivision codes where the tax provider connection is active. ISO 3166-2.
+                  example: ['AU-NSW', 'US-OH']
       x-internal: false


### PR DESCRIPTION
# [TAX-2166]

## What changed?
* Add `target` object to Tax Provider Connection API docs. Includes `country_codes` and `subdivision_codes` fields.

## Release notes draft
- Allows users to inspect where their tax provider connection is active. Useful for determining if there are outstanding steps in the merchant's tax provider configuration.

[TAX-2166]: https://bigcommercecloud.atlassian.net/browse/TAX-2166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ