### PR TITLE
LOCAL-2692: fix GraphQL Admin API link in Locales Configuration section

### DIFF
--- a/docs/store-operations/settings/locales.mdx
+++ b/docs/store-operations/settings/locales.mdx
@@ -18,7 +18,7 @@ With the GraphQL Admin API, merchants can add, update, or remove locales for eac
 This section provides examples of GraphQL Admin API queries and mutations that demonstrate how to manage locales, along with the required HTTP configuration.
 
 ```http filename="GraphQL Admin API HTTP configuration" showLineNumbers copy
-POST https://api.bigcommerce.com/accounts/{{store_hash}}/graphql
+POST https://api.bigcommerce.com/stores/{{store_hash}}/graphql
 X-Auth-Token: {{access_token}}
 Accept: application/json
 Content-Type: application/json


### PR DESCRIPTION
[LOCAL-2692](https://bigcommercecloud.atlassian.net/browse/LOCAL-2692)

## What changed?
Fix GraphQL Admin API link in Locales Configuration section

## Release notes draft
Fix GraphQL Admin API link in Locales Configuration section

## Anything else?

ping @bc-traciporter 


[LOCAL-2692]: https://bigcommercecloud.atlassian.net/browse/LOCAL-2692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ