### PR TITLE
DEVDOCS-6366 - create reusable response models

### DIFF
--- a/docs/b2b-edition/models/response/code-array-message.yaml
+++ b/docs/b2b-edition/models/response/code-array-message.yaml
@@ -1,4 +1,4 @@
-title: response-with-object-and-message
+title: response-with-array-and-message
 description: "Response body for the request."
 type: object
 properties:

--- a/docs/b2b-edition/models/response/code-array-message.yaml
+++ b/docs/b2b-edition/models/response/code-array-message.yaml
@@ -1,0 +1,13 @@
+title: response-with-object-and-message
+description: "Response body for the request."
+type: object
+properties:
+  code:
+    type: integer
+    description: "HTTP response code for the request."
+  message:
+    type: string
+    description: "Message indicating the status of the request."
+  data:
+    type: array
+    description: "Data array associated with the response."

--- a/docs/b2b-edition/models/response/code-array-meta.yaml
+++ b/docs/b2b-edition/models/response/code-array-meta.yaml
@@ -1,0 +1,17 @@
+title: response-with-array-and-metadata
+description: "Response body for a request."
+type: object
+properties:
+  code:
+    type: integer
+    description: "HTTP response code for the request."
+  meta:
+    type: object
+    description: "Metadata associated with the response."
+    properties:
+      message:
+        type: string
+        description: "Message indicating the status of the request."
+  data:
+    type: array
+    description: "Data array associated with the response."

--- a/docs/b2b-edition/models/response/code-message.yaml
+++ b/docs/b2b-edition/models/response/code-message.yaml
@@ -1,0 +1,10 @@
+title: response-with-object-and-message
+description: "Response body for the request."
+type: object
+properties:
+  code:
+    type: integer
+    description: "HTTP response code for the request."
+  message:
+    type: string
+    description: "Message indicating the status of the request."

--- a/docs/b2b-edition/models/response/code-message.yaml
+++ b/docs/b2b-edition/models/response/code-message.yaml
@@ -1,4 +1,4 @@
-title: response-with-object-and-message
+title: response-with-message
 description: "Response body for the request."
 type: object
 properties:

--- a/docs/b2b-edition/models/response/code-meta.yaml
+++ b/docs/b2b-edition/models/response/code-meta.yaml
@@ -1,0 +1,14 @@
+title: response-with-metadata
+description: "Response body for a request."
+type: object
+properties:
+  code:
+    type: integer
+    description: "HTTP response code for the request."
+  meta:
+    type: object
+    description: "Metadata associated with the response."
+    properties:
+      message:
+        type: string
+        description: "Message indicating the status of the request."

--- a/docs/b2b-edition/models/response/code-object-message.yaml
+++ b/docs/b2b-edition/models/response/code-object-message.yaml
@@ -1,0 +1,13 @@
+title: response-with-object-and-message
+description: "Response body for the request."
+type: object
+properties:
+  code:
+    type: integer
+    description: "HTTP response code for the request."
+  message:
+    type: string
+    description: "Message indicating the status of the request."
+  data:
+    type: object
+    description: "Data associated with the response."

--- a/docs/b2b-edition/models/response/code-object-meta.yaml
+++ b/docs/b2b-edition/models/response/code-object-meta.yaml
@@ -1,0 +1,17 @@
+title: response-with-object-and-metadata
+description: "Response body for a request."
+type: object
+properties:
+  code:
+    type: integer
+    description: "HTTP response code for the request."
+  meta:
+    type: object
+    description: "Metadata associated with the response."
+    properties:
+      message:
+        type: string
+        description: "Message indicating the status of the request."
+  data:
+    type: object
+    description: "Data associated with the response."


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6366]

## What changed?
<!-- Provide a bulleted list in the present tense -->
* Responses in B2B generally follow one of 7 formats, which currently have to be re-typed in every document. By creating models of six of these formats, we can save a measure of effort across all B2B specs. Example usage of the models follows:
```yaml
'200':
  description: OK
  content:
    application/json:
      schema:
        allOf:
          - $ref: "https://raw.githubusercontent.com/bigcommerce/docs/main/docs/b2b-edition/models/response/code-object-meta.yaml"
          - properties:
              code:
                default: 200
              meta:
                properties:
                  message:
                    default: "SUCCESS"
              data:
                properties:
                  userId:
                    type: integer
                    description: "The unique ID for the user."
```
While it may not seem like this is more efficient, the equivalent structure would require four extra lines typed repeatedly across all docs. It's a small saving, but it's still cleaner than repeating the same code for every single response.

## Release notes draft
* Added new models to improve efficiency of B2B content project.

## Anything else?

ping { @bc-Vince } for review (it should be pretty straightforward).


[DEVDOCS-6366]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ