### PR TITLE
DEVDOCS-6315 - Account Hierarchies enabled by default

### DIFF
--- a/docs/b2b-edition/specs/api-v3/company/company.yaml
+++ b/docs/b2b-edition/specs/api-v3/company/company.yaml
@@ -38,7 +38,7 @@ info:
     
     ![Graphic explainer for company account hierarchies](https://storage.googleapis.com/bigcommerce-production-dev-center/images/account-hierarchies-examples.png)
 
-    **NOTE:** This functionality is enabled by default on all new B2B Edition stores. It is also available upon request for existing stores using the Buyer Portal experience and Independent Companies behavior. You can request Account Hierarchy by contacting our support team.
+    **NOTE:** This functionality comes enabled by default on all new B2B Edition stores. It is also available upon request for existing stores using the Buyer Portal experience and Independent Companies behavior. You can request Account Hierarchy by contacting our support team.
 
     Account Hierarchy adds support for the following endpoints:
 

--- a/docs/b2b-edition/specs/api-v3/company/company.yaml
+++ b/docs/b2b-edition/specs/api-v3/company/company.yaml
@@ -38,7 +38,7 @@ info:
     
     ![Graphic explainer for company account hierarchies](https://storage.googleapis.com/bigcommerce-production-dev-center/images/account-hierarchies-examples.png)
 
-    **NOTE:** This functionality is available upon request for stores using the Buyer Portal experience and Independent Companies behavior. You can request Account Hierarchy by contacting our support team.
+    **NOTE:** This functionality is enabled by default on all new B2B Edition stores. It is also available upon request for existing stores using the Buyer Portal experience and Independent Companies behavior. You can request Account Hierarchy by contacting our support team.
 
     Account Hierarchy adds support for the following endpoints:
 


### PR DESCRIPTION
Moving forward, account hierarchies feature is enabled by default for new stores. Updated note about availability to reflect this.

<!-- Ticket number or summary of work -->
# [DEVDOCS-6315]


## What changed?
* Account Hierarchies feature is enabled by default on all new B2B Edition stores.
* The feature may be requested, provided prerequisites are met.

## Release notes draft
* All new B2B Edition stores will have Account Hierarchies available.

## Anything else?

ping {names}


[DEVDOCS-6315]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ