### PR TITLE
DEVDOCS-6183 - add callout about authorization limit

### DIFF
--- a/docs/storefront/headless/index.mdx
+++ b/docs/storefront/headless/index.mdx
@@ -170,7 +170,7 @@ The following example uses the GraphQL Storefront API to complete a checkout and
 BigCommerce has introduced a feature that leverages the [Customer Access Token](/docs/start/authentication/graphql-storefront#customer-access-tokens) for seamless redirection, logging in customers automatically when they reach checkout from the storefront. Built with JWT-based "Session Sync," this enhancement enables transferring session details, such as customer and cart data, across various contexts. Developers can use GraphQL API for advanced session syncing, ensuring a smoother, cohesive experience for customers across platforms.
 
 <Callout type="info">
-  After three attempts with invalid session-sync JWT tokens, the IP address will be blocked for 5 minutes.
+  After three attempts with invalid session-sync JWT tokens, the system will block the IP address for five minutes.
 </Callout>
 
 The following examples demonstrate how to sync and validate session details for headless storefronts and hosted checkouts.    

--- a/docs/storefront/headless/index.mdx
+++ b/docs/storefront/headless/index.mdx
@@ -169,6 +169,10 @@ The following example uses the GraphQL Storefront API to complete a checkout and
 
 BigCommerce has introduced a feature that leverages the [Customer Access Token](/docs/start/authentication/graphql-storefront#customer-access-tokens) for seamless redirection, logging in customers automatically when they reach checkout from the storefront. Built with JWT-based "Session Sync," this enhancement enables transferring session details, such as customer and cart data, across various contexts. Developers can use GraphQL API for advanced session syncing, ensuring a smoother, cohesive experience for customers across platforms.
 
+<Callout type="info">
+  After three attempts with invalid session-sync JWT tokens, the IP address will be blocked for 5 minutes.
+</Callout>
+
 The following examples demonstrate how to sync and validate session details for headless storefronts and hosted checkouts.    
 
 <Tabs items={['Format', 'Mutation', 'Validate']}>


### PR DESCRIPTION
JWT Session-Sync is limited to three unsuccessful attempts before IP is locked temporarily.

<!-- Ticket number or summary of work -->
# [DEVDOCS-6183]


## What changed?
* JWT style login has a security limit of three failed attempts before temporarily locking the IP address making calls.

## Release notes draft
* Added call-out note about limit to the Headless Login section.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6183]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ