### PR TITLE
DEVDOCS-4171 - fix broken in-page links

### DIFF
--- a/reference/shipping.v2.yml
+++ b/reference/shipping.v2.yml
@@ -1096,7 +1096,7 @@ paths:
         | - | - | - |
         | default_cost | number &#124; null | Default shipping cost, applied either as a percentage of the orderʼs total value or as a fixed amount. If default cost is not required, you can supply a value of null. |
         | default_cost_type | string | How the default shipping cost is calculated; either `percentage_of_total` or `fixed_amount`. |
-        | range | number | Array of [range](#range) objects. The units for these ranges' `lower_limit` and `upper_limit` properties depend on the default units set in the storeʼs control panel. |
+        | range | number | Array of [range](#range-object--properties) objects. The units for these ranges' `lower_limit` and `upper_limit` properties depend on the default units set in the storeʼs control panel. |
         
         Example request body:
         
@@ -1131,7 +1131,7 @@ paths:
         | - | - | - |
         | default_cost | number &#124; null | Default shipping cost, applied either as a percentage of the orderʼs total value or as a fixed amount. If default cost is not required, you can supply a value of null. |
         | default_cost_type | string | How the default shipping cost is calculated; either `percentage_of_total` or `fixed_amount`. |
-        | range | number | Array of [range](#range) objects. The units for these ranges' `lower_limit` and `upper_limit` properties are values in the storeʼs currency. |
+        | range | number | Array of [range](#range-object--properties) objects. The units for these ranges' `lower_limit` and `upper_limit` properties are values in the storeʼs currency. |
         
         Example request body:
         
@@ -1334,7 +1334,7 @@ paths:
         | - | - | - |
         | default_cost | number &#124; null | Default shipping cost, applied either as a percentage of the orderʼs total value or as a fixed amount. If default cost is not required, you can supply a value of null. |
         | default_cost_type | string | How the default shipping cost is calculated; either `percentage_of_total` or `fixed_amount`. |
-        | range | number | Array of [range](#range) objects. The units for these ranges' `lower_limit` and `upper_limit` properties depend on the default units set in the storeʼs control panel. |
+        | range | number | Array of [range](#range-object--properties) objects. The units for these ranges' `lower_limit` and `upper_limit` properties depend on the default units set in the storeʼs control panel. |
 
 
         #### JSON Example
@@ -1370,7 +1370,7 @@ paths:
         | - | - | - |
         | default_cost | number &#124; null | Default shipping cost, applied either as a percentage of the orderʼs total value or as a fixed amount. If default cost is not required, you can supply a value of null. |
         | default_cost_type | string | How the default shipping cost is calculated; either `percentage_of_total` or `fixed_amount`. |
-        | range | number | Array of [range](#range) objects. The units for these ranges' `lower_limit` and `upper_limit` properties are values in the storeʼs currency. |
+        | range | number | Array of [range](#range-object--properties) objects. The units for these ranges' `lower_limit` and `upper_limit` properties are values in the storeʼs currency. |
 
         #### JSON Example
 
@@ -1419,7 +1419,7 @@ paths:
 
         Object model to define ranges for shipping quotes. Units are defined in the parent object.
 
-        | Name | Type | Description |
+        | Property | Type | Description |
         | - | - | - |
         | lower_limit | number | Lower limit for order total. |
         | upper_limit | number | Upper limit for order total. |
@@ -1477,7 +1477,7 @@ paths:
                   type:
                     $ref: '#/components/schemas/ShippingMethodType'
                   settings:
-                    description: 'Depends on the shipping method type. See the [supported settings object](#supported-settings).'
+                    description: 'Depends on the shipping method type. See the [supported settings object](#settings-objects).'
                     type: object
                     properties: {}
                     additionalProperties: true
@@ -1601,7 +1601,7 @@ paths:
         | - | - | - |
         | default_cost | number &#124; null | Default shipping cost, applied either as a percentage of the orderʼs total value or as a fixed amount. If default cost is not required, you can supply a value of null. |
         | default_cost_type | string | How the default shipping cost is calculated; either `percentage_of_total` or `fixed_amount`. |
-        | range | number | Array of [range](#range) objects. The units for these ranges' `lower_limit` and `upper_limit` properties depend on the default units set in the storeʼs control panel. |
+        | range | number | Array of [range](#range-object--properties) objects. The units for these ranges' `lower_limit` and `upper_limit` properties depend on the default units set in the storeʼs control panel. |
         
         
         Example response: 
@@ -1637,7 +1637,7 @@ paths:
         | - | - | - |
         | default_cost | number &#124; null | Default shipping cost, applied either as a percentage of the orderʼs total value or as a fixed amount. If default cost is not required, you can supply a value of null. |
         | default_cost_type | string | How the default shipping cost is calculated; either `percentage_of_total` or `fixed_amount`. |
-        | range | number | Array of [range](#range) objects. The units for these ranges' `lower_limit` and `upper_limit` properties are values in the storeʼs currency. |
+        | range | number | Array of [range](#range-object--properties) objects. The units for these ranges' `lower_limit` and `upper_limit` properties are values in the storeʼs currency. |
         
         Example response: 
         
@@ -2387,7 +2387,7 @@ components:
         type:
           $ref: '#/components/schemas/ShippingMethodType'
         settings:
-          description: 'Depends on the shipping method type. See the [supported settings object](#supported-settings).'
+          description: 'Depends on the shipping method type. See the [supported settings object](#settings-objects).'
           type: object
           properties:
             rate:


### PR DESCRIPTION
On-page links for Shipping Methods to range object properties and settings object properties returned incorrect anchors. Updated links to match correct anchors.

Also updated Range Object Properties table in the Get a Shipping Method section to match style of other Range Object Properties table.

<!-- Ticket number or summary of work -->
# [DEVDOCS-4171]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Links for settings object properties and range object properties point to correct anchors in-page
* Range object properties tables have consistent content styling and text.

## Release notes draft
* Fixed broken links in the Shipping Methods endpoint documentation.
* Updated text of Range Object Properties tables to match similar content in other areas of the doc.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-4171]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ