### PR TITLE
doc(promotions): PROMO-1018 new field "coupon_type" in the Promotions v3 API

### DIFF
--- a/reference/promotions.v3.yml
+++ b/reference/promotions.v3.yml
@@ -408,6 +408,16 @@ components:
                 - When the property is set to `true`, the coupon will override the applied automatic promotions if it provides a greater discount.
                 - When the property is set to `fasle`, the coupon will not be applied if automatic promotions are already applied.
                 Trying to set the value of this field to `true` when `can_be_used_with_other_promotions` is `true` will yield a 422 error response.
+            coupon_type:
+              type: string
+              enum:
+                - SINGLE
+                - BULK
+              example: BULK
+              description: |-
+                The type of the coupon promotion, whether it will have single or multiple codes.
+
+                Must be the same as existing value because changing coupon type is not supported. The field is there just for the ease of drafting PUT payload.
     DraftCouponPromotion:
       title: Draft Coupon Promotion
       description: 'A draft **Coupon Promotion** to be created. A shopper must manually apply a *coupon promotion* to their cart.'
@@ -431,6 +441,14 @@ components:
               description: The type of the promotion. Promotions applied automatically have a value of `AUTOMATIC` whereas promotions requiring a coupon have a value of `COUPON`.
               enum:
                 - COUPON
+            coupon_type:
+              type: string
+              enum:
+                - SINGLE
+                - BULK
+              default: SINGLE
+              example: BULK
+              description: The type of the coupon promotion, whether it will have single or multiple codes, defaults to "SINGLE" if not provided.
           required:
             - redemption_type
             - name
@@ -473,6 +491,13 @@ components:
                     type: boolean
                     example: false
                     default: false
+            coupon_type:
+              type: string
+              enum:
+                - SINGLE
+                - BULK
+              description: The type of the coupon promotion, whether it will have single or multiple codes.
+              example: BULK
       required:
         - id
         - name
@@ -489,6 +514,7 @@ components:
         - status
         - can_be_used_with_other_promotions
         - coupon_overrides_automatic_when_offering_higher_discounts
+        - coupon_type
     PatchAutomaticPromotion:
       title: Patch Automatic Promotion
       description: 'A Partial **Automatic Promotion** that contains properties to patch.'


### PR DESCRIPTION
# [PROMO-1018]


## What changed?
new field "coupon_type" in the Promotions v3 API: 
* In GET response
* In POST request body and response
* In PUT request body and response

## Release notes draft
Only merge this PR to make it publicly available after the experiment `PROMO-920.support_bulk_coupon_code_generation_in_promotion_API` has been turned `on`

## Anything else?
For example of requests & responses, pls refer to the implementation PR: https://github.com/bigcommerce/bigcommerce/pull/63911 

## Test proof

Rendering correctly in Swagger editor: 

- For GET response: 

<img width="665" alt="image" src="https://github.com/user-attachments/assets/f7a2cd0a-8b3a-4949-8669-8dbecda647b0" />

- For POST request & response: 

<img width="866" alt="image" src="https://github.com/user-attachments/assets/ec60358f-36bb-4236-ab74-db11fe5c8e67" />

<img width="656" alt="image" src="https://github.com/user-attachments/assets/d39fe0cd-03c6-4060-8403-9ad678ee05c0" />

- For PUT request & response: 

<img width="874" alt="image" src="https://github.com/user-attachments/assets/4a1f11da-e388-44ec-a236-674b6aec1e5f" />

<img width="668" alt="image" src="https://github.com/user-attachments/assets/d8c81fd4-c233-4d97-8da2-e435feb78820" />

ping @bigcommerce/team-orders 