### PR TITLE
DEVDOCS-000: Fix multiConcat helper example in handlebars reference

### DIFF
--- a/docs/storefront/stencil/themes/context/handlebars-reference.mdx
+++ b/docs/storefront/stencil/themes/context/handlebars-reference.mdx
@@ -87,7 +87,7 @@ Helpers that are used to define and render templates.
 | [get](#get)                     | object    | Use property paths (`a.b.c`) to get a value or nested value from the context. |
 | [getObject](#getobject)         | object    | Use property paths (`a.b.c`) to get an object from the context.               |
 | [concat](#concat)               | string    | Concatenates two strings.                                                     |
-| [multiConcat](#multiConcat)     | string    | Concatenates multiple strings.                                                |
+| [multiConcat](#multiconcat)     | string    | Concatenates multiple strings.                                                |
 | [join](#join)                   | string    | Joins an array of string elements into one string.                            |
 | [json](#json)                   | string    | Converts a JavaScript object into a JSON string.                              |
 | [JSONparse](#jsonparse)         | object    | Parses the given string using `JSON.parse`.                                                                                                                                                           |
@@ -1338,7 +1338,7 @@ Concatenates multiple strings.
 #### Example
 
 ```handlebars showLineNumbers
-{{concat 'there' 'is' 'no' 'spoon'}}
+{{multiConcat 'there' 'is' 'no' 'spoon'}}
 <!-- => thereisnospoon -->
 ```
 


### PR DESCRIPTION
Fixes #999

This PR fixes the multiConcat helper example in the handlebars reference documentation by changing 'concat' to 'multiConcat' in the example code.