### PR TITLE
Add tax properties API links to related fields

### DIFF
--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -939,7 +939,7 @@ components:
           default: false
         tax_properties:
           type: array
-          description: Merchants may opt to include additional properties that a tax provider can choose to support, factoring these values into tax calculation.
+          description: Merchants may opt to include additional properties that a tax provider can choose to support, factoring these values into tax calculation. See [Tax Properties API](/docs/rest-management/tax-properties) for more information on configuring tax properties.
           items:
             $ref: '#/components/schemas/request-item-tax-property'
       required:
@@ -1058,7 +1058,7 @@ components:
               description: 'If applicable, the tax exemption code of the shopper’s customer account. A taxability code is intended to apply to multiple customers. This code should match the exemption codes provided by the third-party integration.'
             tax_properties:
               type: array
-              description: 'Any tax property values that have been associated with this customer.'
+              description: Any tax property values that have been associated with this customer. See [Tax Properties API](/docs/rest-management/tax-properties) for more information on configuring tax properties.
               items:
                 $ref: '#/components/schemas/request-item-tax-property'
         transaction_date:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [TAX-100]

With some nearby work, I noted a lack of links to our Tax Properties API documentation. Would be helpful to further guide users as to what the concept is speaking to.

## What changed?
* Add links to Tax Properties API for related fields within Tax Provider API documentation.

## Release notes draft
* Tax Properties API links added to Tax Provider API documentation.


[TAX-100]: https://bigcommercecloud.atlassian.net/browse/TAX-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ