### PR TITLE
chore(shipping): SHIPPING-3329 Update documentation of the v3/shipping/settings endpoint

### DIFF
--- a/reference/shipping.v3.yml
+++ b/reference/shipping.v3.yml
@@ -168,7 +168,7 @@ paths:
       tags:
         - Shipping Settings
       summary: Get Shipping Settings
-    post:
+    put:
       operationId: updateShippingSettings
       parameters:
         - $ref: '#/components/parameters/ContentType'
@@ -420,6 +420,10 @@ components:
                 - DISPLAY_ALL_COUNTRIES
                 - DISPLAY_ONLY_SHIPPABLE_COUNTRIES
               example: DISPLAY_ALL_COUNTRIES
+            out_of_zone_delivery_message:
+              description: Message shown to the shopper during checkout when their order does not meet the merchant's shipping criteria.
+              type: string
+              example: Unfortunately, one or more items in your cart can't be shipped to your location. Please choose a different delivery address.
     customsInformation:
       title: customsInformation
       description: Data about the customs information object.


### PR DESCRIPTION
# [SHIPPING-3329](https://bigcommercecloud.atlassian.net/browse/SHIPPING-3329)

## What changed?
* Updating the v3/shipping/settings endpoint from POST to PUT as this endpoint updates settings.
* Added new property - `out_of_zone_delivery_message` where this is used to update the out of zone delivery message that resides in `manage/settings/shipping`

## Additional information
[POST to PUT change](https://github.com/bigcommerce/bigcommerce/pull/60914)

[Out of zone delivery message field addition to shipping/settings endpoint ](https://github.com/bigcommerce/bigcommerce/pull/60916)

[Exposing the PUT method in v3/shipping/settings](https://github.com/bigcommerce/api-proxy-java/pull/3293)

Screenshot:
![image](https://github.com/user-attachments/assets/7eb91b3a-4c49-4c45-8b44-2b5aec27f201)


ping @bigcommerce/team-shipping @bc-andreadao 


[SHIPPING-3163]: https://bigcommercecloud.atlassian.net/browse/SHIPPING-3163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SHIPPING-3329]: https://bigcommercecloud.atlassian.net/browse/SHIPPING-3329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ