### PR TITLE
DEVDOCS-6185 - Update endpoint to include file size limit

### DIFF
--- a/reference/settings.v3.yml
+++ b/reference/settings.v3.yml
@@ -360,6 +360,7 @@ paths:
         Uploads an image file to use as the storefront favicon. Supported MIME types include GIF, JPEG, and PNG. 
 
           - Channel ID can be used as a query parameter for updating channel-specific settings. If omitted, you will interact with the global settings only.
+          - The uploaded image can be up to 10 MB. Larger files result in an error.
       parameters:
         - $ref: '#/components/parameters/ContentType'
         - $ref: '#/components/parameters/ChannelIdParam'
@@ -375,6 +376,8 @@ paths:
       responses:
         '204':
           description: OK
+        '422':
+          description: Failed to save!
       tags:
         - Favicon Image
   '/settings/inventory/notifications':


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6185]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* The Create Favicon Image endpoint has a file size limit that was not previously documented
* Files larger than 10 MB will return a 422

## Release notes draft
* Updated doc to include reference to file size limit
* Added 422 to the responses list

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6185]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ