### PR TITLE
DEVDOCS-6369 - Update - Clarify Price List related webhooks

### DIFF
--- a/reference/price_lists.v3.yml
+++ b/reference/price_lists.v3.yml
@@ -39,15 +39,13 @@ info:
     - Bulk pricing Tiers can additionally be associated with a price record to indicate different pricing as the quantity in the cart increases.
     - If a variant has a Price Record, any existing product-level bulk pricing will not apply to the cart. For variants without Price Records, any existing product bulk pricing will apply.
     - [Price Lists Records](/docs/rest-management/price-lists/price-lists-records) accepts bulk upsert. You can only do one bulk upsert at a time. Running more than one bulk upsert in parallel on the **same store** will cause a `429` error and the request will fail.
-    - There are webhooks available for Price Lists assignments. The price list assignment webhook fires when a price list assignment is assigned, reassigned, or unassigned. Note that since Price Lists directly relate to products, neither product nor SKU webhooks are going to fire for corresponding changes, such as pricing.
+    - There are webhooks available for Price Lists assignments. The price list assignment webhook fires when a price list assignment is assigned, reassigned, or unassigned. Note that since Price Lists **do not** directly relate to products, neither product nor SKU webhooks are going to fire for corresponding changes, such as pricing.
 
     ## Additional information
 
     ### Webhooks
     
     * [Price list assignments](/docs/integrations/webhooks/events/channels#price-list-assignments)
-    * [Products](/docs/integrations/webhooks/events#products)
-    * [SKU](/docs/integrations/webhooks/events#sku)
     ### Related endpoints
     * [Get All Price Lists](/docs/rest-management/price-lists#get-all-price-lists)
   termsOfService: 'https://www.bigcommerce.com/terms'


### PR DESCRIPTION
Products and SKU webhooks are not fired when Price List record is changed. Corrected Usage Notes and deleted links to hooks.

<!-- Ticket number or summary of work -->
# [DEVDOCS-6369]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Products and SKU webhooks are not fired when Price List record is changed. 
* Usage notes incorrectly states that Price Lists directly relates to products.
* Products and SKU webhooks are linked under Additional Information.

## Release notes draft
* Updated Usage Notes to clarify that Price Lists are not directly related to Products. 
* Removed links to Products and SKU webhooks from Additional Information to help avoid confusion.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @bc-terra 


[DEVDOCS-6369]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ