### PR TITLE
fix(docs): DEVDOCS-6407 fix display issue

### DIFF
--- a/reference/promotions.v3.yml
+++ b/reference/promotions.v3.yml
@@ -83,7 +83,7 @@ paths:
         content:
           application/json:
             schema:
-              anyOf:
+              oneOf:
                 - $ref: '#/components/schemas/DraftCouponPromotion'
                 - $ref: '#/components/schemas/DraftAutomaticPromotion'
       responses:
@@ -168,7 +168,7 @@ paths:
         content:
           application/json:
             schema:
-              anyOf:
+              oneOf:
                 - $ref: '#/components/schemas/PatchCouponPromotion'
                 - $ref: '#/components/schemas/PatchAutomaticPromotion'
       responses:
@@ -409,11 +409,11 @@ components:
                 - When the property is set to `fasle`, the coupon will not be applied if automatic promotions are already applied.
                 Trying to set the value of this field to `true` when `can_be_used_with_other_promotions` is `true` will yield a 422 error response.
     DraftCouponPromotion:
+      title: Draft Coupon Promotion
+      description: 'A draft **Coupon Promotion** to be created. A shopper must manually apply a *coupon promotion* to their cart.'
       allOf:
         - $ref: '#/components/schemas/PromotionBase'
-        - title: Draft Coupon Promotion
-          description: 'A draft **Coupon Promotion** to be created. A shopper must manually apply a *coupon promotion* to their cart.'
-          type: object
+        - type: object
           properties:
             codes:
               $ref: '#/components/schemas/CouponCode'
@@ -601,7 +601,7 @@ components:
         - action
     Condition:
       description: '**Condition**'
-      anyOf:
+      oneOf:
         - $ref: '#/components/schemas/CartCondition'
         - $ref: '#/components/schemas/AndCondition'
     AndCondition:


### PR DESCRIPTION
Fix display issue for DraftCouponPromotions
Replace all anyOf with more accurate oneOf

<!-- Ticket number or summary of work -->
# [DEVDOCS-6407]


## What changed?
<!-- Provide a bulleted list in the present tense -->
Fix display issue for docs.

<img width="395" alt="image" src="https://github.com/user-attachments/assets/7de5133a-759b-4acd-8a45-0c9aae950981" />


Here it should say "Draft Coupon Promotion" not "BasePromotion"



Also while im here fixed a few "anyOf" that should say "oneOf"

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @bigcommerce/team-orders @bc-terra 


[DEVDOCS-6407]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ