### PR TITLE
Add explicit detail about tax quote transaction date interaction

### DIFF
--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -1064,7 +1064,7 @@ components:
         transaction_date:
           type: string
           format: date-time
-          description: ISO 8601 formatted date the shopper placed this order. Dates will be provided in UTC.
+          description: ISO 8601 formatted date the shopper placed this order. Tax quotes are expected to reflect taxes applicable on this date. Dates will be provided in UTC.
         documents:
           type: array
           description: 'One or more consignments containing items being purchased by the shopper, including shipping and handling fees that are charged for each consignment. Most orders will contain a single consignment (to a single shipping address), however the BigCommerce platform also supports "Multi-address orders" which allow shoppers to place a single order with items shipped to different addresses.'


### PR DESCRIPTION
# [TAX-100]

Hearing from a case where the merchant sounds like they are misunderstanding some related behaviour, prompting a small clarification to this field description.

## What changed?
* Adding explicit note about how the request `transaction_date` is intended to feed into the tax provider's response.

## Release notes draft
* Clarify Tax Provider API `transaction_date` field usage.

[TAX-100]: https://bigcommercecloud.atlassian.net/browse/TAX-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ