### PR TITLE
STRF-12301: Update Customer JWT payload reference

### DIFF
--- a/docs/start/authentication/customer-login.mdx
+++ b/docs/start/authentication/customer-login.mdx
@@ -42,7 +42,7 @@ JWT is an industry standard ([RFC 7519](https://tools.ietf.org/html/rfc7519)) fo
 | `customer_id` | integer | The ID of the shopper who is signing in.|
 | `redirect_to` | string | Optional field containing a relative path for the shopper's destination after sign-in. Defaults to `/account.php`. |
 | `request_ip` | string | Optional field containing the expected IP address for the request. If provided, BigCommerce will check that it matches the browser trying to sign in.|
-| `enable_persistent_cart` | boolean | Optional field to specify whether or not to use persistent cart functionality on customer token login. This feature depends on you enabling the [Persistent Cart](https://support.bigcommerce.com/s/article/Persistent-Cart) setting on your store. The default value is `false`.|
+| `enable_persistent_cart` | boolean | Optional field specifying whether or not to use persistent cart functionality on customer token login. This feature depends on you enabling the [Persistent Cart](https://support.bigcommerce.com/s/article/Persistent-Cart) setting on your store. The default value is `false`. The system ignores this value if you use the server-side GraphQL JWT login mutation.|
 
 ## Prerequisites
 


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [STRF-12301]

## What changed?
* Update the Customer JWT payload reference to clarify that the `enable_persistent_cart` flag is ignored if you are using the JWT for the `loginWithJwt` GraphQL mutation.

## Release notes draft
* Persistent cart is now supported on all GraphQL login mutations

## Anything else?
n/a

ping @bc-traciporter 


[STRF-12301]: https://bigcommercecloud.atlassian.net/browse/STRF-12301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ