### PR TITLE
feat(tax): TAX-1749 Include new tax_properties field for customer object within Tax Provider API requests

### DIFF
--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -69,6 +69,7 @@ paths:
                     customer_id: '0'
                     customer_group_id: '0'
                     taxability_code: ''
+                    tax_properties: []
                   transaction_date: '2019-08-13T03:17:37+00:00'
                   documents:
                     - id: 5d522b889d3d9
@@ -364,6 +365,7 @@ paths:
                     customer_id: '0'
                     customer_group_id: '0'
                     taxability_code: ''
+                    tax_properties: []
                   transaction_date: '2019-08-13T03:40:15+00:00'
                   documents:
                     - id: shipping_14
@@ -1050,6 +1052,11 @@ components:
             taxability_code:
               type: string
               description: 'If applicable, the tax exemption code of the shopper’s customer account. A taxability code is intended to apply to multiple customers. This code should match the exemption codes provided by the third-party integration.'
+            tax_properties:
+              type: array
+              description: 'Any tax property values that have been associated with this customer.'
+              items:
+                $ref: '#/components/schemas/request-item-tax-property'
         transaction_date:
           type: string
           format: date-time


### PR DESCRIPTION
# [TAX-1749]

## What changed?
* Add new `tax_properties` field to the `customer` object, within Tax Provider API requests.

## Release notes draft
* Customer tax properties now available in Tax Provider API requests. Note: requires tax properties to be configured via the Tax Properties API, as well as setting property values via the Tax Customer API.

[TAX-1749]: https://bigcommercecloud.atlassian.net/browse/TAX-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ