### PR TITLE
docs(tax): TAX-1750 add type field to tax properties API docs

### DIFF
--- a/reference/tax_properties.v3.yml
+++ b/reference/tax_properties.v3.yml
@@ -327,6 +327,13 @@ components:
           format: date-time
           example: 2022-07-21T19:33:57+00:00
           readOnly: true
+        type:
+          type: string
+          description: The type of entity that the tax property can be associated with.
+          enum:
+            - PRODUCT
+            - CUSTOMER
+          example: PRODUCT
     PropertyPOST:
       type: object
       properties:
@@ -347,6 +354,15 @@ components:
             This string will be displayed on the Products screen as a tooltip
             associated with the relevant field.
           example: Food Industry
+        type:
+          type: string
+          description: The type of entity that the tax property can be associated with.
+            Default
+          enum:
+            - PRODUCT
+            - CUSTOMER
+          default: PRODUCT
+          example: PRODUCT
       required:
         - code
         - display_name


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [TAX-1750](https://bigcommercecloud.atlassian.net/browse/TAX-1750)

## What changed?
<!-- Provide a bulleted list in the present tense -->
* Adding a new `type` field to dictate whether property is associated to `PRODUCT` or `CUSTOMER`
* Currently, field is optional and has a default value of `PRODUCT`

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.
* We're adding a new optional `type` field to tax properties, allowing you to specify whether a property is associated with a product or a customer. If not set, it will default to `PRODUCT`.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->
* The new `/tax/customers` endpoint (for configuring customers with said properties) will be documented on a seperate page, in a seperate PR.

ping @bigcommerce/team-tax 


[TAX-1750]: https://bigcommercecloud.atlassian.net/browse/TAX-1750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ