### PR TITLE
chore(orders): ORDERS-6254 make the quantity bound item first so the …

### DIFF
--- a/reference/orders.v3.yml
+++ b/reference/orders.v3.yml
@@ -2576,8 +2576,8 @@ components:
       title: ItemsRefund
       x-internal: false
       oneOf:
-        - $ref: '#/components/schemas/AmountBoundItem'
         - $ref: '#/components/schemas/QuantityBoundItem'
+        - $ref: '#/components/schemas/AmountBoundItem'
         - $ref: '#/components/schemas/TaxExemptItem'
         - $ref: '#/components/schemas/FeeItem'
     PaymentRequest:


### PR DESCRIPTION
…refund adjustment feature is more visible and easier to find

<!-- Ticket number or summary of work -->
# [DEVDOCS-]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Just swap the ordering of different refund item type and put QuantityBoundItem first because that contains refund adjustment feature

Right now, the `adjustment` field is not very visible on the doc because `Amount bound item` is shown by default, only upon click on the `Quantity bound item` it shows the `adjustments` field.  It may cause friction when users searching for the field 

![Screenshot 2025-05-14 at 10 48 44 am](https://github.com/user-attachments/assets/e3367b11-5d5a-4631-b722-b441dc25ac63)


This simple change makes the `QuantityBoundItem` the first default so `adjustments` feature is more visible/searchable.


## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

No release notes required

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @bigcommerce/team-orders @bigcommerce/dev-docs 
