### PR TITLE
Mark Tax Properties API field as required, remove default

### DIFF
--- a/reference/tax_properties.v3.yml
+++ b/reference/tax_properties.v3.yml
@@ -366,6 +366,7 @@ components:
       required:
         - code
         - display_name
+        - type
     PropertyPUT:
       type: object
       properties:

--- a/reference/tax_properties.v3.yml
+++ b/reference/tax_properties.v3.yml
@@ -361,7 +361,6 @@ components:
           enum:
             - PRODUCT
             - CUSTOMER
-          default: PRODUCT
           example: PRODUCT
       required:
         - code


### PR DESCRIPTION
# [TAX-1744]

## What changed?
* Mark Tax Properties API field as required.
* Remove default.

Aligns with future, intended state. This field is currently available and will soon be required.

## Release notes draft
* Tax Properties API now requires the type field (may be CUSTOMER or PRODUCT type).

[TAX-1744]: https://bigcommercecloud.atlassian.net/browse/TAX-1744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ