### PR TITLE
DEVDOCS-6423 - Add new rule for Payments Partners

### DIFF
--- a/docs/integrations/apps/guide/requirements.mdx
+++ b/docs/integrations/apps/guide/requirements.mdx
@@ -35,6 +35,7 @@ Don't reference competitor platforms in the app's listing information or dashboa
 * Apps that modify the checkout experience must use the BigCommerce [Checkout SDK](/docs/storefront/cart-checkout/checkout-sdk).
 * Apps that add another marketplace or sales channel to a store should make use of the [Channels Toolkit](/docs/integrations/channels/guide) and follow [Channel App Requirements](/docs/integrations/channels/guide/requirements).
 * Apps that create orders in the BigCommerce store need to properly mark accurate order source, payment method, and other order details.
+    * To supply the order source, include the `external_source` field in the request body with your [app's ID](/docs/integrations/apps/guide/id) as the value.
 
 <Callout type="info">We have paused all new externally built payment integrations for our publicly available BigCommerce Marketplace. We are updating our available APIs to create a more robust experience and hope to re-open this program in the near future. Please reach out to paymentspod@bigcommerce.com with any questions.</Callout>
 

--- a/docs/integrations/apps/guide/requirements.mdx
+++ b/docs/integrations/apps/guide/requirements.mdx
@@ -35,7 +35,7 @@ Don't reference competitor platforms in the app's listing information or dashboa
 * Apps that modify the checkout experience must use the BigCommerce [Checkout SDK](/docs/storefront/cart-checkout/checkout-sdk).
 * Apps that add another marketplace or sales channel to a store should make use of the [Channels Toolkit](/docs/integrations/channels/guide) and follow [Channel App Requirements](/docs/integrations/channels/guide/requirements).
 * Apps that create orders in the BigCommerce store need to properly mark accurate order source, payment method, and other order details.
-    * To supply the order source, include the `external_source` field in the request body with your [app's ID](/docs/integrations/apps/guide/id) as the value.
+    * To supply the order source, include the `external_source` field in the request body with your [app's ID](/docs/integrations/apps/guide/id) as the value. This is required if you are submitting your app for marketplace approval. 
 
 <Callout type="info">We have paused all new externally built payment integrations for our publicly available BigCommerce Marketplace. We are updating our available APIs to create a more robust experience and hope to re-open this program in the near future. Please reach out to paymentspod@bigcommerce.com with any questions.</Callout>
 


### PR DESCRIPTION
Added an explanation of how to properly mark an order's source with an app.


# [DEVDOCS-6423](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6423)


## What changed?

* The Functionality requirements now clarify how to specify the mandatory external source for apps that create orders.

## Release notes draft

* Provided information on the `external_source` field required for apps that  create orders.

## Anything else?


ping @bc-terra 


[DEVDOCS-6423]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ