### PR TITLE
DEVDOCS-6266 - Price Validation for Storefront Quote Creation

### DIFF
--- a/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
@@ -627,7 +627,10 @@ paths:
                 - isBackendUser
       description: |-
         Create a quote form.
+
         Equivalent Storefront GraphQL API Mutation: `quoteCreate`. For more information, see the [GraphQL Playground](https://api-b2b.bigcommerce.com/graphql/playground).
+
+        **Note:** By default, quotes created with this endpoint undergo a price validation check to prevent invalid prices on quotes. If the check fails, a `BigCommerce API Error` will be raised and logged, preventing quote creation.
       tags:
         - RFQ
   '/rfq/{quote_id}':

--- a/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
@@ -630,7 +630,7 @@ paths:
 
         Equivalent Storefront GraphQL API Mutation: `quoteCreate`. For more information, see the [GraphQL Playground](https://api-b2b.bigcommerce.com/graphql/playground).
 
-        **Note:** By default, quotes created with this endpoint undergo a price validation check to prevent invalid prices on quotes. If the check fails, a `BigCommerce API Error` will be raised and logged, preventing quote creation.
+        **Note:** By default, quotes created with this endpoint undergo a price validation check to prevent invalid prices on quotes. If the check fails, a `BigCommerce API Error` will be raised and logged, preventing quote creation. Quotes with custom pricing should be created with [Create a Quote Form (Server-to-Server)](/b2b-edition/apis/rest-management/quote#create-a-quote-form)
       tags:
         - RFQ
   '/rfq/{quote_id}':

--- a/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
@@ -630,7 +630,7 @@ paths:
 
         Equivalent Storefront GraphQL API Mutation: `quoteCreate`. For more information, see the [GraphQL Playground](https://api-b2b.bigcommerce.com/graphql/playground).
 
-        **Note:** By default, quotes created with this endpoint undergo a price validation check to prevent invalid prices on quotes. If the check fails, a `BigCommerce API Error` will be raised and logged, preventing quote creation. Quotes with custom pricing should be created with [Create a Quote Form (Server-to-Server)](/b2b-edition/apis/rest-management/quote#create-a-quote-form)
+        **Note:** Quotes created with this endpoint undergo a price validation check to prevent invalid prices. If the check fails, a `BigCommerce API Error` will be raised and logged, preventing quote creation. To create quotes with custom pricing, use [Create a Quote Form (Server-to-Server)](/b2b-edition/apis/rest-management/quote#create-a-quote-form).
       tags:
         - RFQ
   '/rfq/{quote_id}':


### PR DESCRIPTION
Callout added for storefront quote creation pricing validation.

<!-- Ticket number or summary of work -->
# [DEVDOCS-6266]


## What changed?
* Price validation occurs for all "storefront quote creation" API calls.
* Failing validation, an error is raised and logged.

## Release notes draft
* We've added pricing validation to storefront quote creation.
* The validation check prevents invalid prices from being passed from the storefront.
* Custom prices are still allowed in the server-to-server endpoint.

## Anything else?

ping {names}


[DEVDOCS-6266]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ