### PR TITLE
Add "building resilience" section to Tax Provider API docs

### DIFF
--- a/docs/integrations/tax.mdx
+++ b/docs/integrations/tax.mdx
@@ -83,6 +83,12 @@ Make sure to also review our [app development best practices](/docs/integrations
   When you develop your app, you can register your app in the Developer Portal without submitting it. The app will be in a Draft state. This means only stores owned by the same email address as that on the Developer Portal account can install the app.
 </Callout>
 
+### Building resilience
+
+We encourage you to write robust, resilient code that will not break end to end functionality when BigCommerce pushes non-breaking changes to the Tax Provider API (e.g., adding a new request field).
+
+See our [API best practices](/docs/start/best-practices) for further guidance, including detail on breaking changes vs non-breaking changes.
+
 ## Installing the app
 
 When the merchant clicks **Install** on your single-click app, the app must handle the OAuth flow before moving on to the next step of establishing a connection with the [Tax Provider API](/docs/rest-contracts/tax). The [Apps Guide](/docs/integrations/apps/guide/auth) provides an overview of the OAuth flow.
@@ -169,7 +175,7 @@ Using [Tax Properties](/docs/store-operations/tax/tax-properties) to enhance the
 
 #### Avoiding infinite loops
 
-Several BigCommerce API endpoints will automatically invoke an estimate call to a tax provider under certain conditions (e.g. when there is not already a tax quote applied to a cart). These API endpoints must not be called by your tax provider's implementation as doing so will cause an infinite loop of requests, resulting in a memory timeout.
+Several BigCommerce API endpoints will automatically invoke an estimate call to a tax provider under certain conditions (e.g., when there is not already a tax quote applied to a cart). These API endpoints must not be called by your tax provider's implementation as doing so will cause an infinite loop of requests, resulting in a memory timeout.
 
 An infinite loop is able to be identified by observing any duplicated requests being received by a tax provider within a very short time frame.
 


### PR DESCRIPTION
# [TAX-2428]

## What changed?
* Add "building resilience" section to Tax Provider API docs.

In response to our second significant report on this topic.

## Release notes draft
* Added additional guidance around API best practices to our Tax Provider API implementation guide.

[TAX-2428]: https://bigcommercecloud.atlassian.net/browse/TAX-2428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ