### PR TITLE
DEVDOCS-6373 - Add flag to responses

### DIFF
--- a/reference/checkouts.v3.yml
+++ b/reference/checkouts.v3.yml
@@ -8213,6 +8213,9 @@ components:
                   type: string
                   description: 'ISO-4217 currency code. (See: https://www.iso.org/iso-4217-currency-codes.html.)'
                   example: USD
+            tax_included:
+              type: boolean
+              description: 'Indicates whether product prices are shown inclusive of sales tax.'
             base_amount:
               type: number
               description: 'Sum of cart line-item amounts before cart-level discounts, coupons, or taxes are applied.'


### PR DESCRIPTION
Responses including checkout data should have the field `tax_included`. Added to the Checkout schema.

<!-- Ticket number or summary of work -->
# [DEVDOCS-6373]


## What changed?
* Documentation now includes reference to the `tax_included` field.

## Release notes draft
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping { @bigcommerce/dev-docs-team }


[DEVDOCS-6373]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ