### PR TITLE
DEVDOCS-000 | Add direction parameter to GET /catalog/brands endpoint

### DIFF
--- a/reference/catalog/brands_catalog.v3.yml
+++ b/reference/catalog/brands_catalog.v3.yml
@@ -69,6 +69,7 @@ paths:
         - $ref: '#/components/parameters/IncludeFieldsQuery'
         - $ref: '#/components/parameters/ExcludeFieldsQuery'
         - $ref: '#/components/parameters/SortQuery'
+        - $ref: '#/components/parameters/DirectionQuery'
       responses:
         '200':
           description: ''
@@ -2394,6 +2395,17 @@ components:
           type: object
           properties: { }
   parameters:
+    DirectionQuery:
+      name: direction
+      in: query
+      description: |
+        Sort direction. Acceptable values are: `asc`, `desc`.
+      required: false
+      schema:
+        type: string
+        enum:
+          - asc
+          - desc
     BrandIdPath:
       name: brand_id
       in: path


### PR DESCRIPTION
## What
Added the missing 'direction' query parameter to the GET /catalog/brands endpoint documentation.

## Why
The parameter was missing from the documentation but is available in the API.

## Testing/Proof
The parameter has been added to the brands_catalog.v3.yml file with appropriate description and schema definition.

Fixes #964