### PR TITLE
DEVDOCS-6358 - Add custom field object information to Update an Invoice

### DIFF
--- a/docs/b2b-edition/specs/api-v3/invoice-management.yaml
+++ b/docs/b2b-edition/specs/api-v3/invoice-management.yaml
@@ -594,7 +594,9 @@ paths:
                             code: USA
                             value: string
                           description: string
-                          customFields: {}
+                          customFields:
+                            "key": string
+                            "value": string
                           unitDiscount:
                             code: string
                             value: string
@@ -818,6 +820,18 @@ paths:
                                     type: string
                                     description: Product description or product name. This field is required for custom product.
                                     minLength: 1
+                                  customFields:
+                                    type: object
+                                    description: Adds custom information to the product. 
+                                    properties:
+                                      key:
+                                        type: string
+                                        description: The custom field name.
+                                        example: Back-ordered
+                                      value:
+                                        type: string
+                                        description: The custom field value.
+                                        example: 'No'
                                   unitDiscount:
                                     type: object
                                     properties:
@@ -899,6 +913,9 @@ paths:
                             code: USD
                             value: "200.0000"
                           description: "[Sample] Canvas Laundry Cart"
+                          customFields:
+                            key: 'Back-ordered'
+                            value: 'No'
                   openBalance:
                     code: USD
                     value: "12.0000"


### PR DESCRIPTION
The customField object is available in the the request body of the Update an Invoice endpoint. A description of the object and its component fields, as well as examples, have been added to the endpoint's information.


# [DEVDOCS-6358](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6358)


## What changed?

* Added customField object and component fields to the list of fields in the request body of Update an Invoice
* Added customField object and component fields to the example request

## Release notes draft

* Added usage information and examples for the customField object in Update an Invoice

## Anything else?

ping @bc-terra 


[DEVDOCS-6358]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ