### PR TITLE
DEVDOCS-6398 - Fix URL paths in "Quote" (S2S)

### DIFF
--- a/docs/b2b-edition/specs/api-v3/quote/quote.yaml
+++ b/docs/b2b-edition/specs/api-v3/quote/quote.yaml
@@ -21,9 +21,9 @@ info:
 
     Custom shipping can be enabled from **Settings › Quotes** in your B2B Edition control panel. This is required for the following endpoints: 
 
-    * [Get All B2B Quote Custom Shipping Methods](#get-all-b2b-quote-custom-shipping-methods)
-    * [Select a Shipping Rate for a Quote](#select-a-shipping-rate-for-quote) (if you are adding a custom shipping rate)
-    * [Remove Selected Shipping Rate from a Quote](#remove-selected-shipping-rate-for-quote) (if you are removing a custom shipping rate)
+    * [Get All B2B Quote Custom Shipping Methods](/b2b-edition/apis/rest-management/quote/quotes#get-all-b2b-quote-custom-shipping-methods)
+    * [Select a Shipping Rate for a Quote](/b2b-edition/apis/rest-management/quote/quotes#select-a-shipping-rate-for-quote) (if you are adding a custom shipping rate)
+    * [Remove Selected Shipping Rate from a Quote](/b2b-edition/apis/rest-management/quote/quotes#remove-selected-shipping-rate-for-quote) (if you are removing a custom shipping rate)
 
     See [B2B Edition Settings (Help Center)](https://support.bigcommerce.com/s/article/B2B-Edition-Settings) to learn more about enabling and configuring custom shipping methods.
 
@@ -33,7 +33,7 @@ info:
 
     A custom item is a one-time line item which uses the SKU and pricing of the selected product, but not the product’s ID. Note that the missing product ID can cause downstream issues if you have an external integration which uses the ID to sync information and events.
 
-    Custom items can be added to a quote via the [Create a Quote](#create-a-quote) and [Update a Quote](#update-a-quote) endpoints. In order to use custom items, your store must meet the following prerequisites:
+    Custom items can be added to a quote via the [Create a Quote](/b2b-edition/apis/rest-management/quote/quotes#create-a-quote) and [Update a Quote](/b2b-edition/apis/rest-management/quote/quotes#update-a-quote) endpoints. In order to use custom items, your store must meet the following prerequisites:
 
     * Your store must use the Buyer Portal experience.
     * You must enable custom items from **Settings › Quotes** in your B2B Edition control panel.
@@ -45,7 +45,7 @@ info:
 
     Sales quotes have seven different statuses corresponding to the different parts of a quote’s life cycle. 
 
-    Each status is assigned a numeric ID, which appears in the `status` field of the response body when using the [Get All Quotes](#get-all-quotes) and [Get Quote Details](#get-quote-details) endpoints. You can also use a quote’s `status` as a parameter of the [Get All Quotes](#get-all-quotes) endpoint in order to filter for quotes in a specific status.
+    Each status is assigned a numeric ID, which appears in the `status` field of the response body when using the [Get All Quotes](#get-all-quotes) and [Get Quote Details](/b2b-edition/apis/rest-management/quote/quotes#get-quote-details) endpoints. You can also use a quote’s `status` as a parameter of the [Get All Quotes]/b2b-edition/apis/rest-management/quote/quotes(#get-all-quotes) endpoint in order to filter for quotes in a specific status.
 
     See the table below for information on each quote status, as well as its corresponding `status` code.
     | Status Name | Description | Status ID |


### PR DESCRIPTION
Fixed relative URL paths on "Quote" page links so that they direct to the corresponding endpoint sections in "Quotes".

<!-- Ticket number or summary of work -->
# [DEVDOCS-6398](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6398)


## What changed?

* Fixed links on the "Quote" overview page so that they direct to the corresponding endpoint sections

## Release notes draft

* We've updated links to endpoints on the Quote overview page to enhance usability.

## Anything else?

ping @bc-terra 


[DEVDOCS-6398]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ