### PR TITLE
Add type filter to tax properties API documentation

### DIFF
--- a/reference/tax_properties.v3.yml
+++ b/reference/tax_properties.v3.yml
@@ -32,6 +32,7 @@ paths:
       operationId: getTaxProperties
       parameters:
         - $ref: "#/components/parameters/idin"
+        - $ref: "#/components/parameters/typein"
       responses:
         "200":
           description: OK
@@ -263,6 +264,17 @@ components:
         type: array
         items:
           type: integer
+    typein:
+      name: type:in
+      in: query
+      required: false
+      description: Filter result by the type of tax property. To target multiple types, provide a comma-separated list of types such as `customer,product`.
+      style: form
+      explode: false
+      schema:
+        type: array
+        items:
+          type: string
   securitySchemes:
     X-Auth-Token:
       name: X-Auth-Token


### PR DESCRIPTION
# [TAX-2314]

## What changed?
* Add information about our newly introduced `type` filter on our Tax Properties API.

## Release notes draft
* Tax Properties API now supports filtering results by type (customer or product).

## Anything else?
Related PR: https://github.com/bigcommerce/bigcommerce/pull/64034

[TAX-2314]: https://bigcommercecloud.atlassian.net/browse/TAX-2314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ