### PR TITLE
chore(shipping): SHIPPING-3338 Publish documentation for v3 channel based out of zone delivery message

### DIFF
--- a/reference/shipping.v3.yml
+++ b/reference/shipping.v3.yml
@@ -164,7 +164,7 @@ paths:
                     type: object
                     properties: {}
       description: |-
-        Get shipping settings.
+        Returns the global-level shipping settings.
       tags:
         - Shipping Settings
       summary: Get Shipping Settings
@@ -185,9 +185,53 @@ paths:
                   meta:
                     type: object
                     properties: {}
+        '400':
+          description: Bad Request. Input is invalid.
+          content:
+            application/json:
+              schema:
+                description: ''
+                type: object
+                properties:
+                  status:
+                    type: number
+                  title:
+                    type: string
+                    minLength: 1
+                  type:
+                    type: string
+                    minLength: 1
+                  detail:
+                    type: string
+                    minLength: 1
+              example:
+                status: 400
+                title: Input is invalid
+                type: 'https://developer.bigcommerce.com/api-docs/getting-started/api-status-codes'
+                detail: Syntax error
+        '422':
+          description: The request body does not meet the specification.
+          content:
+            application/json:
+              schema:
+                description: ''
+                type: object
+                properties:
+                  status:
+                    type: number
+                  title:
+                    type: string
+                    minLength: 1
+                  type:
+                    type: string
+                    minLength: 1
+              example:
+                status: 422
+                title: Input is invalid
+                type: 'https://developer.bigcommerce.com/api-docs/getting-started/api-status-codes'
       summary: Update Shipping Settings
       description: |-
-        Updates shipping settings.
+        Updates the global-level shipping settings.
       tags:
         - Shipping Settings
       requestBody:
@@ -195,6 +239,107 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/shippingSettings'
+  '/shipping/settings/channels/{channel_id}':
+    parameters:
+      - $ref: '#/components/parameters/Accept'
+      - name: channel_id
+        in: path
+        schema:
+          type: string
+        description: Channel ID
+        required: true
+
+    get:
+      operationId: getChannelShippingSettings
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/channelShippingSettings'
+                  meta:
+                    type: object
+                    properties: {}
+      description: |-
+        Returns shipping settings for a specific channel.
+      tags:
+        - Shipping Settings
+      summary: Get Shipping Settings per Channel
+    put:
+      operationId: updateChannelShippingSettings
+      parameters:
+        - $ref: '#/components/parameters/ContentType'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/channelShippingSettings'
+                  meta:
+                    type: object
+                    properties: {}
+        '400':
+          description: Bad Request. Input is invalid.
+          content:
+            application/json:
+              schema:
+                description: ''
+                type: object
+                properties:
+                  status:
+                    type: number
+                  title:
+                    type: string
+                    minLength: 1
+                  type:
+                    type: string
+                    minLength: 1
+                  detail:
+                    type: string
+                    minLength: 1
+              example:
+                status: 400
+                title: Input is invalid
+                type: 'https://developer.bigcommerce.com/api-docs/getting-started/api-status-codes'
+                detail: Syntax error
+        '422':
+          description: The request body does not meet the specification.
+          content:
+            application/json:
+              schema:
+                description: ''
+                type: object
+                properties:
+                  status:
+                    type: number
+                  title:
+                    type: string
+                    minLength: 1
+                  type:
+                    type: string
+                    minLength: 1
+              example:
+                status: 422
+                title: Input is invalid
+                type: 'https://developer.bigcommerce.com/api-docs/getting-started/api-status-codes'
+      summary: Update Shipping Settings per Channel
+      description: |-
+        Updates shipping settings for a specific channel.
+      tags:
+        - Shipping Settings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/channelShippingSettings'
 components:
   parameters:
     store_hash:
@@ -420,7 +565,17 @@ components:
                 - DISPLAY_ALL_COUNTRIES
                 - DISPLAY_ONLY_SHIPPABLE_COUNTRIES
               example: DISPLAY_ALL_COUNTRIES
-            out_of_zone_delivery_message:
+            out_of_delivery_zone_message:
+              description: Message shown to the shopper during checkout when their order does not meet the merchant's shipping criteria.
+              type: string
+              example: Unfortunately, one or more items in your cart can't be shipped to your location. Please choose a different delivery address.
+    channelShippingSettings:
+      type: object
+      properties:
+        checkout:
+          type: object
+          properties:
+            out_of_delivery_zone_message:
               description: Message shown to the shopper during checkout when their order does not meet the merchant's shipping criteria.
               type: string
               example: Unfortunately, one or more items in your cart can't be shipped to your location. Please choose a different delivery address.


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [SHIPPING-3329]

## What changed?
* Providing documentation for `v3/shipping/settings/{channel_id}` endpoint.
* Updating property name for `out_of_zone_delivery_message` in `v3/shipping/settings` endpoint to `out_of_delivery_zone_message`
* Added missing http error responses

## References:
[Out of delivery zone message property update](https://github.com/bigcommerce/bigcommerce/pull/61705)
[Channel based settings endpoint](https://github.com/bigcommerce/bigcommerce/pull/61225)
[Published route in api-proxy](https://github.com/bigcommerce/api-proxy-java/pull/3348)

## Anything else?
[SHIPPING-3449 Update name of out of delivery zone message property](https://bigcommercecloud.atlassian.net/browse/SHIPPING-3449)
[SHIPPING-3336 Create an v1/internalapi endpoint for channel based out of delivery message](https://bigcommercecloud.atlassian.net/browse/SHIPPING-3336)
[SHIPPING-3337 Expose the endpoint which handles channel based out of delivery message](https://bigcommercecloud.atlassian.net/browse/SHIPPING-3337)

## Screenshot
Channel based settings endpoint
<img width="953" alt="Screenshot 2025-02-24 at 11 55 36 am" src="https://github.com/user-attachments/assets/f1665af5-e0e2-4eea-b478-7a68186bbc6c" />

Settings endpoint (property name update)
<img width="956" alt="Screenshot 2025-02-24 at 11 56 34 am" src="https://github.com/user-attachments/assets/90314ad8-3c69-4b89-91ed-8d38914362c4" />

ping @bigcommerce/team-shipping @bigcommerce/dev-docs 


[SHIPPING-3329]: https://bigcommercecloud.atlassian.net/browse/SHIPPING-3329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ