### PR TITLE
DEVDOCS-6205 - Add character limit for PUT and POST product image

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -5678,12 +5678,6 @@ components:
       title: productImage_Base
       type: object
       properties:
-        image_url:
-          type: string
-          description: |
-            The URL for an image displayed on the storefront when the conditions are applied. Limit of 8MB per file.
-
-            Cannot be used with `image_file`.
         is_thumbnail:
           type: boolean
           description: |
@@ -5716,6 +5710,13 @@ components:
               type: integer
               description: |
                 The unique numeric identifier for the product with which the image is associated.
+            image_url:
+              maxLength: 255
+              type: string
+              description: |
+                The URL for an image displayed on the storefront when the conditions are applied. Limit of 8MB per file.
+
+                Cannot be used with `image_file`.
           description: Common ProductImage properties.
         - $ref: '#/components/schemas/productImage_Base'
       x-internal: false
@@ -6434,6 +6435,12 @@ components:
               type: integer
               description: |
                 The unique numeric identifier for the product with which the image is associated.
+            image_url:
+              type: string
+              description: |
+                The URL for an image displayed on the storefront when the conditions are applied. Limit of 8MB per file.
+
+                Cannot be used with `image_file`.
             url_zoom:
               readOnly: true
               type: string


### PR DESCRIPTION
Adding and updating product images by URL both have a maximum URL length of 255

<!-- Ticket number or summary of work -->
# [DEVDOCS-6205]


## What changed?
* Adding and updating product images via URL has a maximum length limit of 255 characters
* This limit is reflected specifically for POST and PUT endpoints on Product Images

## Release notes draft
* Updated POST and PUT endpoints for Product Images to include URL character length limit of 255

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6205]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ