### PR TITLE
DEVDOCS-6336 - Include header-based example

### DIFF
--- a/docs/storefront/graphql/multi-language-support.mdx
+++ b/docs/storefront/graphql/multi-language-support.mdx
@@ -29,7 +29,7 @@ The response includes the following:
 
 ## Example
 
-<Tabs items={['Request', 'Response']}>
+<Tabs items={['Request with Directive', 'Request with Header', 'Response']}>
   <Tab>
 
 ```graphql filename="Get products information for a locale" showLineNumbers copy
@@ -39,6 +39,40 @@ Accept: application/json
 Content-Type: application/json
 
 query @shopperPreferences(locale:"fr") { # specific requested locale via directive
+  shopperPreferences {
+    locale {
+      resolved # resolved locale
+    }
+  }
+  site {
+    settings {
+      locales { # list of enabled locales
+        code
+        isDefault
+      }
+    }
+    products {
+      edges {
+        node {
+          name # localized name
+        }
+      }
+    }
+  }
+}
+```
+
+</Tab>
+<Tab>
+
+```graphql filename="Get products information for a locale" showLineNumbers copy
+POST https://your_store.example.com/graphql
+Authorization: Bearer {token}
+Accept: application/json
+Content-Type: application/json
+Accept-Language: "fr"
+ 
+query {
   shopperPreferences {
     locale {
       resolved # resolved locale

--- a/docs/storefront/graphql/multi-language-support.mdx
+++ b/docs/storefront/graphql/multi-language-support.mdx
@@ -145,4 +145,4 @@ query {
 ## Resources 
 
 - [International Enhancements for Multi-Storefront](/docs/store-operations/catalog/msf-international-enhancements/overview) overview
-- [International Enhancements for Multi-Storefront - Localization Settings](https://support.bigcommerce.com/s/article/International-Enhancements-for-Multi-Storefront#localization) support article
+- [International Enhancements for Multi-Storefront - Localization Settings](https://support.bigcommerce.com/s/article/International-Enhancements-for-Multi-Storefront) support article


### PR DESCRIPTION
Added header-based example to request as new tab

<!-- Ticket number or summary of work -->
# [DEVDOCS-6336]


## What changed?
* The documentation states that locales may be pulled either by a query directive or by a header. The examples now include both methods.

## Release notes draft
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping { @CNanninga @bigcommerce/dev-docs-team }


[DEVDOCS-6336]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ