### PR TITLE
DEVDOCS-6197: [update] add concurrent limits

### DIFF
--- a/reference/segments.v3.yml
+++ b/reference/segments.v3.yml
@@ -50,6 +50,9 @@ paths:
         - Segments
       description: |
         Creates *Segments*.
+
+        **Limits**
+        * Limit of 10 concurrent requests.
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -143,6 +146,9 @@ paths:
         - Segments
       description: |
         Updates *Segments*.
+
+         **Limits**
+         * Limit of 10 concurrent requests.
       operationId: 'PutSegmentObjects'
       parameters:
         - $ref: '#/components/parameters/ContentType'
@@ -207,7 +213,7 @@ paths:
         - Shopper Profiles for a Segment
       description: |-
         Add *Shopper Profiles* to a specific *Segment*. 
-        A maximum number of *Shopper Profiles* per request is `50`, and up to three concurrent requests are allowed.
+        A maximum number of *Shopper Profiles* per request is `50`, and up to 10 concurrent requests are allowed.
       operationId: 'PostShopperProfile'
       parameters:
         - $ref: '#/components/parameters/ContentType'

--- a/reference/segments.v3.yml
+++ b/reference/segments.v3.yml
@@ -213,7 +213,10 @@ paths:
         - Shopper Profiles for a Segment
       description: |-
         Add *Shopper Profiles* to a specific *Segment*. 
-        A maximum number of *Shopper Profiles* per request is `50`, and up to 10 concurrent requests are allowed.
+
+        **Limits**
+        * Limit of *Shopper Profiles* per request is `50`.
+        * Limit of 10 concurrent requests.
       operationId: 'PostShopperProfile'
       parameters:
         - $ref: '#/components/parameters/ContentType'


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6197]


## What changed?

Added 10 concurrent limits to the following endpoints:
Create Segments
Update Segments
Create Shopper Profiles

## Release notes draft

Added concurrent limits to Create Segments, Update Segments, and Create Shopper Profiles endpoints.

<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6197]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ