### PR TITLE
DEVDOCS-6393 - Channel-specific settings

### DIFF
--- a/reference/checkouts.v3.yml
+++ b/reference/checkouts.v3.yml
@@ -8072,6 +8072,60 @@ paths:
                   order_confirmation_use_custom_checkout_script: false
                   custom_order_confirmation_script_url: 'webdav:vtz-order-confirmation/dist/auto-loader.js'
                 meta: {}
+  /checkouts/settings/channels/{channelId}:
+    parameters:
+      - name: channelId
+        in: path
+        required: true
+        schema:
+          type: integer
+    get:
+      summary: Get Channel-Specific Checkout Settings
+      description: Returns the checkout settings for a given channel (storefront) by channelId.
+      tags:
+        - Checkout Settings
+      responses:
+        '200':
+          description: Channel checkout settings retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/ChannelCheckoutsSettings'
+                  meta:
+                    $ref: '#/components/schemas/MetaOpen'
+        '422':
+          description: Invalid channelId or invalid request
+  
+    put:
+      summary: Update Channel-Specific Checkout Settings
+      description: |-
+        Updates the checkout settings for a given channel (storefront) by channelId.
+        
+        This endpoint will update all settings included in the request body. Any settings excluded will remain unchanged. All non-boolean 
+      tags:
+        - Checkout Settings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChannelCheckoutsSettings'
+      responses:
+        '200':
+          description: Channel checkout settings updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/ChannelCheckoutsSettings'
+                  meta:
+                    $ref: '#/components/schemas/MetaOpen'
+        '422':
+          description: Invalid channelId or invalid request
   '/checkouts/{checkoutId}/token':
     parameters:
       
@@ -9427,6 +9481,31 @@ components:
           type: string
         custom_order_confirmation_sri_hash:
           type: string
+    ChannelCheckoutsSettings:
+      title: Channel-Specific Checkouts Settings
+      allOf:
+        - properties:
+            checkout_type:
+              type: string
+            guest_checkout_type:
+              type: string
+            guest_checkout_for_existing_accounts:
+              type: string
+            policy_consent:
+              type: string
+            order_confirmation_contact_email:
+              type: string
+            is_order_terms_and_conditions_enabled:
+              type: boolean
+            order_terms_and_conditions_type:
+              type: string
+            order_terms_and_conditions_link:
+              type: string
+            order_terms_and_conditions_textarea:
+              type: string
+            should_redirect_to_storefront_for_auth: 
+              type: boolean
+        - $ref: "#/components/schemas/CheckoutsSettings"
     CheckoutsSettingsRequest:
       title: Checkouts settings request
       type: object


### PR DESCRIPTION
Added Channel-Specific Checkout Settings endpoints

<!-- Ticket number or summary of work -->
# [DEVDOCS-6393]


## What changed?
* We now support setting and fetching channel-specific checkout settings via API.

## Release notes draft
* Added endpoints for channel-specific checkouts settings, which were previously available but un-documented.

## Anything else?

ping {names}
