### PR TITLE
DEVDOCS-6350 | Correct limits of total custom widget templates

### DIFF
--- a/reference/widgets.v3.yml
+++ b/reference/widgets.v3.yml
@@ -117,7 +117,7 @@ paths:
       description: |-
         Creates a **Widget Template**.
 
-        ***Note:*** *There is a limit of 1000 custom widget templates per store.*
+        ***Note:*** *There is a limit of 1000 custom widget templates per channel, and a limit of 5000 across all channels.*
 
         **Required Fields**
         * name


### PR DESCRIPTION
Adding widget template limit for all channels (5000) to: https://developer.bigcommerce.com/docs/rest-content/widgets/widget-template

<!-- Ticket number or summary of work -->
# [DEVDOCS-6350]


## What changed?
<!-- Provide a bulleted list in the present tense -->
Changed
"Note: There is a limit of 1000 custom widget templates per store."
to
"Note: There is a limit of 1000 custom widget templates per channel, and a limit of 5000 across all channels."

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* Updated widget template limits in Content API reference.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

@bc-terra - Ready for review.

[DEVDOCS-6350]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ