### PR TITLE
DEVDOCS-6212:[Update]B2B Refresh - Non-Catalyst Channel Setup

### DIFF
--- a/docs/b2b-edition/headless.mdx
+++ b/docs/b2b-edition/headless.mdx
@@ -1,10 +1,16 @@
-# Creating Channels
+# Channel Setup for Non-Catalyst Frameworks 
+
+B2B Edition's Buyer Portal can be used with headless storefronts created using a third-party solution, such as WordPress or Next.js. This allows you to extend B2B Edition's front-end buyer tools to multiple headless storefronts, while managing your back-end processes from the BigCommerce control panel.
+
+ <Callout type="info">
+  Use the following instructions to enable B2B Edition on non-Catalyst headless frameworks. See [B2B Edition](https://www.catalyst.dev/docs/b2b) for Catalyst-specific considerations.
+ </Callout>
 
 <Steps>
 
 ### Prepare
 
-You will need to create two API tokens for your BigCommerce store. They have different permissions required, so please pay attention to which one is used for the step you are working on. Refer to this [support article](https://support.bigcommerce.com/s/article/Store-API-Accounts?language=en_US#:~:text=Level%20API%20Accounts-,1.,to%20use%20the%20API%20account) for more information on how to create API Accounts.
+You will need to create two API tokens for your BigCommerce store. They have different permissions required, so please pay attention to which one is used for the step you are working on. Refer to this [support article](https://support.bigcommerce.com/s/article/Store-API-Accounts) for more information on how to create API Accounts.
 
 * Create a token (TOKEN_A) with modify permissions for the following resources:
   - Channel listings
@@ -64,7 +70,7 @@ X-Auth-Token: {{TOKEN_B}}
 
 ### Create a site for the channel
 
-[Create the site for the channel](/docs/rest-management/sites#create-a-site), you should use TOKEN_A.
+[Create the site for the channel](/docs/rest-management/sites#create-a-site), using TOKEN_A.
 
 ```http filename="Example request: Create an impersonation token" showLineNumbers copy
 POST https://api.bigcommerce.com/stores/{store_hash}/v3/sites
@@ -92,7 +98,9 @@ Add the following script tag on your application.
 ```
 ### Enable headless channel on the B2B dashboard
 
-In the B2B dashboard, go to **Storefronts** > **Headless Storefronts** and select **Activate B2B** for the storefront channel.
+In the B2B Edition control panel, go to **Storefronts** > **Headless Storefronts** and select **Activate B2B** for the storefront channel.
+
+![Activating B2B on a headless storefront](https://storage.googleapis.com/bigcommerce-production-dev-center/images/B2B%20Edition/Channel-Setup-for-non-Catalyst-Frameworks/enable-b2b-headless.png)
 
 ### Make products available on your new channel
 

--- a/docs/b2b-edition/headless.mdx
+++ b/docs/b2b-edition/headless.mdx
@@ -2,7 +2,7 @@
 
 B2B Edition's Buyer Portal can be used with headless storefronts created using a third-party solution, such as WordPress or Next.js. This allows you to extend B2B Edition's front-end buyer tools to multiple headless storefronts, while managing your back-end processes from the BigCommerce control panel.
 
-Follow the instructions in this article to set up a headless storefront channel that uses the default, hosted version of the Buyer Portal. If you want to deploy a locally-developed custom Buyer Portal to your headless channel, see the [Headless Guide](https://github.com/bigcommerce/b2b-buyer-portal/blob/main/docs/headless.md) in the b2b-buyer-portal repository. 
+Follow the instructions in this article to set up a headless storefront channel that uses the default, hosted version of the Buyer Portal. If you want to deploy a locally-developed custom Buyer Portal to your headless channel, see the [Headless Guide](https://github.com/bigcommerce/b2b-buyer-portal/blob/main/docs/headless.md) in the `b2b-buyer-portal` repository. 
 
  <Callout type="info">
   These instructions are for enabling B2B Edition on non-Catalyst headless frameworks. See [B2B Edition](https://www.catalyst.dev/docs/b2b) for Catalyst-specific considerations.

--- a/docs/b2b-edition/headless.mdx
+++ b/docs/b2b-edition/headless.mdx
@@ -2,8 +2,10 @@
 
 B2B Edition's Buyer Portal can be used with headless storefronts created using a third-party solution, such as WordPress or Next.js. This allows you to extend B2B Edition's front-end buyer tools to multiple headless storefronts, while managing your back-end processes from the BigCommerce control panel.
 
+Follow the instructions in this article to set up a headless storefront channel that uses the default, hosted version of the Buyer Portal. If you want to deploy a locally-developed custom Buyer Portal to your headless channel, see the [Headless Guide](https://github.com/bigcommerce/b2b-buyer-portal/blob/main/docs/headless.md) in the b2b-buyer-portal repository. 
+
  <Callout type="info">
-  Use the following instructions to enable B2B Edition on non-Catalyst headless frameworks. See [B2B Edition](https://www.catalyst.dev/docs/b2b) for Catalyst-specific considerations.
+  These instructions are for enabling B2B Edition on non-Catalyst headless frameworks. See [B2B Edition](https://www.catalyst.dev/docs/b2b) for Catalyst-specific considerations.
  </Callout>
 
 <Steps>
@@ -47,10 +49,6 @@ X-Auth-Token: {{TOKEN_A}}
     "is_visible": true
 }
 ```
-
- <Callout type="info">
-  Currently we’re working with [Vercel template, and that uses NextJS](https://github.com/B3BC/b2b-headless-example).
- </Callout>
 
  ### Generate an impersonation token
 


### PR DESCRIPTION
# [DEVDOCS-6212](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6212)


## What changed?

* Article title reflects that steps are for non-Catalyst frameworks
* Link to API Accounts article in Step 1 uses standard URL instead of directing to specific text 
* Includes an introduction with a callout to Catalyst's B2B-specific documentation
* Step 6 now has an accompanying screenshot of the Headless Storefronts area of the B2B Edition control panel

## Release notes draft

* The article now reflects that it is geared toward non-Catalyst frameworks, and provides a link to Catalyst-specific instructions for integration.

## Anything else?

ping @bc-terra 


[DEVDOCS-6212]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ