### PR TITLE
Add note about our new document submission strategy setting

### DIFF
--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -340,6 +340,8 @@ paths:
       summary: Commit Tax Quote
       description: |-
         Submit the quote request to be persisted by the enabled third-party tax provider. A commit operation is intended to be submitted once only, when the Order has been confirmed and paid.
+        
+        Merchants may adjust when commit operations occur by adjusting the document submission strategy in their store tax settings. The selected document submission strategy will adjust whether order status or payment status is used to determine if the order is paid. For more information, see the [Tax Settings API Reference](/docs/rest-management/tax-settings).
 
         > Server URL
         > - For supporting tax providers, the server URL contains the tax providerʼs profile field; for example, `your_profile.example.com`.


### PR DESCRIPTION
# [TAX-100]

## What changed?
* Added a note to our Tax Provider API commit operation reference to describe the relationship to the document submission strategy store tax setting.

Change is on the back of some confusion from a tax partner recently.

[TAX-100]: https://bigcommercecloud.atlassian.net/browse/TAX-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ