### PR TITLE
DEVDOCS-6171 - Add call-out for PCI 4.0

### DIFF
--- a/docs/storefront/stencil/start/index.mdx
+++ b/docs/storefront/stencil/start/index.mdx
@@ -10,6 +10,7 @@ The [Page Builder](/docs/storefront/stencil/content/page-builder) tool available
 BigCommerce Stencil themes are responsive, mobile friendly themes, allowing shoppers to have a first class experience across any device. Each Stencil theme can contain one to four variations. You can optimize individual variations for specific markets, audiences, and styles, while still managing and distributing all of these variations as one theme.
 
 ## Cornerstone
+<Callout type="info">As of PCI 4.0, scripts require nonce-based authorization, integrity checks, and justification. In order to remain compliant, upgrade your theme to Cornerstone >= 6.16.0, which is compatible with this change.</Callout>
 
 BigCommerce's [Cornerstone](https://github.com/bigcommerce/cornerstone) theme is the building block and starting point for rapidly developing themes for BigCommerce. Cornerstone is available open source on [GitHub](https://github.com/bigcommerce/cornerstone).
 

--- a/docs/storefront/stencil/start/index.mdx
+++ b/docs/storefront/stencil/start/index.mdx
@@ -10,7 +10,7 @@ The [Page Builder](/docs/storefront/stencil/content/page-builder) tool available
 BigCommerce Stencil themes are responsive, mobile friendly themes, allowing shoppers to have a first class experience across any device. Each Stencil theme can contain one to four variations. You can optimize individual variations for specific markets, audiences, and styles, while still managing and distributing all of these variations as one theme.
 
 ## Cornerstone
-<Callout type="info">As of PCI 4.0, scripts require nonce-based authorization, integrity checks, and justification. In order to remain compliant, upgrade your theme to Cornerstone >= 6.16.0, which is compatible with this change.</Callout>
+<Callout type="info">With PCI 4.0, scripts now require nonce-based authorization, integrity checks, and justification. To stay compliant, upgrade your Cornerstone theme to version 6.16.0 or later, which supports this change.</Callout>
 
 BigCommerce's [Cornerstone](https://github.com/bigcommerce/cornerstone) theme is the building block and starting point for rapidly developing themes for BigCommerce. Cornerstone is available open source on [GitHub](https://github.com/bigcommerce/cornerstone).
 


### PR DESCRIPTION
Added callout alerting devs of minimum version to remain PCI compliant with respect to nonce-based authorization.

<!-- Ticket number or summary of work -->
# [DEVDOCS-6171]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* PCI 4.0 Section 6.4.3 requires nonce-based authorization, which has not been present previously.
* As of Cornerstone 6.16.0, nonce-based authorization and SRI features are implemented natively.
* A notice of the requirement and action are included in Stencil documentation.

## Release notes draft
* Added a call-out regarding PCI 4.0 Section 6.4.3 and upgrading to the current version of Cornerstone.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6171]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ