### PR TITLE
Remove global store context from options and modifiers webhooks

### DIFF
--- a/docs/integrations/webhooks/events/index.mdx
+++ b/docs/integrations/webhooks/events/index.mdx
@@ -444,7 +444,7 @@ Payload objects with the following scopes take the form that follows:
 
 | Name / Scope             | Description |
 |:-------------------------|:------------|
-| store/modifier/updated | Fires when you edit attributes for a local or shared modifier. Updates to the channel locale as an override, not the global store, trigger the webhook.<br /><br />The `context` fields are present when you update the overrides. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview. |
+| store/modifier/updated | Only fires when you edit attributes for a local or shared modifier in a context of a channel and locale. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview. |
 
 The payload object takes the form that follows:
 
@@ -475,7 +475,7 @@ Consult the [notifications section of the Channel Webhooks Guide](/docs/integrat
 
 | Name / Scope             | Description |
 |:-------------------------|:------------|
-| store/option/updated | Fires when you edit attributes for a local or shared variant option, including its display name and option values. Updates to the channel locale as an override, not the global store, trigger the webhook.<br /><br />The `context` fields are present when you update the overrides. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview. |
+| store/option/updated | Fires when you customize display name and values for a local or shared variant option in a context of a channel and locale. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview. |
 
 The payload object takes the form that follows:
 

--- a/docs/integrations/webhooks/events/index.mdx
+++ b/docs/integrations/webhooks/events/index.mdx
@@ -444,7 +444,7 @@ Payload objects with the following scopes take the form that follows:
 
 | Name / Scope             | Description |
 |:-------------------------|:------------|
-| store/modifier/updated | Fires when you edit attributes for a local or shared modifier. Updates to the global store and channel locale as an override triggers the webhook.<br /><br />The `context` fields are present for only updates to overrides, not the global store. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview. |
+| store/modifier/updated | Fires when you edit attributes for a local or shared modifier. Updates to the channel locale as an override, not the global store, trigger the webhook.<br /><br />The `context` fields are present when you update the overrides. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview. |
 
 The payload object takes the form that follows:
 
@@ -475,7 +475,7 @@ Consult the [notifications section of the Channel Webhooks Guide](/docs/integrat
 
 | Name / Scope             | Description |
 |:-------------------------|:------------|
-| store/option/updated | Fires when you edit attributes for a local or shared variant option, including its display name and option values. Updates to the global store and channel locale as an override triggers the webhook.<br /><br />The `context` fields are present for only updates to overrides, not the global store. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview. |
+| store/option/updated | Fires when you edit attributes for a local or shared variant option, including its display name and option values. Updates to the channel locale as an override, not the global store, trigger the webhook.<br /><br />The `context` fields are present when you update the overrides. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview. |
 
 The payload object takes the form that follows:
 

--- a/docs/webhooks/callbacks/_all.yml
+++ b/docs/webhooks/callbacks/_all.yml
@@ -278,13 +278,13 @@ properties:
       allOf:
       - $ref: https://raw.githubusercontent.com/bigcommerce/docs/main/docs/webhooks/callbacks/store_metafield_updated.yml  
   store/modifier/updated:
-    description: Fires when a product modifier is edited for a channel locale. The `context` fields are present when you update the overrides. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
+    description: Only fires when you edit attributes for a local or shared modifier in a context of a channel and locale. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
     type: object
     properties:
       allOf:
       - $ref: https://raw.githubusercontent.com/bigcommerce/docs/main/docs/webhooks/callbacks/store_modifier_updated.yml
   store/option/updated:
-    description: Fires when product options are edited for a channel locale. The `context` fields are present when you update the overrides. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
+    description: Fires when you customize display name and values for a local or shared variant option in a context of a channel and locale. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
 
     type: object
     properties:

--- a/docs/webhooks/callbacks/_all.yml
+++ b/docs/webhooks/callbacks/_all.yml
@@ -284,7 +284,7 @@ properties:
       allOf:
       - $ref: https://raw.githubusercontent.com/bigcommerce/docs/main/docs/webhooks/callbacks/store_modifier_updated.yml
   store/option/updated:
-    description: Fires when product options are edited. The `context` fields are present when you update the overrides. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
+    description: Fires when product options are edited for a channel locale. The `context` fields are present when you update the overrides. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
 
     type: object
     properties:

--- a/docs/webhooks/callbacks/_all.yml
+++ b/docs/webhooks/callbacks/_all.yml
@@ -278,13 +278,13 @@ properties:
       allOf:
       - $ref: https://raw.githubusercontent.com/bigcommerce/docs/main/docs/webhooks/callbacks/store_metafield_updated.yml  
   store/modifier/updated:
-    description: Fires when product modifier are edited. The `context` fields are present for only updates to overrides, not the global store. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
+    description: Fires when a product modifier is edited for a channel locale. The `context` fields are present when you update the overrides. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
     type: object
     properties:
       allOf:
       - $ref: https://raw.githubusercontent.com/bigcommerce/docs/main/docs/webhooks/callbacks/store_modifier_updated.yml
   store/option/updated:
-    description: Fires when product options are edited. The `context` fields are present for only updates to overrides, not the global store. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
+    description: Fires when product options are edited. The `context` fields are present when you update the overrides. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
 
     type: object
     properties:

--- a/docs/webhooks/callbacks/store_modifier_updated.yml
+++ b/docs/webhooks/callbacks/store_modifier_updated.yml
@@ -2,7 +2,7 @@ type: object
 properties:
   store/modifier/updated:
     description: |
-      Fires when you edit attributes for a local or shared modifier. Updates to the channel locale as an override, not the global store, trigger the webhook. The `context` fields are present when you update the overrides. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
+      Only fires when you edit attributes for a local or shared modifier in a context of a channel and locale. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
       
       For shared modifiers, the maximum number of product IDs in a payload is 100. If a shared modifier is assigned to more than 100 products, the payload includes a link to the API so you can query all the event data.  
     type: object

--- a/docs/webhooks/callbacks/store_modifier_updated.yml
+++ b/docs/webhooks/callbacks/store_modifier_updated.yml
@@ -2,7 +2,7 @@ type: object
 properties:
   store/modifier/updated:
     description: |
-      Fires when you edit attributes for a local or shared modifier. Updates to the global store and channel locale as an override triggers the webhook. The `context` fields are present for only updates to overrides, not the global store. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
+      Fires when you edit attributes for a local or shared modifier. Updates to the channel locale as an override, not the global store, trigger the webhook. The `context` fields are present when you update the overrides. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
       
       For shared modifiers, the maximum number of product IDs in a payload is 100. If a shared modifier is assigned to more than 100 products, the payload includes a link to the API so you can query all the event data.  
     type: object

--- a/docs/webhooks/callbacks/store_option_updated.yml
+++ b/docs/webhooks/callbacks/store_option_updated.yml
@@ -2,7 +2,7 @@ type: object
 properties:
   store/option/updated:
     description: |
-      Fires when you edit attributes for a local or shared variant option. Updates to the global store and channel locale as an override triggers the webhook. The `context` fields are present for only updates to overrides, not the global store. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
+      Fires when you edit attributes for a local or shared variant option. Updates to the channel locale as an override, not the global store, trigger the webhook. The `context` fields are present when you update the overrides. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
     
       For shared options, the maximum number of product IDs in a payload is 100. If a shared modifier is assigned to more than 100 products, the payload includes a link to the API so you can query all the event data.  
     type: object

--- a/docs/webhooks/callbacks/store_option_updated.yml
+++ b/docs/webhooks/callbacks/store_option_updated.yml
@@ -2,7 +2,7 @@ type: object
 properties:
   store/option/updated:
     description: |
-      Fires when you edit attributes for a local or shared variant option. Updates to the channel locale as an override, not the global store, trigger the webhook. The `context` fields are present when you update the overrides. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
+      Fires when you customize display name and values for a local or shared variant option in a context of a channel and locale. For information on updating overrides, see the [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements) overview.
     
       For shared options, the maximum number of product IDs in a payload is 100. If a shared modifier is assigned to more than 100 products, the payload includes a link to the API so you can query all the event data.  
     type: object


### PR DESCRIPTION
## What changed?
<!-- Provide a bulleted list in the present tense -->
* Removed global store context from options and modifiers webhooks

## Release notes draft
* Fixed the webhook documentation for options and modifiers. You can only trigger the `store/option/updated` and `store/modifier/updated` webhooks by updating the option or modifier in the context of a channel and locale. 

## Anything else?
cc @bigcommerce/team-catalog-ops  @kristinapototska 
