### PR TITLE
Update references to Auth docs

### DIFF
--- a/docs/b2b-edition/authentication/hosted-auth.mdx
+++ b/docs/b2b-edition/authentication/hosted-auth.mdx
@@ -6,7 +6,7 @@ B2B Edition has four APIs that let you manage data, log in customers, make clien
 
 B2B Edition's REST Management APIs require you to create and pass a token along with the request using the `authToken` header.
 
-For the REST Management V3 API, create an auth token using the [Create a server-to-server token](/b2b-edition/apis/rest-management/auth#get-server-to-server-tokens) endpoint.
+For the REST Management V3 API, create an auth token using the [Create a server-to-server token](/b2b-edition/apis/rest-management/authentication#get-server-to-server-tokens) endpoint.
 
 For the REST Management V2 API, request an auth token by contacting support.
 
@@ -22,9 +22,9 @@ https://{yourstore.example.com}/customer/current.jwt?app_client_id=dl7c39mdpul6h
 
 If your request is successful, BigCommerce returns a current customer [JSON web token (JWT)](https://jwt.io/). Retain the token.
 
-After you receive the current customer JWT, make a request to the B2B Edition [Get a storefront OpenAPI authtoken](/b2b-edition/apis/rest-management/auth#get-a-storefront-api-authtoken) endpoint. Use the current customer JWT as the value of the `jwtToken` query parameter.
+After you receive the current customer JWT, make a request to the B2B Edition [Get a storefront OpenAPI authtoken](/b2b-edition/apis/rest-management/authentication#get-a-storefront-api-authtoken) endpoint. Use the current customer JWT as the value of the `jwtToken` query parameter.
 
-A successful request to the [Get a storefront OpenAPI authtoken](/b2b-edition/apis/rest-management/auth#get-a-storefront-api-authtoken) endpoint returns a B2B Edition REST Storefront API token, which you can pass as a value of the `authToken` header in requests to the B2B Edition REST Storefront API.
+A successful request to the [Get a storefront OpenAPI authtoken](/b2b-edition/apis/rest-management/authentication#get-a-storefront-api-authtoken) endpoint returns a B2B Edition REST Storefront API token, which you can pass as a value of the `authToken` header in requests to the B2B Edition REST Storefront API.
 
 ```curl filename="Example token request (CURL)" copy
 curl https://api-b2b.bigcommerce.com/api/io/auth/storefront?jwtToken=bigCommerce.currentCustomerResponse.jwtString
@@ -50,9 +50,9 @@ async function() {
 
 ## REST Management V3 API
 
-To get a REST Management API auth token, use the [Get server to server OpenAPI tokens](/b2b-edition/apis/rest-management/auth#get-server-to-server-tokens) endpoint. Send the store's `storeHash` and the email and password you use to sign in to the B2B Edition app in the store control panel. The response returns tokens you can use as the value of the authToken header in requests to the B2B Edition REST Management V3 API.
+To get a REST Management API auth token, use the [Get server to server OpenAPI tokens](/b2b-edition/apis/rest-management/authentication#get-server-to-server-tokens) endpoint. Send the store's `storeHash` and the email and password you use to sign in to the B2B Edition app in the store control panel. The response returns tokens you can use as the value of the authToken header in requests to the B2B Edition REST Management V3 API.
 
-For details, see the [Get server to server OpenAPI tokens](/b2b-edition/apis/rest-management/auth#get-server-to-server-tokens) endpoint reference.
+For details, see the [Get server to server OpenAPI tokens](/b2b-edition/apis/rest-management/authentication#get-server-to-server-tokens) endpoint reference.
 
 ```js http
 async function() {

--- a/docs/b2b-edition/authentication/hosted-auth.mdx
+++ b/docs/b2b-edition/authentication/hosted-auth.mdx
@@ -50,7 +50,7 @@ async function() {
 
 ## REST Management V3 API
 
-To get a REST Management API auth token, use the [Get server to server OpenAPI tokens](/b2b-edition/apis/rest-management/authentication#get-server-to-server-tokens) endpoint. Send the store's `storeHash` and the email and password you use to sign in to the B2B Edition app in the store control panel. The response returns tokens you can use as the value of the authToken header in requests to the B2B Edition REST Management V3 API.
+To get a REST Management API auth token, use the [Get server to server OpenAPI tokens](/b2b-edition/apis/rest-management/authentication#get-server-to-server-tokens) endpoint. Send the store's `storeHash` and the email and password you use to sign in to B2B Edition in the store control panel. The response returns tokens you can use as the value of the authToken header in requests to the B2B Edition REST Management V3 API.
 
 For details, see the [Get server to server OpenAPI tokens](/b2b-edition/apis/rest-management/authentication#get-server-to-server-tokens) endpoint reference.
 

--- a/docs/b2b-edition/specs/api-v3/authentication.yaml
+++ b/docs/b2b-edition/specs/api-v3/authentication.yaml
@@ -1,6 +1,6 @@
 openapi: '3.0.0'
 info:
-  title: Auth
+  title: Authentication
   version: '3.0'
   description: API auth manage
   contact:
@@ -10,7 +10,7 @@ info:
 servers:
   - url: 'https://api-b2b.bigcommerce.com/api/io'
 tags:
-  - name: Auth
+  - name: Authentication
     description: ''
 paths:
   /auth/backend:
@@ -19,7 +19,7 @@ paths:
       summary: Get Server to Server Tokens
       operationId: post-auth-backend
       tags:
-        - Auth
+        - Authentication
       responses:
         '200':
           description: OK
@@ -242,12 +242,12 @@ paths:
               required:
                 - id
       tags:
-        - Auth
+        - Authentication
   /backend/tokens:
     get:
       summary: Get All Server to Server Tokens
       tags:
-        - Auth
+        - Authentication
       responses:
         '200':
           description: OK
@@ -348,7 +348,7 @@ paths:
     get:
       summary: Get a Storefront API authToken
       tags:
-        - Auth
+        - Authentication
       responses:
         '200':
           description: OK
@@ -543,7 +543,7 @@ paths:
         description: ''
       description: BigCommerce customer gets an authentication token
       tags:
-        - Auth
+        - Authentication
       security: []
     parameters: []
   /auth/customers/storefront:
@@ -615,7 +615,7 @@ paths:
                     value: sometoken
                     expires_at: 2024-12-31T00:00:00.0Z
       tags:
-        - Auth
+        - Authentication
 components:
   schemas: {}
   securitySchemes:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6221]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* The navigation items for Authentication pages now read "Authentication" instead of "Auth"
* Links to Authentication pages are updated to reflect the change
* Authentication endpoints now live on the root page for their family (e.g. Storefront Authentication)

## Release notes draft
* Navigation items and links related to B2B Edition authentication have been updated to be more readable and user friendly.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6221]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ