### PR TITLE
BRP-17278 Add scope filter for SubscriptionsQuery

### DIFF
--- a/docs/integrations/apps/unified-billing/example-queries.mdx
+++ b/docs/integrations/apps/unified-billing/example-queries.mdx
@@ -911,6 +911,8 @@ Filters can also be used to query subscriptions.
 The supported filters are
 * `productId`
 * `productType`
+* `scopeId`
+* `scopeType`
 * `updatedAfter`
 * `status`
 * `ids`
@@ -979,6 +981,18 @@ The supported filters are
     {
        "filters": {
            "ids": ["bc/account/subscription/d7762d54-1aab-4243-938b-294b846222b5", "bc/account/subscription/f34807ed-493a-4d17-90f1-11b2c3283cfd"]
+       }
+    }
+    ```
+
+
+    Use `scopeId` and `scopeType` filters together to retrieve specific subscriptions for a given scope:
+
+    ```json filename="Scope filters" showLineNumbers copy
+    {
+       "filters": {
+           "scopeId": "bc/account/scope/9godyw034y",
+           "scopeType": "STORE"
        }
     }
     ```


### PR DESCRIPTION
# [[BRP-17278](https://bigcommercecloud.atlassian.net/browse/BRP-17278)]

## What changed?
Provide a bulleted list in the present tense
* Adding in the new scope filters that we are adding as a part of the other PR's in this ticket to allow for end users to filter by scope (store's in this case)

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.
https://github.com/bigcommerce/merchant-subscription-manager/pull/345
https://github.com/bigcommerce/api-proxy-java/pull/3340

ping {names}


[BRP-17278]: https://bigcommercecloud.atlassian.net/browse/BRP-17278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ