### PR TITLE
DEVDOCS-6352 - Update - Page links should follow RFC 3986 standards

### DIFF
--- a/reference/pages.v3.yml
+++ b/reference/pages.v3.yml
@@ -29,7 +29,7 @@ info:
     | `raw` | A user-defined page that contains HTML markup or other stringified code. | HTML, other code |
     | `blog` | A page that contains blog posts. Use caution; `blog`-type pages can only be created in the store control panel, but you may be able to change the type of a blog page to something else with this API. Use the [blog feature of the REST Content API](/docs/rest-content/store-content/blog-posts#create-a-blog-post) to work with blog posts and tags. | empty string |
     | `feed` | Makes RSS-syndicated content feeds available in the menu of other pages that contain markup. | &mdash; |
-    | `link` | A link to an external absolute URL. Displays in the menu of other pages that contain markup. | &mdash; |
+    | `link` | A link to an external absolute URL that follows [RFC 3986 standards](https://www.rfc-editor.org/rfc/rfc3986). Displays in the menu of other pages that contain markup. | &mdash; |
 servers:
   - url: 'https://api.bigcommerce.com/stores/{store_hash}/v3'
     variables:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# DEVDOCS-6352


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Link row in the Page Types table should contain a reference to RFC 3986 standards.

## Release notes draft
* Added link to RFC standards under "link" in Page Types table. 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @bc-terra 
