### PR TITLE
DEVDOCS-6376 - add customer_id field

### DIFF
--- a/reference/pricing.sf.yml
+++ b/reference/pricing.sf.yml
@@ -45,7 +45,6 @@ paths:
               required:
                 - channel_id
                 - currency_code
-                - customer_group_id
                 - items
               type: object
               properties:
@@ -65,6 +64,9 @@ paths:
                 customer_group_id:
                   type: integer
                   description: The customer group ID that's relevant for any customer group pricing, tax values, etc.
+                customer_id:
+                  type: integer
+                  description: The ID of the customer for whom to fetch pricing.
                 items:
                   type: array
                   description: The items for which to fetch prices.

--- a/reference/pricing.sf.yml
+++ b/reference/pricing.sf.yml
@@ -66,7 +66,8 @@ paths:
                   description: The customer group ID that's relevant for any customer group pricing, tax values, etc.
                 customer_id:
                   type: integer
-                  description: The ID of the customer for whom to fetch pricing.
+                  description: The ID of the customer for whom to fetch prices.
+
                 items:
                   type: array
                   description: The items for which to fetch prices.

--- a/reference/pricing.sf.yml
+++ b/reference/pricing.sf.yml
@@ -67,7 +67,6 @@ paths:
                 customer_id:
                   type: integer
                   description: The ID of the customer for whom to fetch prices.
-
                 items:
                   type: array
                   description: The items for which to fetch prices.


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6376]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Pricing now supports requests with `customer_id` and not just `customer_group_id`

## Release notes draft
* Added the `customer_id` field to the request body.
* Updated the list of required fields.

## Anything else?

ping { @megdesko @bc-Vince @bigcommerce/dev-docs-team }


[DEVDOCS-6376]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ