### PR TITLE
fix: token property in b2b storefront auth token response should be array

### DIFF
--- a/docs/b2b-edition/specs/api-v3/authentication.yaml
+++ b/docs/b2b-edition/specs/api-v3/authentication.yaml
@@ -564,7 +564,9 @@ paths:
                     type: object
                     properties:
                       token:
-                        type: string
+                        type: array
+                        items:
+                          type: string
                   meta:
                     type: object
                     properties:
@@ -575,7 +577,9 @@ paths:
                   value:
                     code: 200
                     data:
-                      token: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6IjEyM0AxMi5jb20iLCJiY19jdXN0b21lcl9pZCI6MzEzLCJzdG9yZV9oYXNoIjoiaW1rOHp6N2ppcCIsImRiIjoiZGVmYXVsdCIsImJjX2NoYW5uZWxfaWQiOjEsImV4cCI6MTY5MDg1NDI5Mn0.97rY-1aGDFKtLbIePR5g202AHZJ0x2kDjmyzGVGK45
+                      token: [
+                        "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6IjEyM0AxMi5jb20iLCJiY19jdXN0b21lcl9pZCI6MzEzLCJzdG9yZV9oYXNoIjoiaW1rOHp6N2ppcCIsImRiIjoiZGVmYXVsdCIsImJjX2NoYW5uZWxfaWQiOjEsImV4cCI6MTY5MDg1NDI5Mn0.97rY-1aGDFKtLbIePR5g202AHZJ0x2kDjmyzGVGK45"
+                      ]
                     meta:
                       message: success
       description: Get B2B storefront token by v3 io token


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# NO-TICKET

## What changed?
<!-- Provide a bulleted list in the present tense -->
* The [B2B Storefront Auth Token API](https://developer.bigcommerce.com/b2b-edition/apis/rest-management/auth#get-a-b2b-storefront-token) response does not return a token as a string, it returns it as an array of strings. 

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* No functional change, just updating the documentation to be more accurate. 

## Anything else?
Screenshot of response from API:
<img width="1005" alt="Screenshot 2025-02-07 at 4 25 31 PM" src="https://github.com/user-attachments/assets/c2ff2173-1cff-4c73-8e28-6e6bb30e78ee" />



ping {names}
