### PR TITLE
Tax Provider API guide: add note about infinite loops

### DIFF
--- a/docs/integrations/tax.mdx
+++ b/docs/integrations/tax.mdx
@@ -162,6 +162,12 @@ Avoid synchronous calls to external systems when preparing your tax estimate res
 
 Using [Tax Properties](/docs/store-operations/tax/tax-properties) to enhance the initial Tax Provider API request can help you avoid looking up additional tax estimate inputs on external systems.
 
+#### Avoiding infinite loops
+
+Several BigCommerce API endpoints will automatically invoke an estimate call to a tax provider under certain conditions (e.g. when there is not already a tax quote applied to a cart). These API endpoints must not be called by your tax provider's implementation as doing so will cause an infinite loop of requests, resulting in a memory timeout.
+
+An infinite loop is able to be identified by observing any duplicated requests being received by a tax provider within a very short time frame.
+
 ## Document submission
 
 Document submission enables you to persist a tax quote request, replace it with another one, or invalidate it if necessary.


### PR DESCRIPTION
# [TAX-2194]

## What changed?
* Added a section to our Tax Provider API guide to describe avoiding infinite loops - which is a topic that has caused some disruption a handful of times over the years.

[TAX-2194]: https://bigcommercecloud.atlassian.net/browse/TAX-2194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ