### PR TITLE
Fix channel IDs field documentation for shipping methods

### DIFF
--- a/reference/shipping.v2.yml
+++ b/reference/shipping.v2.yml
@@ -1207,7 +1207,7 @@ paths:
           "settings": {
             "rate": 5
           },
-          channel_ids: [1, 3]
+          "channel_ids": [1, 3]
         }
         ```
 
@@ -1322,7 +1322,7 @@ paths:
             "settings": {
                 "rate": 8
             },
-            "channel_ids: [1]
+            "channel_ids": [1]
         },
         ```
 
@@ -1446,7 +1446,7 @@ paths:
           "settings": {
             "rate": 5
           },
-          channel_ids: [1, 3]
+          "channel_ids": [1, 3]
         }
         ```
 
@@ -1711,7 +1711,7 @@ paths:
           "settings": {
           "rate": 5
           },
-          channel_ids: [1, 3]
+          "channel_ids": [1, 3]
         }
         ```
 


### PR DESCRIPTION
# [SHIPPING-3046]

## What changed?
* Fixed some issues with the Channel IDs documentation for Shipping Methods.

Spotted while reviewing some relatively recent changes to this documentation. 

Link: https://developer.bigcommerce.com/docs/rest-management/shipping-v2/shipping-method#create-a-shipping-method

[SHIPPING-3046]: https://bigcommercecloud.atlassian.net/browse/SHIPPING-3046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ