### PR TITLE
docs(checkout): CHECKOUT-8921 Change graphql storefront document to reflect the change of JWT payment token with checkout payment context

### DIFF
--- a/docs/storefront/cart-checkout/guide/graphql-storefront.mdx
+++ b/docs/storefront/cart-checkout/guide/graphql-storefront.mdx
@@ -44,7 +44,7 @@ To handle payments, use the [Payments API (Overview)](/docs/store-operations/pay
 
 For PCI compliance-related reasons, the GraphQL Storefront API does not handle payments. You can use the [Payments API (Reference)](/docs/rest-payments) to process payments. 
 
-The GraphQL Storefront API returns the checkout ID and order ID, which you can use to [Get accepted payment methods](/docs/rest-payments/methods#get-accepted-payment-methods) and [Create a payment access token](/docs/rest-payments/tokens#create-payment-access-token). You can also generate a payment access token using the GraphQL Storefront [completeCheckout](#complete-checkout) mutation.
+The GraphQL Storefront API returns the checkout ID and order ID, which you can use to [Get accepted payment methods](/docs/rest-payments/methods#get-accepted-payment-methods) and [Create a payment access token](/docs/rest-payments/tokens#create-payment-access-token). You can also generate a payment JWT token (with the `checkout` payment context) using the GraphQL Storefront [completeCheckout](#complete-checkout) mutation.
 
 The GraphQL Storefront API returns the customer ID, which you can use to [Get stored payment instruments](/docs/rest-management/customers/customer-stored-instruments#get-stored-instruments). To learn more about authenticating REST endpoints, locate the **Authentication** section at the top of each endpoint, then click **Show Details**.
 
@@ -1154,7 +1154,7 @@ The current platform limit is 250 metafields for a single cart. When you create 
           "checkout": {
             "completeCheckout": {
               "orderEntityId": 106,
-              "paymentAccessToken": "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2ODU3MjQwMzQsIm5iZiI6MTY4NTcyMDQzNCwiaXNzIjoicGF5bWVudHMuYmlnY29tbWVyY2UuY29tIiwic3ViIjoidmpid3FiYWJwMSIsImp0aSI6IjAzODU3ODk2LTdkY2YtNDIzNi04OTQ5LWU0MjcyYWU3ZGZjMSIsImlhdCI6MTY4NTcyMDQzNCwiZGF0YSI6eyJzdG9yZV9pZCI6IjEwMDI4ODA3NDYiLCJvcmRlcl9pZCI6IjEwNiIsImFtb3VudCI6MjUwMCwiY3VycmVuY3kiOiJVU0QifX0.iiJ96cYKtk2-oLRXvZHs1lWUl9v8JkEkCdHShbyfEK4"
+              "paymentAccessToken": "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEyMywiZW1haWwiOiJleGFtcGxlQGVtYWlsLmNvbSIsImlhdCI6MTcwODg1NzIwMCwiZXhwIjoxNzA4ODU5MDAwfQ._d2ZZMtkQFPhd4Gje22D8vTep7YXmA9z_o3F9Nv8LJc"
             }
           }
         }


### PR DESCRIPTION
# [CHECKOUT-8921](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-8921)


## What changed?
changed the documentation to explain the completeCheckout mutation will return a payment JWT token (for the storefront flow).

## Release notes draft

* `completeCheckout` mutation no longer returns access token with server payment context, instead it will return a payment JWT token with `checkout` payment context that can be used in the storefront flow. 

## Anything else?

ping @bigcommerce/team-checkout 


[CHECKOUT-8921]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-8921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ