### PR TITLE
CATALOG-11019: Add new sort field to get products

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -9454,6 +9454,7 @@ components:
           - inventory_level
           - is_visible
           - total_sold
+          - calculated_price
     IncludeFieldsBulkPricingParam:
       name: include_fields
       in: query


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [CATALOG-11019]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Add new sort field to get products

## Release notes draft
* Endpoint `v3/catalog/products` now support sorting by `calculated_price`

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @bigcommerce/team-catalog 


[CATALOG-11019]: https://bigcommercecloud.atlassian.net/browse/CATALOG-11019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ