### PR TITLE
DEVDOCS-6420 - Remove documentation for b2b create-a-company-user

### DIFF
--- a/docs/b2b-edition/specs/storefront/storefront/company.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/company.yaml
@@ -11,7 +11,7 @@ info:
     * Confirm that a user is assigned to a specific Company account
     * Create a Company address
     * Update a Company address
-    * Get a Company’s address book or its default addresses
+    * Get a Company's address book or its default addresses
     * Mark an address as active or inactive
 
     ## Users
@@ -299,59 +299,6 @@ paths:
                                       $ref: "#/components/schemas/catalogId"
                           pagination:
                             $ref: "#/components/schemas/responsePagination"
-    post:
-      tags:
-        - Companies
-        - User
-      summary: "Create a Company User"
-      operationId: post-companies-companyId-users
-      description: |-
-        Creates a user associated with a particular Company account.
-
-        Equivalent Storefront GraphQL API Mutation: `userCreate`. For more information, see the [GraphQL Playground](https://api-b2b.bigcommerce.com/graphql/playground).
-
-        If you enter an email address in the `email` field that is associated with a BigCommerce customer account, and the customer account does not already have a corresponding Company user account, it will link the existing customer account with the new Company user. If the email is not associated with a customer account, a new one will be created with the Company user.
-
-        You can confirm if a particular email address is associated with a BigCommerce customer account by using the [Validate a Frontend User Email](/b2b-edition/apis/rest-storefront/company/companies#validate-a-frontend-user-email) endpoint.
-      parameters: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              required:
-                - firstName
-                - lastName
-                - email
-                - phone
-                - userRole
-              allOf:
-                - $ref: "#/components/schemas/user_BASE"
-                - type: object
-                  properties:
-                    userRole:
-                      $ref: "#/components/schemas/userRoleInt"
-                    phone:
-                      $ref: "#/components/schemas/userPhone"
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/responseObject"
-                  - type: object
-                    properties:
-                      code:
-                        type: number
-                        default: 200
-                      data:
-                        type: object
-                        properties:
-                          userId:
-                            type: number
-                            description: "The unique ID for the customer account."
-                            example: 123
   /companies/validations/frontend/user-emails/{email}:
     parameters:
       - name: email


### PR DESCRIPTION
Removed information on the now-defunct /api/v2/companies/{companyId}/users (POST) endpoint.


# [DEVDOCS-6420](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6420)


## What changed?

* The article no longer includes the Create a Company User [`/api/v2/companies/{companyId}/users` (POST)] endpoint

## Release notes draft

* Removed the now-defunct Create a Company User [`/api/v2/companies/{companyId}/users` (POST)] endpoint from the document.

## Anything else?


ping @bc-terra @bc-amandalan 
