### PR TITLE
DEVDOCS-6186 - Remove Beta label from Form Fields Doc

### DIFF
--- a/reference/form_fields.sf.yml
+++ b/reference/form_fields.sf.yml
@@ -1,6 +1,6 @@
 openapi: '3.0.1'
 info:
-  title: Storefront Form Fields (Beta)
+  title: Storefront Form Fields
   description: |-
     Read form fields on BigCommerce-hosted storefronts. To work with headless storefronts, use the [GraphQL Storefront API](/graphql-storefront/reference).
     
@@ -8,8 +8,6 @@ info:
         
     For info about authenticating BigCommerce APIs, see [Authentication and Example Requests](/docs/start/authentication#same-origin-cors-authentication).
 
-    > #### Warning
-    > Breaking changes may be introduced to this endpoint while in beta.
   version: ''
   termsOfService: 'https://www.bigcommerce.com/terms'
   contact:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6186]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Feature is now in GA
* Removing Beta messaging from doc

## Release notes draft
* Storefront Form Fields API endpoint is now GA.
* We've removed the Beta messaging from the documentation.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6186]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ