### PR TITLE
Add note about document submission operations

### DIFF
--- a/docs/integrations/tax.mdx
+++ b/docs/integrations/tax.mdx
@@ -33,14 +33,15 @@ Once your tax provider configuration is ready, we'll let you know through email.
 | Platform availability | Required | All stores, Limited availability | Whether your tax provider will be available to all stores or a limited number of stores. | `Limited availability` |
 | Supported / unsupported countries | Required | ISO 3166-1 alpha-2 | Comma separated ISO 3166-1 alpha-2 country codes for supported countries. You can also select to support to all countries, or all countries except a list of unsupported countries. | `US,CA,GB,FR,AU,NZ` |
 | **URLs** | | | | |
-| <sup>+</sup>Estimate URL | Required | URL | URL BigCommerce should use for Tax Provider API estimate requests. | `https://sampletax.example.com/tax/estimate` |
-| <sup>+</sup>Commit URL | Optional | URL | URL BigCommerce should use for Tax Provider API quote requests. | `https://sampletax.example.com/doc/commit` |
-| <sup>+</sup>Adjust URL | Optional | URL | URL BigCommerce should use for Tax Provider API quote requests. | `https://sampletax.example.com/doc/adjust` |
-| <sup>+</sup>Void URL | Optional | URL | URL BigCommerce should use for Tax Provider API quote requests. | `https://sampletax.example.com/doc/void` 
+| Estimate URL <sup>1</sup> | Required | URL | URL BigCommerce should use for Tax Provider API estimate requests. | `https://sampletax.example.com/tax/estimate` |
+| Commit URL <sup>1,2</sup> | Optional | URL | URL BigCommerce should use for Tax Provider API quote requests. | `https://sampletax.example.com/doc/commit` |
+| Adjust URL <sup>1,2</sup> | Optional | URL | URL BigCommerce should use for Tax Provider API quote requests. | `https://sampletax.example.com/doc/adjust` |
+| Void URL <sup>1,2</sup> | Optional | URL | URL BigCommerce should use for Tax Provider API quote requests. | `https://sampletax.example.com/doc/void`
 | **Testing** | | | | |
 | Partner sandbox store domain | Required | Domain name | Share your partner sandbox store for testing purposes prior to launching your tax provider. Learn how to [create a partner sandbox store](/docs/start/about/sandboxes). | `https://sampletax-test-store.mybigcommerce.com/` |
 
-<sup>+</sup> You have the option of supporting a URL that merchants can customize. See [Tax Profile](#tax-profile-optional).
+<sup>1</sup> You have the option of supporting a URL that merchants can customize. See [Tax Profile](#tax-profile-optional).
+<sup>2</sup> URL is only called when the **Submit Order Data** provider setting is enabled. See [Document Submission](#document-submission).
 
 ### Tax profile (optional)
 

--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -2,7 +2,11 @@ openapi: '3.0.3'
 info:
   title: Tax Provider API
   version: '1.0'
-  description: 'Use BigCommerce’s platform-to-platform Tax Provider API to integrate a tax calculation engine into the BigCommerce storefront and control panel. Supports [estimate](/docs/rest-contracts/tax#estimate-taxes), [adjust](/docs/rest-contracts/tax#adjust-tax-quote), [commit](/docs/rest-contracts/tax#commit-tax-quote), and [void](/docs/rest-contracts/tax#void-tax-quote) operations. For more information, see [Tax Provider API Overview](/docs/integrations/tax).'
+  description: |-
+    Use BigCommerce’s platform-to-platform Tax Provider API to integrate a tax calculation engine into the BigCommerce storefront and control panel. Supports [estimate](/docs/rest-contracts/tax#estimate-taxes), [adjust](/docs/rest-contracts/tax#adjust-tax-quote), [commit](/docs/rest-contracts/tax#commit-tax-quote), and [void](/docs/rest-contracts/tax#void-tax-quote) operations. For more information, see [Tax Provider API Overview](/docs/integrations/tax).
+    
+    > #### Note
+    > * [Document submission](/docs/integrations/tax#document-submission) operations are only triggered when the **Submit Order Data** provider setting is enabled.
   termsOfService: 'https://www.bigcommerce.com/terms'
   contact:
     name: BigCommerce


### PR DESCRIPTION
# [TAX-100]

## What changed?
* Added a note about document submission operations directly within our API reference.

We keep getting tax providers miss this key detail, so we're hoping this change helps reduce the number of these questions.

"Note" style is lifted from the nearby Tax Provider Connection API documentation.

Related docs: https://developer.bigcommerce.com/docs/rest-contracts/tax

[TAX-100]: https://bigcommercecloud.atlassian.net/browse/TAX-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ