### PR TITLE
DEVDOCS-6237 - Refresh Quotes (SF)

### DIFF
--- a/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
@@ -797,7 +797,7 @@ paths:
                 emailTemplate:
                   type: string
                   enum:
-                    - "Simple"
+                    - "Default with Checkout Button"
                     - "Simple with Pictures"
                     - "Waves with Pictures"
                     - "Sky"
@@ -805,7 +805,7 @@ paths:
                     - "Database with checkout button"
                     - "Modern with checkout link"
                     - "Modern without checkout link"
-                  example: "Simple"
+                  example: "Default with Checkout Button"
                   description: "The template used to format the quote email."
                 emailLang:
                   type: string

--- a/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
@@ -414,7 +414,7 @@ paths:
           description: |-
             Not Found
           
-            This error occurs if the `storeHash` entered in the query is missign or invalid.
+            This error occurs if the `storeHash` entered in the query is missing or invalid.
           content:
             application/json:
               schema:
@@ -635,25 +635,25 @@ paths:
 
         | Config Key | Description |
         | --- | --- |
-        | quote_reminder_notification | Indicates whether or not the Quote reminder template for buyers is enabled in the store's Email settings |
-        | quote_customer | Indicates whether or not quotes are enabled in the Feature management area of the store's General settings |
-        | quote_on_product_page | Indicates whether or not the product page Add to quote button is enabled in the store's Quotes settings |
-        | quote_on_cart_page | Indicates whether or not the cart page Add to quote button is enabled in the store's Quotes settings |
-        | quote_for_guest | Indicates whether or not quote requests are enabled for guest shoppers in the store's Quotes settings |
-        | quote_for_individual_customer | Indicates whether or not quote requests are enabled for storefront customers in the store's Quotes settings |
-        | quote_for_b2b | Indicates whether or not quote requests are enabled for Company users in the store's Quotes settings |
-        | quote_sales_rep_visibility | Indicates whether or not Sales Staff users are restricted to viewing quotes from their assigned Companies. This is enabled by default, and cannot be disabled. |
-        | quote_sales_rep_creation | Indicates whether or not the built-in Sales Rep system user role is authorized to create quotes in the B2B Edition control panel. This configuration cannot be disabled, but you can create a custom user role for Sales Staff without quote permissions. |
-        | email_quote_for_merchant | Indicates whether or not the New quote email template for merchants is enabled in the store's Email settings |
+        | quote_reminder_notification | Indicates whether the Quote reminder template for buyers is enabled in the store's Email settings |
+        | quote_customer | Indicates whether quotes are enabled in the Feature management area of the store's General settings |
+        | quote_on_product_page | Indicates whether the product page Add to quote button is enabled in the store's Quotes settings |
+        | quote_on_cart_page | Indicates whether the cart page Add to quote button is enabled in the store's Quotes settings |
+        | quote_for_guest | Indicates whether quote requests are enabled for guest shoppers in the store's Quotes settings |
+        | quote_for_individual_customer | Indicates whether quote requests are enabled for storefront customers in the store's Quotes settings |
+        | quote_for_b2b | Indicates whether quote requests are enabled for Company users in the store's Quotes settings |
+        | quote_sales_rep_visibility | Indicates whether Sales Staff users are restricted to viewing quotes from their assigned Companies. This is enabled by default, and cannot be disabled. |
+        | quote_sales_rep_creation | Indicates whether the built-in Sales Rep system user role is authorized to create quotes in the B2B Edition control panel. This configuration cannot be disabled, but you can create a custom user role for Sales Staff without quote permissions. |
+        | email_quote_for_merchant | Indicates whether the New quote email template for merchants is enabled in the store's Email settings |
         | quote_logo | The URL for the logo image in the store's General setings, which appears on quote emails and PDFs |
-        | quote_cost_column | Indicates whether or not the store's Quotes settings are configured to display the product cost column in the line items table while viewing a quote in the B2B Edition control panel |
-        | quote_margin_column | Indicates whether or not the store's Quotes settings are configured to display the cost margin column in the line items table while viewing a quote in the B2B Edition control panel |
-        | customer_update_quote_message_email_sales_rep | Indicates whether or not Sales Staff users are notified via email when a buyer from an assigned Company has created a quote. This is configured during initial setup. |
-        | sales_rep_update_quote_message_email_customer | Indicates whether or not buyers are notified via email when a Sales Staff user has created a quote for them. This is configured during initial setup. |
-        | quote_send_customer_notes_to_order | Indicates whether or not the store's Quotes settings are configured to transfer customer-facing notes on the quote to the corresponding order by default |
-        | quote_send_product_notes_to_order | Indicates whether or not the store's Quotes settings are configured to transfer line item-specific notes on the quote to the corresponding order by default |
-        | quote_custom_shipping | Indicates whether or not custom shipping is enabled in the store's Quotes settings |
-        | quote_default_pdf |  |
+        | quote_cost_column | Indicates whether the store's Quotes settings are configured to display the product cost column in the line items table while viewing a quote in the B2B Edition control panel |
+        | quote_margin_column | Indicates whether the store's Quotes settings are configured to display the cost margin column in the line items table while viewing a quote in the B2B Edition control panel |
+        | customer_update_quote_message_email_sales_rep | Indicates whether Sales Staff users are notified via email when a buyer from an assigned Company has created a quote. This is configured during initial setup. |
+        | sales_rep_update_quote_message_email_customer | Indicates whether buyers are notified via email when a Sales Staff user has created a quote for them. This is configured during initial setup. |
+        | quote_send_customer_notes_to_order | Indicates whether the store's Quotes settings are configured to transfer customer-facing notes on the quote to the corresponding order by default |
+        | quote_send_product_notes_to_order | Indicates whether the store's Quotes settings are configured to transfer line item-specific notes on the quote to the corresponding order by default |
+        | quote_custom_shipping | Indicates whether custom shipping is enabled in the store's Quotes settings |
+        | quote_default_pdf | The template used by default when buyers download a quote PDF |
         | defaultExpirationDate | The default number of days before a new quote expires |
         | defaultTermsAndConditions | The default terms and conditions configured in the store's Quotes settings |
       parameters:
@@ -765,7 +765,7 @@ paths:
 
         The following email templates can be used:
 
-        * `Simple`
+        * `Default with Checkout Button`
         * `Simple with Pictures`
         * `Waves with Pictures`
         * `Database with checkout button`
@@ -1201,8 +1201,8 @@ components:
                         enum:
                           - "none"
                           - "product"
-                          - "option"
-                        example: "option"
+                          - "variant"
+                        example: "variant"
                         description: "Indicates whether the line item’s inventory is tracked on the product (product) or variant level (option), or if it is not tracked (none)."
                       inventoryLevel:
                         type: number


### PR DESCRIPTION
Added revisions from the post-publish feedback in [PR 902](https://github.com/bigcommerce/docs/pull/902).

# [DEVDOCS-6237](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6237)


## What changed?

* The `quote_default_pdf` config now includes a description of what it does.
* The list of quote email templates includes all available templates and no longer displays an unavailable template.
* The `inventory` field in the `productList` array includes the correct enum values.

## Release notes draft

* We've updated the following field descriptions to include more information on accepted values and how to use them:
    * `inventory`
    * `emailTemplate`
    * `quote_default_pdf`

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @bc-terra @bc-eduardogamboa 


[DEVDOCS-6237]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ