### PR TITLE
DEVDOCS-6211 - update concurrent call limit (category trees)

### DIFF
--- a/reference/catalog/category-trees_catalog.v3.yml
+++ b/reference/catalog/category-trees_catalog.v3.yml
@@ -402,7 +402,11 @@ paths:
   '/catalog/trees/{tree_id}/categories':
     get:
       summary: Get a category tree
-      description: Returns a category tree.
+      description: |-
+        Returns a category tree.
+
+        **Note:**
+        The default rate limit for this endpoint is 1 concurrent request.
       operationId: getCategoryTree
       parameters:
         - name: depth


### PR DESCRIPTION
Added messaging about concurrent call rate limit to Get a Category Tree endpoint. This will be affected by an experiment in the next 90 days.

<!-- Ticket number or summary of work -->
# [DEVDOCS-6211]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* The Get a Category Tree endpoint is getting a concurrent call limit to prevent overloading on the back-end.
* This endpoint is now documented.

## Release notes draft
* Updated Get a Category Tree endpoint to include mention of the default concurrent call limit.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}
