### PR TITLE
doc(orders): ORDERS-6930 update Refund API docs to include `tax_adjustment_amount`

### DIFF
--- a/reference/orders.v3.yml
+++ b/reference/orders.v3.yml
@@ -2295,17 +2295,12 @@ components:
         $ref: '#/components/schemas/RefundQuote_Post'
       x-internal: false
     RefundQuote_Post:
-      type: object
       title: RefundQuote_Post
       description: Request body for refund quotes.
       x-internal: false
-      properties:
-        items:
-          type: array
-          items:
-            $ref: '#/components/schemas/ItemsRefund'
-      required:
-        - items
+      anyOf:
+        - $ref: '#/components/schemas/RefundQuote_ItemsRefund'
+        - $ref: '#/components/schemas/RefundQuote_TaxAdjustmentAmount'
     RefundQuote_Full:
       type: object
       title: RefundQuote_Full
@@ -2391,10 +2386,15 @@ components:
           items:
             $ref: '#/components/schemas/RefundMethod'
     RefundRequest_Post:
-      type: object
       description: Request body for refund requests.
       title: RefundRequest_Post
       x-internal: false
+      anyOf:
+          - $ref: '#/components/schemas/RefundRequest_Post_Items'
+          - $ref: '#/components/schemas/RefundRequest_Post_TaxAdjustmentAmount'
+    RefundRequest_Post_Items:
+      title: Items Refund
+      type: object
       properties:
         items:
           type: array
@@ -2409,6 +2409,16 @@ components:
       required:
         - items
         - payments
+    RefundRequest_Post_TaxAdjustmentAmount:
+      title: Tax Adjustment Refund
+      type: object
+      properties:
+        tax_adjustment_amount:
+          $ref: '#/components/schemas/TaxAdjustmentAmount'
+        merchant_calculated_override:
+          $ref: '#/components/schemas/MerchantOverride'
+      required:
+        - tax_adjustment_amount
     RefundID_Get:
       type: object
       x-examples:
@@ -2504,6 +2514,7 @@ components:
                     description: |
                       Message indicates why the payment was declined.
             items:
+              description: Array of items refunded. In cases when `tax_refund_adjustment` was used to create the refund, this array will be empty.
               type: array
               items:
                 type: object
@@ -2760,6 +2771,37 @@ components:
         - total_amount
         - total_tax
       x-internal: false
+    TaxAdjustmentAmount:
+      type: number
+      format: float
+      title: Tax Adjustment Amount
+      example: 1.99
+      description: Amount to be used when tax may have been overcharged for an order, such as when the value for a partial refund is overridden. This amount should be equal to the calculated overcharged value, or should be used with `merchant_calculated_override` to override the value. If not, this will result in a `422` error.
+      x-internal: false
+    RefundQuote_ItemsRefund:
+      title: Items Refund
+      type: object
+      x-internal: false
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ItemsRefund'
+        merchant_calculated_override:
+          $ref: '#/components/schemas/MerchantOverride'
+      required:
+        - items
+    RefundQuote_TaxAdjustmentAmount:
+      title: Tax Adjustment Refund
+      type: object
+      x-internal: false
+      properties:
+        tax_adjustment_amount:
+          $ref: '#/components/schemas/TaxAdjustmentAmount'
+        merchant_calculated_override:
+          $ref: '#/components/schemas/MerchantOverride'
+      required:
+        - tax_adjustment_amount
     Refund:
       type: object
       title: Refund
@@ -2793,8 +2835,7 @@ components:
           description: Whether refund amount and tax are provided explicitly by merchant override.
         items:
           type: array
-          description: Array of items refunded.
-          minItems: 1
+          description: Array of items refunded. In cases when `tax_refund_adjustment` was used to create the refund, this array will be empty.
           items:
             $ref: '#/components/schemas/RefundItem'
         payments:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [ORDERS-6930]
Update `orders.v3.yml` to include a previously undocumented field `tax_adjustment_amount` for refunds and refund quotes

## What changed?
<!-- Provide a bulleted list in the present tense -->
* Add new option including `tax_adjustment_amount` for POST request body for `/orders/{order_id}/payment_actions/refunds_quotes`, mutually exclusive with the existing `items` payload.
* Add new option including `tax_adjustment_amount` for POST request body for `/orders/{order_id}/payment_actions/refunds`, mutually exclusive with the existing `items` payload.
* Extend description of `items` in the GET/POST response body for `/orders/{order_id}/payment_actions/refunds` to indicate that the `items` array will be empty if `tax_adjustment_amount` was used to create the refund.

![image](https://github.com/user-attachments/assets/dab939dd-10a2-4bac-9541-17c1d4d0029e)

![image](https://github.com/user-attachments/assets/81e4277d-5318-41ad-b506-5ddcdd9a5b27)

![image](https://github.com/user-attachments/assets/f08c192a-c027-495e-98b6-f81bb43c657f)


## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @bigcommerce/team-orders


[ORDERS-6930]: https://bigcommercecloud.atlassian.net/browse/ORDERS-6930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ