### PR TITLE
Order transactions return 503

### DIFF
--- a/reference/orders.v3.yml
+++ b/reference/orders.v3.yml
@@ -152,6 +152,25 @@ paths:
                   instance:
                     type: string
                 title: Not Found
+        '503':
+          description: |
+            Service Unavailable.
+          content:
+            application/json:
+              schema:
+                description: Error payload for the BigCommerce API.
+                type: object
+                properties:
+                  status:
+                    description: |
+                      503 HTTP status code.
+                    type: integer
+                  title:
+                    description: The error title describing the particular error.
+                    type: string
+                  type:
+                    type: string
+                title: Service Unavailable
       summary: Get Transactions
   '/orders/{order_id}/payment_actions/refund_quotes':
     post:


### PR DESCRIPTION
# [PAYMENTS-10239]

## What changed?
* Order transactions end point will return 503 in case if it is not able to get transactions data from bigpay

Sample 503 response

<img width="1048" alt="image" src="https://github.com/user-attachments/assets/9994d4db-aaf2-4949-bfbb-49b904cb40d3" />

## Anything else?
Related to https://github.com/bigcommerce/bigcommerce/pull/61192

ping @bigcommerce/team-payments @bigcommerce/team-orders 


[PAYMENTS-10239]: https://bigcommercecloud.atlassian.net/browse/PAYMENTS-10239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ