### PR TITLE
DEVDOCS-6403 - fix broken link

### DIFF
--- a/docs/storefront/stencil/themes/context/handlebars-reference.mdx
+++ b/docs/storefront/stencil/themes/context/handlebars-reference.mdx
@@ -1,6 +1,6 @@
 # Handlebars Helpers Reference
 
-This article is a reference for [Stencil](/docs/storefront/stencil/start) supported [Handlebars](https://handlebarsjs.com/) helpers. It includes [custom helpers](#custom-helpers) documentation and a list of acceptlisted [standard helpers](#standard-helpers).
+This article is a reference for [Stencil](/docs/storefront/stencil/start) supported [Handlebars](https://handlebarsjs.com/) helpers. It includes [custom helpers](#helpers-documentation) documentation and a list of acceptlisted [standard helpers](#standard-helpers).
 
 
 ## Supported standard features


### PR DESCRIPTION
Link for custom helpers is broken. Adjusting the target to the correct ID within the page

<!-- Ticket number or summary of work -->
# [DEVDOCS-6403]


## What changed?
* Link for custom handlebars now points to the correct ID

## Release notes draft
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}
