### PR TITLE
DEVDOCS-6375 - New GraphQL response headers

### DIFF
--- a/docs/start/about/index.mdx
+++ b/docs/start/about/index.mdx
@@ -196,7 +196,7 @@ HTTP response header names are case-insensitive; see the [HTTP specification on 
 | `X-Bc-Graphql-Complexity` | integer | Shows the complexity of the response content. If this exceeds `10000`, an error is returned. | `5241` |
 | `x-bc-graphql-query-hash` | A `sha256` hash | A hash of the query body, not including variables. This allows identification of specific queries among those with non-unique names. | `bd2e22a00004abd3ec9437a6f895` |
 | `x-bc-graphql-variables-hash` | A `sha256` hash | A hash of the variables included in a query. | `44136fa355b3678a1146ad16f7e8` |
-| `x-bc-gql-operation-type` | One of `query`, `mutation`, or `subscription` | The operation type of the request. Currently, `subscription` is not supported. | `query` |
+| `x-bc-graphql-operation-type` | One of `query`, `mutation`, or `subscription` | The operation type of the request. Currently, `subscription` is not supported. | `query` |
 | `x-bc-gql-operation-name` | string | The response name. This will return an empty string for anonymous requests. | `HomePageQuery` |
 
 #### Response content type

--- a/docs/start/about/index.mdx
+++ b/docs/start/about/index.mdx
@@ -189,6 +189,16 @@ HTTP response header names are case-insensitive; see the [HTTP specification on 
 
 {/* | `X-Request-ID` |  |  |  | */}
 
+#### GraphQL-specific response headers
+
+| Header | Possible Values | Description | Example |
+|:-------|:----------------|:------------|:--------|
+| `X-Bc-Graphql-Complexity` | integer | Shows the complexity of the response content. If this exceeds `10000`, an error is returned. | `5241` |
+| `x-bc-gql-query-hash` | string | A hash of the query body, not including variables. This allows identification of specific queries among those with non-unique names. | `bd2e22a00004abd3ec9437a6f895` |
+| `x-bc-graphql-variables-hash` | string | A hash of the variables included in a query. | `44136fa355b3678a1146ad16f7e8` |
+| `x-bc-gql-operation-type` | One of `query`, `mutation`, or `subscription` | The operation type of the request. Currently, `subscription` is not supported. | `query` |
+| `x-bc-gql-operation-name` | string | The response name. This will return an empty string for anonymous requests. | `HomePageQuery` |
+
 #### Response content type
 
 When requesting a resource that returns a body, specify the type of content you want to receive with the `Accept` header. Alternatively, you can supply an extension to the resource you're requesting.

--- a/docs/start/about/index.mdx
+++ b/docs/start/about/index.mdx
@@ -194,7 +194,7 @@ HTTP response header names are case-insensitive; see the [HTTP specification on 
 | Header | Possible Values | Description | Example |
 |:-------|:----------------|:------------|:--------|
 | `X-Bc-Graphql-Complexity` | integer | Shows the complexity of the response content. If this exceeds `10000`, an error is returned. | `5241` |
-| `x-bc-gql-query-hash` | A `sha256` hash | A hash of the query body, not including variables. This allows identification of specific queries among those with non-unique names. | `bd2e22a00004abd3ec9437a6f895` |
+| `x-bc-graphql-query-hash` | A `sha256` hash | A hash of the query body, not including variables. This allows identification of specific queries among those with non-unique names. | `bd2e22a00004abd3ec9437a6f895` |
 | `x-bc-graphql-variables-hash` | A `sha256` hash | A hash of the variables included in a query. | `44136fa355b3678a1146ad16f7e8` |
 | `x-bc-gql-operation-type` | One of `query`, `mutation`, or `subscription` | The operation type of the request. Currently, `subscription` is not supported. | `query` |
 | `x-bc-gql-operation-name` | string | The response name. This will return an empty string for anonymous requests. | `HomePageQuery` |

--- a/docs/start/about/index.mdx
+++ b/docs/start/about/index.mdx
@@ -195,7 +195,7 @@ HTTP response header names are case-insensitive; see the [HTTP specification on 
 |:-------|:----------------|:------------|:--------|
 | `X-Bc-Graphql-Complexity` | integer | Shows the complexity of the response content. If this exceeds `10000`, an error is returned. | `5241` |
 | `x-bc-gql-query-hash` | A `sha256` hash | A hash of the query body, not including variables. This allows identification of specific queries among those with non-unique names. | `bd2e22a00004abd3ec9437a6f895` |
-| `x-bc-graphql-variables-hash` | string | A hash of the variables included in a query. | `44136fa355b3678a1146ad16f7e8` |
+| `x-bc-graphql-variables-hash` | A `sha256` hash | A hash of the variables included in a query. | `44136fa355b3678a1146ad16f7e8` |
 | `x-bc-gql-operation-type` | One of `query`, `mutation`, or `subscription` | The operation type of the request. Currently, `subscription` is not supported. | `query` |
 | `x-bc-gql-operation-name` | string | The response name. This will return an empty string for anonymous requests. | `HomePageQuery` |
 

--- a/docs/start/about/index.mdx
+++ b/docs/start/about/index.mdx
@@ -194,10 +194,10 @@ HTTP response header names are case-insensitive; see the [HTTP specification on 
 | Header | Possible Values | Description | Example |
 |:-------|:----------------|:------------|:--------|
 | `x-bc-graphql-complexity` | integer | Indicates the computed complexity score of the executed GraphQL query. If this exceeds `10000`, an error is returned. | `5241` |
-| `x-bc-graphql-query-hash` | A `sha256` hash | A hash of the query body, not including variables. This allows identification of specific queries among those with non-unique names. | `bd2e22a00004abd3ec9437a6f895` |
-| `x-bc-graphql-variables-hash` | A `sha256` hash | A hash of the variables included in a query. | `44136fa355b3678a1146ad16f7e8` |
+| `x-bc-graphql-query-hash` | string | A 'sha256' hash of the query body, not including variables. This allows identification of specific queries among those with non-unique names. | `bd2e22a00004abd3ec9437a6f895` |
+| `x-bc-graphql-variables-hash` | string | A `sha256` hash of the variables included in a query. | `44136fa355b3678a1146ad16f7e8` |
 | `x-bc-graphql-operation-type` | One of `query`, `mutation`, or `subscription` | The operation type of the request. Currently, `subscription` is not supported. | `query` |
-| `x-bc-graphql-operation-name` | string | The response name. This will return an empty string for anonymous requests. | `HomePageQuery` |
+| `x-bc-graphql-operation-name` | string |The operation name within a query. Used with queries with multiple operations. This will return an empty string for anonymous requests. | `HomePageQuery` |
 
 #### Response content type
 

--- a/docs/start/about/index.mdx
+++ b/docs/start/about/index.mdx
@@ -194,7 +194,7 @@ HTTP response header names are case-insensitive; see the [HTTP specification on 
 | Header | Possible Values | Description | Example |
 |:-------|:----------------|:------------|:--------|
 | `X-Bc-Graphql-Complexity` | integer | Shows the complexity of the response content. If this exceeds `10000`, an error is returned. | `5241` |
-| `x-bc-gql-query-hash` | string | A hash of the query body, not including variables. This allows identification of specific queries among those with non-unique names. | `bd2e22a00004abd3ec9437a6f895` |
+| `x-bc-gql-query-hash` | A `sha256` hash | A hash of the query body, not including variables. This allows identification of specific queries among those with non-unique names. | `bd2e22a00004abd3ec9437a6f895` |
 | `x-bc-graphql-variables-hash` | string | A hash of the variables included in a query. | `44136fa355b3678a1146ad16f7e8` |
 | `x-bc-gql-operation-type` | One of `query`, `mutation`, or `subscription` | The operation type of the request. Currently, `subscription` is not supported. | `query` |
 | `x-bc-gql-operation-name` | string | The response name. This will return an empty string for anonymous requests. | `HomePageQuery` |

--- a/docs/start/about/index.mdx
+++ b/docs/start/about/index.mdx
@@ -197,7 +197,7 @@ HTTP response header names are case-insensitive; see the [HTTP specification on 
 | `x-bc-graphql-query-hash` | A `sha256` hash | A hash of the query body, not including variables. This allows identification of specific queries among those with non-unique names. | `bd2e22a00004abd3ec9437a6f895` |
 | `x-bc-graphql-variables-hash` | A `sha256` hash | A hash of the variables included in a query. | `44136fa355b3678a1146ad16f7e8` |
 | `x-bc-graphql-operation-type` | One of `query`, `mutation`, or `subscription` | The operation type of the request. Currently, `subscription` is not supported. | `query` |
-| `x-bc-gql-operation-name` | string | The response name. This will return an empty string for anonymous requests. | `HomePageQuery` |
+| `x-bc-graphql-operation-name` | string | The response name. This will return an empty string for anonymous requests. | `HomePageQuery` |
 
 #### Response content type
 

--- a/docs/start/about/index.mdx
+++ b/docs/start/about/index.mdx
@@ -193,7 +193,7 @@ HTTP response header names are case-insensitive; see the [HTTP specification on 
 
 | Header | Possible Values | Description | Example |
 |:-------|:----------------|:------------|:--------|
-| `X-Bc-Graphql-Complexity` | integer | Shows the complexity of the response content. If this exceeds `10000`, an error is returned. | `5241` |
+| `x-bc-graphql-complexity` | integer | Indicates the computed complexity score of the executed GraphQL query. If this exceeds `10000`, an error is returned. | `5241` |
 | `x-bc-graphql-query-hash` | A `sha256` hash | A hash of the query body, not including variables. This allows identification of specific queries among those with non-unique names. | `bd2e22a00004abd3ec9437a6f895` |
 | `x-bc-graphql-variables-hash` | A `sha256` hash | A hash of the variables included in a query. | `44136fa355b3678a1146ad16f7e8` |
 | `x-bc-graphql-operation-type` | One of `query`, `mutation`, or `subscription` | The operation type of the request. Currently, `subscription` is not supported. | `query` |


### PR DESCRIPTION
Added table of GraphQL headers as documentation doesn't currently exist

<!-- Ticket number or summary of work -->
# [DEVDOCS-6375]


## What changed?
* We now have GraphQL headers for features of a request
    * `x-bc-gql-query-hash` - a hash for identifying specific requests
    * `x-bc-gql-operation-type` - the operation type used in the request
    * `x-bc-gql-operation-name` - the name of the operation, if given

## Release notes draft
* We've added documentation for our GraphQL response headers, including several for quickly identifying specific requests.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping { @bigcommerce/team-api-platform @bigcommerce/dev-docs-team }


[DEVDOCS-6375]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ