### PR TITLE
DEVDOCS-6414 - Call out decimal place limitations in Quotes (S2S)

### DIFF
--- a/docs/b2b-edition/specs/api-v3/quote/quote.yaml
+++ b/docs/b2b-edition/specs/api-v3/quote/quote.yaml
@@ -1720,7 +1720,7 @@ components:
           example: "."
         decimalPlaces:
           type: integer
-          description: "The number of decimal places displayed in quote pricing."
+          description: "The number of decimal places displayed in quote pricing. You can display a maximum of 4 decimal places."
           example: 2
         thousandsToken:
           type: string


### PR DESCRIPTION
Updated `decimalPlaces` description to call out that you can display up to 4 decimal places.

# [DEVDOCS-6414](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6414)


## What changed?

* The description for the `decimalPlaces` field clarifies that you can display up to 4 decimal places.

## Release notes draft

*  The description for the `decimalPlaces` field now clarifies that you can display up to 4 decimal places on quotes.

## Anything else?

ping @bc-terra 


[DEVDOCS-6414]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ