### PR TITLE
Remove deprecated field, add new control panel price display strategy field

### DIFF
--- a/reference/tax_settings.v3.yml
+++ b/reference/tax_settings.v3.yml
@@ -124,9 +124,13 @@ components:
           type: object
           description: Settings that describe how prices display at the global level.
           properties:
-            show_inclusive_in_control_panel:
-              type: boolean
-              description: Whether to show prices as tax inclusive or tax exclusive in the BigCommerce control panel.
+            control_panel_price_display_strategy:
+              type: string
+              description: Whether to show prices as tax inclusive or tax exclusive in the BigCommerce control panel, or use the order's tax zone for price display.
+              enum:
+                - ZONE
+                - INCLUSIVE
+                - EXCLUSIVE
             invoice_price_display_strategy:
               type: string
               description: 'Whether to show prices as tax inclusive or tax exclusive across all invoices, or use the shopperʼs tax zone for price display on invoices.'


### PR DESCRIPTION
# [TAX-2184]

## What changed?
* Removed deprecated `show_inclusive_in_control_panel` field from Tax Settings API.
* Added `control_panel_price_display_strategy` field to Tax Settings API.

## Release notes draft
* Updated available Tax Settings API fields, new option available for controlling tax price display in the control panel.

[TAX-2184]: https://bigcommercecloud.atlassian.net/browse/TAX-2184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ