### PR TITLE
BRP-17658 Add docs for checkout misuse

### DIFF
--- a/docs/integrations/apps/unified-billing/example-queries.mdx
+++ b/docs/integrations/apps/unified-billing/example-queries.mdx
@@ -12,6 +12,8 @@ When creating a checkout with a product that has a trial period, set the `trialD
 
 The merchant will not be charged during this period. A subscription only generates an invoice once the trial period ends. No charges are made during the trial.
 
+Checkout links are valid for 24 hours and expire automatically to prevent misuse.
+
 To create a checkout, run the `createCheckout` mutation:
 
 <Tabs items={["Request", "Sample variables", "Response"]}>


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [BRP-17658]
Adding a line to the Unified Billing docs to state the already in place behavior of protections around checkout links.

## What changed?
<!-- Provide a bulleted list in the present tense -->
* Add line around checkout links

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}
