### PR TITLE
Adjust customer tax properties example

### DIFF
--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -69,7 +69,9 @@ paths:
                     customer_id: '0'
                     customer_group_id: '0'
                     taxability_code: ''
-                    tax_properties: []
+                    tax_properties:
+                      - code: 'property123'
+                        value: 'property-value'
                   transaction_date: '2019-08-13T03:17:37+00:00'
                   documents:
                     - id: 5d522b889d3d9
@@ -365,7 +367,9 @@ paths:
                     customer_id: '0'
                     customer_group_id: '0'
                     taxability_code: ''
-                    tax_properties: []
+                    tax_properties:
+                      - code: 'property123'
+                        value: 'property-value'
                   transaction_date: '2019-08-13T03:40:15+00:00'
                   documents:
                     - id: shipping_14


### PR DESCRIPTION
# [TAX-1749]

## What changed?
* Adjust customer tax properties example.

Driving change is the online parsing engine did not appreciate the empty array in this context. So, instead, we're using an actual example - which is more descriptive and hence helpful anyway.

## Release notes draft
N/A

[TAX-1749]: https://bigcommercecloud.atlassian.net/browse/TAX-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ