### PR TITLE
doc(catalog): CATALOG-11250 Handle url parameter absence in GET a category tree request documentation

### DIFF
--- a/reference/catalog/category-trees_catalog.v3.yml
+++ b/reference/catalog/category-trees_catalog.v3.yml
@@ -429,6 +429,7 @@ paths:
                     is_visible: true
                     children:
                       - string
+                    url: "/bath/"
                 meta:
                   type: object
                   properties: {}
@@ -831,6 +832,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CategoryNode'
+        url:
+          type: string
+          minLength: 1
+          maxLength: 255
+          example: '/bath/'
       x-tags:
         - Models
     MetaPaginationObject:

--- a/reference/catalog/category-trees_catalog.v3.yml
+++ b/reference/catalog/category-trees_catalog.v3.yml
@@ -836,7 +836,6 @@ components:
           type: string
           minLength: 1
           maxLength: 255
-          example: '/bath/'
       x-tags:
         - Models
     MetaPaginationObject:


### PR DESCRIPTION
# [CATALOG-11250]

## What changed?
Handle url parameter absence in GET a category tree request documentation

## Release notes draft
* Added missed url parameter in GET a category tree request documentation


## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[CATALOG-11250]: https://bigcommercecloud.atlassian.net/browse/CATALOG-11250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ