### PR TITLE
Added consents array to put and post request bodies

### DIFF
--- a/reference/subscribers.v3.yml
+++ b/reference/subscribers.v3.yml
@@ -382,10 +382,10 @@ components:
               type: string
             description: Shows what active subscriptions a shopper may have. If the consents array is empty, the user has unsubscribed or didn’t enable the newsletter subscription checkbox during checkout.
             enum:
-              - [marketing_newsletter]
-              - [abandoned_cart]
+              - ["marketing_newsletter"]
+              - ["abandoned_cart"]
             example: 
-              - [marketing_newsletter]
+              - ["marketing_newsletter"]
       x-internal: false
     subscriber_Base:
       title: subscriber_Base
@@ -433,11 +433,11 @@ components:
               type: string
             description: Shows what active subscriptions a shopper may have. If the consents array is empty, the user has unsubscribed or didn’t enable the newsletter subscription checkbox during checkout.
             enum:
-              - [marketing_newsletter]
-              - [abandoned_cart]
+              - ["marketing_newsletter"]
+              - ["abandoned_cart"]
             example: 
-              - [marketing_newsletter]
-              - [abandoned_cart]
+              - ["marketing_newsletter"]
+              - ["abandoned_cart"]
       description: Common Subscriber properties.
       x-internal: false
     Subscriber:

--- a/reference/subscribers.v3.yml
+++ b/reference/subscribers.v3.yml
@@ -380,12 +380,11 @@ components:
             type: array
             items:
               type: string
+              enum:
+                - marketing_newsletter
+                - abandoned_cart
             description: Shows the active subscriptions a shopper may have. If the consents array is empty, the user has unsubscribed or didn’t enable the newsletter subscription checkbox during checkout. The array will contain consent types like 'marketing_newsletter' and 'abandoned_cart'.
-            enum:
-              - ["marketing_newsletter"]
-              - ["abandoned_cart"]
-            example: 
-              - "marketing_newsletter"
+            example: ["marketing_newsletter"]
       x-internal: false
     subscriber_Base:
       title: subscriber_Base
@@ -431,12 +430,11 @@ components:
             type: array
             items:
               type: string
+              enum:
+                - marketing_newsletter
+                - abandoned_cart
             description: Shows the active subscriptions a shopper may have. If the consents array is empty, the user has unsubscribed or didn’t enable the newsletter subscription checkbox during checkout. The array will contain consent types like 'marketing_newsletter' and 'abandoned_cart'.
-            enum:
-              - ["marketing_newsletter"]
-              - ["abandoned_cart"]
-            example:
-              - "abandoned_cart"
+            example: ["abandoned_cart"]
       description: Common Subscriber properties.
       x-internal: false
     Subscriber:

--- a/reference/subscribers.v3.yml
+++ b/reference/subscribers.v3.yml
@@ -380,10 +380,10 @@ components:
             type: array
             items:
               type: string
-            description: Shows what active subscriptions a shopper may have. If the consents array is empty, the user has unsubscribed or didn’t enable the newsletter subscription checkbox during checkout.
+            description: Shows the active subscriptions a shopper may have. If the consents array is empty, the user has unsubscribed or didn’t enable the newsletter subscription checkbox during checkout. The array will contain consent types like 'marketing_newsletter' and 'abandoned_cart'.
             enum:
-              - ["marketing_newsletter"]
-              - ["abandoned_cart"]
+              - "marketing_newsletter"
+              - "abandoned_cart"
             example: 
               - "marketing_newsletter"
       x-internal: false
@@ -431,10 +431,10 @@ components:
             type: array
             items:
               type: string
-            description: Shows what active subscriptions a shopper may have. If the consents array is empty, the user has unsubscribed or didn’t enable the newsletter subscription checkbox during checkout.
+            description: Shows the active subscriptions a shopper may have. If the consents array is empty, the user has unsubscribed or didn’t enable the newsletter subscription checkbox during checkout. The array will contain consent types like 'marketing_newsletter' and 'abandoned_cart'.
             enum:
-              - ["marketing_newsletter"]
-              - ["abandoned_cart"]
+              - "marketing_newsletter"
+              - "abandoned_cart"
             example: 
               - "marketing_newsletter"
               - "abandoned_cart"

--- a/reference/subscribers.v3.yml
+++ b/reference/subscribers.v3.yml
@@ -385,7 +385,7 @@ components:
               - [marketing_newsletter]
               - [abandoned_cart]
             example: 
-              - marketing_newsletter
+              - [marketing_newsletter]
       x-internal: false
     subscriber_Base:
       title: subscriber_Base
@@ -436,8 +436,8 @@ components:
               - [marketing_newsletter]
               - [abandoned_cart]
             example: 
-              - marketing_newsletter
-              - abandoned_cart
+              - [marketing_newsletter]
+              - [abandoned_cart]
       description: Common Subscriber properties.
       x-internal: false
     Subscriber:

--- a/reference/subscribers.v3.yml
+++ b/reference/subscribers.v3.yml
@@ -381,6 +381,9 @@ components:
             items:
               type: string
             description: Shows what active subscriptions a shopper may have. If the consents array is empty, the user has unsubscribed or didn’t enable the newsletter subscription checkbox during checkout.
+            enum:
+              - [marketing_newsletter]
+              - [abandoned_cart]
             example: 
               - marketing_newsletter
       x-internal: false
@@ -429,6 +432,9 @@ components:
             items:
               type: string
             description: Shows what active subscriptions a shopper may have. If the consents array is empty, the user has unsubscribed or didn’t enable the newsletter subscription checkbox during checkout.
+            enum:
+              - [marketing_newsletter]
+              - [abandoned_cart]
             example: 
               - marketing_newsletter
               - abandoned_cart

--- a/reference/subscribers.v3.yml
+++ b/reference/subscribers.v3.yml
@@ -385,7 +385,7 @@ components:
               - ["marketing_newsletter"]
               - ["abandoned_cart"]
             example: 
-              - ["marketing_newsletter"]
+              - "marketing_newsletter"
       x-internal: false
     subscriber_Base:
       title: subscriber_Base
@@ -436,8 +436,8 @@ components:
               - ["marketing_newsletter"]
               - ["abandoned_cart"]
             example: 
-              - ["marketing_newsletter"]
-              - ["abandoned_cart"]
+              - "marketing_newsletter"
+              - "abandoned_cart"
       description: Common Subscriber properties.
       x-internal: false
     Subscriber:

--- a/reference/subscribers.v3.yml
+++ b/reference/subscribers.v3.yml
@@ -382,8 +382,8 @@ components:
               type: string
             description: Shows the active subscriptions a shopper may have. If the consents array is empty, the user has unsubscribed or didn’t enable the newsletter subscription checkbox during checkout. The array will contain consent types like 'marketing_newsletter' and 'abandoned_cart'.
             enum:
-              - "marketing_newsletter"
-              - "abandoned_cart"
+              - ["marketing_newsletter"]
+              - ["abandoned_cart"]
             example: 
               - "marketing_newsletter"
       x-internal: false
@@ -433,10 +433,9 @@ components:
               type: string
             description: Shows the active subscriptions a shopper may have. If the consents array is empty, the user has unsubscribed or didn’t enable the newsletter subscription checkbox during checkout. The array will contain consent types like 'marketing_newsletter' and 'abandoned_cart'.
             enum:
-              - "marketing_newsletter"
-              - "abandoned_cart"
-            example: 
-              - "marketing_newsletter"
+              - ["marketing_newsletter"]
+              - ["abandoned_cart"]
+            example:
               - "abandoned_cart"
       description: Common Subscriber properties.
       x-internal: false

--- a/reference/subscribers.v3.yml
+++ b/reference/subscribers.v3.yml
@@ -424,6 +424,14 @@ components:
           minimum: 1
           type: integer
           description: The channel ID where the subscriber was created.
+        consents:
+            type: array
+            items:
+              type: string
+            description: Shows what active subscriptions a shopper may have. If the consents array is empty, the user has unsubscribed or didn’t enable the newsletter subscription checkbox during checkout.
+            example: 
+              - marketing_newsletter
+              - abandoned_cart
       description: Common Subscriber properties.
       x-internal: false
     Subscriber:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
#NO TICKET


## What changed?

Added the consents array to the PUT and POST request body schema and examples.
See slack conversation: https://bigcommerce.slack.com/archives/C57SQ401K/p1737710187469379

## Release notes draft

Enhancement
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}
