### PR TITLE
DEVDOCS-6423 - Add new rule for Payments Partners

### DIFF
--- a/docs/store-operations/orders/index.mdx
+++ b/docs/store-operations/orders/index.mdx
@@ -547,6 +547,8 @@ To specify a guest checkout, set `customer_id` to 0.
 
 You cannot specify the `order_source`; its value is external. You can optionally specify a value for `external_source` to define which external source the order is coming from - e.g., POS system X, accounting system Y, etc.
 
+> **Note:** To publish an app that creates orders, it must include the `external_source` field on new orders. See [App Store Approval Requirements](/docs/integrations/apps/guide/requirements#functionality) to learn more.
+
 **Can I create an order with only custom products?**
 
 Yes, the store's catalog does not include products.


### PR DESCRIPTION
Added an explanation of how to properly mark an order's source with an app.


# [DEVDOCS-6423](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6423)


## What changed?

* The FAQ includes a notice that calls out the external source requirements for apps that create orders.

## Release notes draft

* Expanded the FAQ about setting the order source to call out the requirements for approving apps that create orders.

## Anything else?


ping @bc-terra 