### PR TITLE
Ad `ttl` to shipping rates response body: [update] add missing ttl object to response body

### DIFF
--- a/reference/shipping_provider.yml
+++ b/reference/shipping_provider.yml
@@ -353,7 +353,7 @@ paths:
                 Without shipping rates:
                   value:
                     quote_id: example_quote
-                    ttl: 0
+                    ttl: 5
                     messages: []
                     carrier_quotes: []
       summary: Request shipping rates
@@ -764,7 +764,8 @@ components:
           type: string
           maxLength: 50
         ttl:
-          type: number
+          type: integer
+          description: Time-to-live (TTL) in seconds
         messages:
           type: array
           items:

--- a/reference/shipping_provider.yml
+++ b/reference/shipping_provider.yml
@@ -353,6 +353,7 @@ paths:
                 Without shipping rates:
                   value:
                     quote_id: example_quote
+                    ttl: 0
                     messages: []
                     carrier_quotes: []
       summary: Request shipping rates
@@ -762,6 +763,8 @@ components:
         quote_id:
           type: string
           maxLength: 50
+        ttl:
+          type: number
         messages:
           type: array
           items:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# NO TICKET


## What changed?

add missing ttl object to response body

See slack conversation: https://bigcommerce.slack.com/archives/C57SQ401K/p1738596845318689
<!-- Provide a bulleted list in the present tense -->
* 

## Release notes draft

Bug Fix: Added missing optional field
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}
