### PR TITLE
Remove x-internal from tax documentation

### DIFF
--- a/reference/tax.v3.yml
+++ b/reference/tax.v3.yml
@@ -223,4 +223,3 @@ components:
                     type: string
                   description: The list of subdivision codes where the tax provider connection is active. ISO 3166-2.
                   example: ['AU-NSW', 'US-OH']
-      x-internal: false

--- a/reference/tax_classes.v2.yml
+++ b/reference/tax_classes.v2.yml
@@ -158,7 +158,6 @@ components:
         name: Shipping
         created_at: 1973-01-20T21:34:57.903+00:00
         updated_at: 1990-12-30T00:29:23.515+00:00
-      x-internal: false
   securitySchemes:
     X-Auth-Token:
       name: X-Auth-Token

--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -898,7 +898,6 @@ components:
       type: object
       description: An **ItemRequest** represents required information relating to completing tax calculations for a specific line item.
       title: ItemRequest
-      x-internal: false
       properties:
         id:
           type: string
@@ -962,7 +961,6 @@ components:
       required:
         - code
         - value
-      x-internal: false
     request-document:
       type: object
       description: 'Each **DocumentRequest** represents an order or part of an order of items fulfilled from a single origin address to a single destination address. In addition to shipping and billing details, a document request includes the collection of items in the shipment, with tax-relevant information for each item. Multi-address orders, in which items ship to or from multiple addresses, require at least one **DocumentRequest** per combination of sender-recipient addresses. These are similar to "consignments" or "shipments" in other BigCommerce APIs.'
@@ -1027,7 +1025,6 @@ components:
         - shipping
         - handling
         - items
-      x-internal: false
     request-quote:
       type: object
       description: 'Each **QuoteRequest** represents an order. In addition to transaction details, it contains a `documents` array of one or more **DocumentRequest** objects, which represent distinct combinations of origin and fulfillment addresses and the tax-relevant contents of those consignments. This is similar to an "order" in other BigCommerce APIs.'
@@ -1076,7 +1073,6 @@ components:
         - customer
         - transaction_date
         - documents
-      x-internal: false
     request-adjust:
       description: An **AdjustRequest** contains the same data as a standard **QuoteRequest** with added detail of the adjustment operation.
       allOf:
@@ -1087,7 +1083,6 @@ components:
               description: 'Specifies the reason for the adjustment operation, for auditing purposes. May be a custom, user-entered description.'
         - $ref: '#/components/schemas/request-quote'
       title: AdjustRequest
-      x-internal: false
     Address:
       type: object
       description: 'Requests may have partial Address data. For example, the BigCommerce Cart page has the "Estimate Shipping & Tax" feature which is only expected to supply Country, Region and Postal Code.'
@@ -1131,7 +1126,6 @@ components:
           enum:
             - RESIDENTIAL
             - COMMERCIAL
-      x-internal: false
     TaxClass:
       type: object
       properties:
@@ -1148,7 +1142,6 @@ components:
         - code
         - class_id
         - name
-      x-internal: false
     response-quote:
       type: object
       properties:
@@ -1164,7 +1157,6 @@ components:
         - id
         - documents
       title: Quote
-      x-internal: false
     response-document:
       type: object
       title: Document
@@ -1223,7 +1215,6 @@ components:
         - items
         - shipping
         - handling
-      x-internal: false
     response-item:
       type: object
       description: |-
@@ -1240,7 +1231,6 @@ components:
       required:
         - id
         - price
-      x-internal: false
     response-taxprice:
       type: object
       properties:
@@ -1269,7 +1259,6 @@ components:
         - tax_rate
         - sales_tax_summary
       title: TaxPrice
-      x-internal: false
     SalesTax:
       type: object
       properties:
@@ -1300,7 +1289,6 @@ components:
         - name
         - rate
         - amount
-      x-internal: false
     item_type:
       type: string
       description: |-


### PR DESCRIPTION
# [TAX-100]

We were previously advised that `x-internal` is no longer used. So, to stop any further copy pasting, removing it.

## What changed?
* Removed all `x-internal` items from tax documentation.

## Release notes draft
N/A

[TAX-100]: https://bigcommercecloud.atlassian.net/browse/TAX-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ