### PR TITLE
DEVDOCS-6301 - Remove Blueprint features

### DIFF
--- a/docs/storefront/stencil/themes/templates/checkout-confirmation.mdx
+++ b/docs/storefront/stencil/themes/templates/checkout-confirmation.mdx
@@ -157,39 +157,6 @@ As an example of injecting an app from the BigCommerce App Marketplace, you coul
 <!-- end olark code -->
 ```
 
-### Bluecheck Age Verification
-
-Similarly, you could enable the Bluecheck age-verification app by using the script manager or our new Scripts API:
-
-```html showLineNumbers copy
-<!-- Bluecheck AV Start Here -->
-<script src="https://api.bluecheck.me/modal/latest/custom/bigcommerce.js"></script>
-<script src='//api.bluecheck.me/age-gate/v2/loader.js.php?domain_token=[user-token-value]'></script>
-<span style='display:none' id='bc_selected_shipping_info'>%%GLOBAL_ShippingAddress%%</span>
-<span style='display:none' id='bc_selected_billing_info'>%%GLOBAL_BillingAddress%%</span>
-<span style='display:none' id='bc_customer_acct_email'>%%GLOBAL_CurrentCustomerEmail%%</span>
-<span style='display:none' id='bc_customer_acct_id'>%%GLOBAL_CurrentCustomerID%%</span>
-<span style='display:none' id='bc_customer_acct_fname'>%%GLOBAL_CurrentCustomerFirstName%%</span>
-<span style='display:none' id='bc_customer_acct_lname'>%%GLOBAL_CurrentCustomerLastName%%</span>
-<!-- Bluecheck AV End Here -->
-```
-
-### Rebillia Recurring Billing
-
-To add the Rebillia app, you could add the following tags by using the script manager or our new Scripts API:
-
-```html showLineNumbers copy
-<div id='rebillia_overlay'></div>
-
-<script src="https://js.braintreegateway.com/v2/braintree.js"></script>
-
-<script type="text/javascript" src="https://js.stripe.com/v2/"></script>
-
-<script type="text/javascript">
-function customerJWT(a){var b="r1sc6nvnnhed377cozp2bfwfa69cfz5",c=new XMLHttpRequest;c.onreadystatechange=function(){if(4==c.readyState)if(200==c.status){var b=new XMLHttpRequest;b.open("GET","https://demo.rebillia.com/storefront/login/"+c.responseText,!0),b.withCredentials=!0,b.send()}else if(404==c.status){var d=new XMLHttpRequest;params="bc_email="+a,d.open("POST","https://demo.rebillia.com/storefront/login/guest",!0),d.setRequestHeader("Content-type","application/x-www-form-urlencoded"),d.withCredentials=!0,d.send(params)}else console.log("Something went wrong")},c.open("GET","/customer/current.jwt?app_client_id="+b,!0),c.send()}var currentcustomeremail="%%GLOBAL_CurrentCustomerEmail%%",shopPath="%%GLOBAL_ShopPathSSL%%",domainName="https://demo.rebillia.com",domainURL="https://demo.rebillia.com/";$(document).ready(function(){$.getScript(domainName+"/js/embed-common.js");var a=window.location.href.match(/[^\/]+$/);if(a&&a.length){var b=a[0].split(".");"account"!=b[0]&&"checkout"!=b[0]&&"finishorder"!=b[0]||$.getScript(domainName+"/js/embed-"+b[0]+".js"),"account"==b[0]&&customerJWT()}});
-</script>
-```
-
 ### Conversion Tracking: Conversions on Demand
 
 Here is one final example of an app that you could enable by using the script manager or our new Scripts API. This example enables Conversions on Demand:


### PR DESCRIPTION
Blueprint references were IDd in this doc, and they have been removed.

<!-- Ticket number or summary of work -->
# [DEVDOCS-6301]

## What changed?
* References to Blueprint are no longer useful, and the apps referenced are now deprecated, so references are being removed.

## Release notes draft
* We've removed references to Blueprint under Bluecheck and Rebilia apps.
* The apps were deprecated, so we've removed the full sections.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[DEVDOCS-6301]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ