### PR TITLE
Fix customers/{customerId}/metafields GET responses

### DIFF
--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -1717,7 +1717,19 @@ paths:
         - $ref: '#/components/parameters/customerId'
       responses:
         '200':
-          $ref: '#/components/responses/MetafieldCollectionResponse'
+          description: Response payload for the BigCommerce API.
+          content:
+            application/json:
+              schema:
+                title: Meta Field Collection Response
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/metafield_Full'
+                  meta:
+                    $ref: '#/components/schemas/metaCollection_Full'
     post:
       summary: Create Customer Metafields
       tags:
@@ -1780,7 +1792,7 @@ paths:
     get:
       summary: Get a Customer Metafield
       description: |
-        Lists available metafields for a customer. To retrieve the list, use `customerId` and `metafieldId` in the query parameters.
+        Returns a single *Customer Metafield*.
       operationId: getMetafieldsCustomerId
       tags:
         - Metafields
@@ -1799,7 +1811,17 @@ paths:
             type: integer
       responses:
         '200':
-          $ref: '#/components/responses/MetafieldCollectionResponse'
+          description: ''
+          content:
+            application/json:
+              schema:
+                title: Metafield Response
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/metafield_Full'
+                  meta:
+                    $ref: '#/components/schemas/metaEmpty_Full'
         '404':
           description: |
             Not found (A metafield was not found with this query).
@@ -3122,105 +3144,6 @@ components:
                     name: What is your favorite pizza topping?
                     value: Mushrooms
                 meta: {}
-    MetafieldCollectionResponse:
-      description: Response payload for the BigCommerce API.
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              items:
-                type: object
-                properties:
-                  id: 
-                    type: integer
-                    description: Unique ID of the *Metafield*. Read-Only.
-                    readOnly: true
-                    example: 0
-                  key:
-                    type: string
-                    description: The key for the metafields.
-                    example: Staff Name
-                  value:
-                    type: string
-                    description: The description for the metafield.
-                    example: Ronaldo
-                  namespace:
-                    type: string
-                    description: |
-                      Namespace for the metafield, for organizational purposes.
-                    example: Sales Department
-                    minLength: 1
-                    maxLength: 64
-                  permission_set:
-                    type: string
-                    description: |
-                      Determines the visibility and writeability of the field by other API consumers.
-                      | Value | Description |
-                      | :--- | :--- |
-                      | `app_only` | Private to the app that owns the field. |
-                      | `read` | Visible to other API consumers. |
-                      | `write` | Open for reading and writing by other API consumers. |
-                      | `read_and_sf_access` | Visible to other API consumers, including on storefront. |
-                      | `write_and_sf_access` | Open for reading and writing by other API consumers, including on storefront. |
-                    enum:
-                      - app_only
-                      - read
-                      - write
-                      - read_and_sf_access
-                      - write_and_sf_access
-                  resource_type:
-                    type: string
-                    description: |
-                      The type of resource with which the metafield is associated.
-                    enum:
-                      - brand
-                      - product
-                      - variant
-                      - category
-                      - cart
-                      - channel
-                      - location
-                      - order
-                      - customer
-                    example: cart 
-                  resource_id:
-                    type: integer
-                    description: |
-                      The unique identifier for the resource with which the metafield is associated.
-                    example: 0
-                    readOnly: true
-                  description: 
-                    type: string
-                    description: |
-                      Description for the metafields.
-                    example: order
-                  date_created:
-                    type: string
-                    format: date-time
-                    description: Date and time of the metafieldʼs creation.
-                    example: '2022-06-16T18:39:00+00:00'
-                  date_modified:
-                    type: string
-                    format: date-time
-                    description: Date and time when the metafield was last updated.
-                    example: '2022-06-16T18:39:00+00:00'
-                  owner_client_id:
-                    type: string
-                    description: Client ID for the metafield's creator.
-                    readOnly: true
-                    example: ramciw4fnoz87it3ynjfif2zrkil5p
-                required:
-                  - namespace
-                  - key
-                  - value
-                  - permission_set
-                  - resource_type
-                  - resource_id
-                  - description
-                  - id
-                  - date_created
-                  - date_modified       
     consent_Resp:
       description: ''
       content:
@@ -4729,6 +4652,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Metafield'
+        meta:
+          $ref: '#/components/schemas/CollectionMeta'
       x-internal: false
     MetaFieldCollectionPostPutResponses:
       type: object


### PR DESCRIPTION
## What changed?
<!-- Provide a bulleted list in the present tense -->
* Delete incorrect `responses/MetafieldCollectionResponse` component
* Add correct `200` response for GET /v3/customers/{customerId}/metafields
* Add correct `200` response for GET /v3/customers/{customerId}/metafields/{metafieldId}

## Release notes draft
* Fixed API documentation for GET /v3/customers/{customerId}/metafields and GET /v3/customers/{customerId}/metafields/{metafieldId} responses

## Anything else?
Fixes https://github.com/bigcommerce/docs/issues/912
