### PR TITLE
DEVDOCS-6309 - update complex rule schema

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -2401,15 +2401,6 @@ paths:
               title: Complex Rule
               type: object
               properties:
-                product_id:
-                  type: integer
-                  description: |
-                    The unique numeric ID of the product with which the rule is associated; increments sequentially.
-                  nullable: true
-                  example: 67
-                  x-required:
-                    - post
-                    - put
                 sort_order:
                   maximum: 2147483647
                   minimum: -2147483648
@@ -2895,15 +2886,6 @@ paths:
               title: Complex Rule
               type: object
               properties:
-                product_id:
-                  type: integer
-                  description: |
-                    The unique numeric ID of the product with which the rule is associated; increments sequentially.
-                  nullable: true
-                  example: 67
-                  x-required:
-                    - post
-                    - put
                 sort_order:
                   maximum: 2147483647
                   minimum: -2147483648


### PR DESCRIPTION
Removed product ID from complex rule schema.
Confirmed adjusters have correct schema.

<!-- Ticket number or summary of work -->
# [DEVDOCS-6309]


## What changed?
* Complex rules PUT/POST bodies no longer have product_id as its presence confuses usage.

## Release notes draft
* We've removed the reference to product_id from the Complex Rules PUT/POST bodies to prevent confusion over usage.
    * Including product_id in the body overrides the parameter, which can result in applying or updating rules where they should not be.
    * The parameter is required, so the body occurrence is removed.

## Anything else?

ping { @megdesko  }


[DEVDOCS-6309]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ