### PR TITLE
CATALOG-10610: Add custom_url field to POST v3 product 409 error

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -597,7 +597,7 @@ paths:
 
         '409':
           description: |
-            `Product` was in conflict with another product. This is the result of duplicate unique values, such as name or SKU; a missing or invalid `category_id`, `brand_id`, or `tax_class id`; or a conflicting `bulk_pricing_rule`.
+            `Product` conflicted with another product. This is the result of duplicate unique values, such as name or SKU; a missing or invalid `category_id`, `brand_id`, or `tax_class id`; or a conflicting `bulk_pricing_rule` or `custom_url`.
           content:
             application/json:
               schema:


### PR DESCRIPTION
# [CATALOG-10610]


## What changed?
* Add custom_url field to POST v3 product 409 error

## Release notes draft
* Endpoint `POST v3/catalog/products` now failed product creation when `custom_url` is not unique with 409 error code.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @bigcommerce/team-catalog 

[CATALOG-10610]: https://bigcommercecloud.atlassian.net/browse/CATALOG-10610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ