### PR TITLE
DEVDOCS-6421

### DIFF
--- a/reference/checkouts.v3.yml
+++ b/reference/checkouts.v3.yml
@@ -1660,9 +1660,6 @@ paths:
                           discounted_amount:
                             type: number
                             example: 10
-                          name:
-                            type: string
-                            example: manual
                     line_items:
                         type: array
                         items:
@@ -1682,7 +1679,6 @@ paths:
               cart:
                 discounts: 
                   - discounted_amount: 10
-                    name: "manual-discount"
               version: 1
         required: false
       responses:


### PR DESCRIPTION
Removed reference to `name` field in Add Discount to Checkout endpoint.

<!-- Ticket number or summary of work -->
# [DEVDOCS-6421]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Minor adjustment to Add Discount to Checkout endpoint, addressing a non-persisting field.

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* `name` has been removed from the affected endpoint, as it doesn't persist

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping { @bc-mackxu @bigcommerce/dev-docs  }


[DEVDOCS-6421]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ