### PR TITLE
STRF-13437: Remove rss feed page type from public documentation

### DIFF
--- a/docs/storefront/stencil/themes/context/object-reference/schemas/page-type.yml
+++ b/docs/storefront/stencil/themes/context/object-reference/schemas/page-type.yml
@@ -48,7 +48,6 @@ description: |-
   * product* 
   * amp_product_options 
   * search      
-  * rss 
   * sitemap 
   * newsletter_subscribe      
   * wishlist 

--- a/docs/storefront/stencil/themes/context/object-reference/schemas/page.yml
+++ b/docs/storefront/stencil/themes/context/object-reference/schemas/page.yml
@@ -1,5 +1,5 @@
 description: |-
-  `{{page}}` object present on content pages, forms, and RSS feeds.
+  `{{page}}` object present on content pages, and forms.
 
   **Handlebars Expression**: `{{page}}`
 type: object
@@ -11,18 +11,6 @@ properties:
   content:
     type: string
     description: HTML content of the page
-  feed:
-    description: Present if page is an RSS feed page.
-    type: array
-    items:
-      type: object
-      properties:
-        content:
-          type: string
-        title:
-          type: string
-        url:
-          type: string
   id:
     type: integer
   sub_pages:

--- a/docs/storefront/stencil/themes/context/object-reference/schemas/urls.yml
+++ b/docs/storefront/stencil/themes/context/object-reference/schemas/urls.yml
@@ -98,28 +98,6 @@ properties:
     properties:
       post_review:
         type: string
-  rss:
-    type: object
-    properties:
-      products:
-        type: object
-        properties: 
-          new:
-            type: string
-          new_atom:
-            type: string
-          popular:
-            type: string
-          popular_atom:
-            type: string
-          featured:
-            type: string
-          featured_atom:
-            type: string
-          search:
-            type: string
-          search_atom:
-            type: string
   search:
     type: string
   sitemap:

--- a/reference/pages.v3.yml
+++ b/reference/pages.v3.yml
@@ -12,7 +12,7 @@ info:
 
     A **page** appears on a **site** that is associated with a **channel**. 
 
-    Some pages, such as blog pages, contact forms, and plain-text or HTML pages, are web pages in the traditional sense. They contain markup (a `body`) and load at a relative page location on the site itself (the `url`). Other pages, such as link and feed pages, make external or non-visual content available from the menu of a parent page or by direct link.
+    Some pages, such as blog pages, contact forms, and plain-text or HTML pages, are web pages in the traditional sense. They contain markup (a `body`) and load at a relative page location on the site itself (the `url`). Other pages, such as link pages, make external or non-visual content available from the menu of a parent page or by direct link.
 
     ### Bulk operations
 
@@ -28,7 +28,6 @@ info:
     | `contact_form` | A user-customizable page that contains a contact form. | HTML |
     | `raw` | A user-defined page that contains HTML markup or other stringified code. | HTML, other code |
     | `blog` | A page that contains blog posts. Use caution; `blog`-type pages can only be created in the store control panel, but you may be able to change the type of a blog page to something else with this API. Use the [blog feature of the REST Content API](/docs/rest-content/store-content/blog-posts#create-a-blog-post) to work with blog posts and tags. | empty string |
-    | `feed` | Makes RSS-syndicated content feeds available in the menu of other pages that contain markup. | &mdash; |
     | `link` | A link to an external absolute URL that follows [RFC 3986 standards](https://www.rfc-editor.org/rfc/rfc3986). Displays in the menu of other pages that contain markup. | &mdash; |
 servers:
   - url: 'https://api.bigcommerce.com/stores/{store_hash}/v3'
@@ -92,7 +91,6 @@ paths:
                   - $ref: '#/components/schemas/typePage'
                   - $ref: '#/components/schemas/typeBlog'
                   - $ref: '#/components/schemas/typeContactForm'
-                  - $ref: '#/components/schemas/typeFeed'
                   - $ref: '#/components/schemas/typeRaw'
                   - $ref: '#/components/schemas/typeLink'
                 - title: "Create multiple pages using array"
@@ -102,7 +100,6 @@ paths:
                       - $ref: '#/components/schemas/typePage'
                       - $ref: '#/components/schemas/typeBlog'
                       - $ref: '#/components/schemas/typeContactForm'
-                      - $ref: '#/components/schemas/typeFeed'
                       - $ref: '#/components/schemas/typeRaw'
                       - $ref: '#/components/schemas/typeLink'
             examples:
@@ -137,16 +134,18 @@ paths:
                     search_keywords: string
                     url: /my-content-page
                   - channel_id: 547
-                    name: A feed page
+                    name: Content Page For Secondary Channel
                     is_visible: false
                     parent_id: 0
                     sort_order: 0
-                    type: feed
-                    meta_title: A feed page
+                    type: page
+                    body: <div>Hello World!</div>
+                    is_homepage: false
+                    meta_title: My Content page
                     meta_keywords: string
                     meta_description: string
                     search_keywords: string
-                    feed: /rss/a-feed-page
+                    url: /my-content-page-for-secondary-channel
         description: ''
         required: true
       responses:
@@ -394,24 +393,6 @@ paths:
                       is_homepage: false
                       is_customers_only: false
                       meta: {}
-                Feed:
-                  value:
-                    data:
-                      id: 21
-                      channel_id: 1
-                      name: Detergents podcast feed
-                      meta_title: ''
-                      is_visible: false
-                      parent_id: 0
-                      sort_order: 0
-                      meta_keywords: null
-                      feed: /rss/detergents
-                      type: feed
-                      meta_description: ''
-                      is_homepage: false
-                      is_customers_only: false
-                      search_keywords: ''
-                    meta: {}
         '404':
           description: Not Found.
           content:
@@ -759,7 +740,6 @@ components:
               - $ref: '#/components/schemas/typePage'
               - $ref: '#/components/schemas/typeBlog'
               - $ref: '#/components/schemas/typeContactForm'
-              - $ref: '#/components/schemas/typeFeed'
               - $ref: '#/components/schemas/typeRaw'
               - $ref: '#/components/schemas/typeLink'
         meta:
@@ -773,7 +753,6 @@ components:
             - $ref: '#/components/schemas/typePage'
             - $ref: '#/components/schemas/typeBlog'
             - $ref: '#/components/schemas/typeContactForm'
-            - $ref: '#/components/schemas/typeFeed'
             - $ref: '#/components/schemas/typeRaw'
             - $ref: '#/components/schemas/typeLink'
         meta:
@@ -824,7 +803,6 @@ components:
             - page
             - raw
             - contact_form
-            - feed
             - link
             - blog
         body:
@@ -848,10 +826,6 @@ components:
         meta_title:
           type: string
           nullable: true
-        feed:
-          type: string
-          description: |
-            The URL of the RSS feed. Required in a `POST` request if the page type is `feed`.
         link:
           type: string
           description: |
@@ -946,7 +920,6 @@ components:
             - page
             - raw
             - contact_form
-            - feed
             - link
             - blog
         is_homepage:
@@ -1016,22 +989,6 @@ components:
                 | `orderno` | A field that lets customers specify a subject order number. |
                 | `rma` | A customer’s submitted RMA (Return Merchandise Authorization) number. |
               example: 'fullname,companyname,phone,orderno,rma'
-    typeFeed:
-      description: |-
-        `type: feed`.  Makes RSS-syndicated content feeds available in the menu of other pages that contain markup. No page body.
-      title: feed
-      allOf:
-        - $ref: '#/components/schemas/anyTypePage'
-        - $ref: '#/components/schemas/pageMeta'
-        - $ref: '#/components/schemas/searchKeywords'
-        - type: object
-          properties:
-            feed:
-              type: string
-              description: |
-                The URL of the RSS feed. Required in a `POST` request if the page type is `feed`.
-          required:
-            - feed
     typeRaw:
       description: |-
         `type: raw`. A user-defined page with a body that contains HTML markup or other stringified code.
@@ -1120,7 +1077,6 @@ components:
                   - $ref: '#/components/schemas/typePage'
                   - $ref: '#/components/schemas/typeBlog'
                   - $ref: '#/components/schemas/typeContactForm'
-                  - $ref: '#/components/schemas/typeFeed'
                   - $ref: '#/components/schemas/typeRaw'
                   - $ref: '#/components/schemas/typeLink'
               meta:

--- a/reference/store_content.v2.yml
+++ b/reference/store_content.v2.yml
@@ -443,7 +443,7 @@ paths:
                   has_mobile_version: false
                   mobile_body: ''
                   url: /contact-us/
-                  
+
     post:
       deprecated: true
       tags:
@@ -456,7 +456,6 @@ paths:
         *   `type`
         *   `name`
         *   `link` (for a page of `type: link`)
-        *   `feed` (for a page of `type: rss_feed`)
         *   `body` (for a page of `type: raw`)
 
         **Read Only Fields**
@@ -469,7 +468,7 @@ paths:
         > #### Warning
         > **Deprecated**
         > * This API operation is deprecated. Avoid using this API operation if possible. It will be removed in a future version.
-        > * To create one or more pages, use Pages V3ʼs [Create pages](/docs/rest-content/pages#create-pages) endpoint. 
+        > * To create one or more pages, use Pages V3ʼs [Create pages](/docs/rest-content/pages#create-pages) endpoint.
       operationId: createPage
       parameters:
         - $ref: '#/components/parameters/ContentType'
@@ -492,7 +491,7 @@ paths:
               meta_description: string
               is_homepage: false
               is_customers_only: false
-              search_keywords: "string"             
+              search_keywords: "string"
               has_mobile_version: false
               mobile_body: '0'
               url: /contact-us/
@@ -563,26 +562,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/page_Full'
               example:
-                id: 1
+                id: 6
                 channel_id: 11
-                name: RSS Syndication
+                name: Contact Form
                 meta_title: ''
-                body: '%%Syndicate%%'
+                body: "We're happy to answer questions or help you with returns.<br />Please fill out the form below if you need assistance."
                 is_visible: true
-                parent_id: 0
-                sort_order: 5
-                meta_keywords: '0'
+                parent_id: 5
+                sort_order: 3
+                meta_keywords: ''
                 type: page
                 meta_description: ''
                 is_homepage: false
-                layout_file: ''
-                is_customers_only: false
-                search_keywords: '0'
+                layout_file: page.html
+                is_customers_only: true
+                search_keywords: ''
                 has_mobile_version: false
-                feed: ''
-                link: ''
-                mobile_body: '0'
-                url: /rss-syndication/
+                mobile_body: ''
+                url: /contact-us/
     put:
       deprecated: true
       tags:
@@ -633,7 +630,6 @@ paths:
                 is_customers_only: false
                 search_keywords: ''
                 has_mobile_version: false
-                feed: ''
                 link: ''
                 mobile_body: ''
                 url: /shipping-returns/
@@ -656,7 +652,7 @@ paths:
         > #### Warning
         > **Deprecated**
         > * This API operation is deprecated. Avoid using this API operation if possible. It will be removed in a future version.
-        > * To delete multiple pages, use Pages V3ʼs [Delete pages](/docs/rest-content/pages#delete-pages) endpoint. To delete a single page, use Pages V3ʼs [Delete a page](/docs/rest-content/pages#delete-a-page) endpoint. 
+        > * To delete multiple pages, use Pages V3ʼs [Delete pages](/docs/rest-content/pages#delete-pages) endpoint. To delete a single page, use Pages V3ʼs [Delete a page](/docs/rest-content/pages#delete-a-page) endpoint.
       operationId: deletePage
       responses:
         '204':
@@ -1503,11 +1499,9 @@ components:
           description: |
             `page`: free-text page
             `link`: link to another web address
-            `rss_feed`: syndicated content from an RSS feed
             `contact_form`: When the store’s contact form is used
           enum:
             - page
-            - rss_feed
             - contact_form
             - raw
             - link
@@ -1549,9 +1543,6 @@ components:
           type: string
           description: Layout template for this page. This field is writable only for stores with a Blueprint theme applied.
           example: page.html
-        feed:
-          type: string
-          description: If page type is `rss_feed` then this field is visible. Required in POST required for `rss page` type.
         link:
           type: string
           description: If page type is `link` this field is returned. Required in  POST to create a `link` page.
@@ -1609,18 +1600,16 @@ components:
           description: |
             `page`: free-text page
             `link`: link to another web address
-            `rss_feed`: syndicated content from an RSS feed
             `contact_form`: When the store’s contact form is used
           enum:
             - page
-            - rss_feed
             - contact_form
             - raw
             - link
         contact_fields:
           type: string
           description: Where the page’s type is a contact form - object whose members are the fields enabled (in the control panel) for storefront display. Possible members are:`fullname` - full name of the customer submitting the form; `phone` - customer’s phone number, as submitted on the form; `companyname`- customer’s submitted company name; `orderno`- customer’s submitted order number; `rma` - customer’s submitted RMA (Return Merchandise Authorization) number.
-          example: fullname,companyname,phone,orderno,rma  
+          example: fullname,companyname,phone,orderno,rma
         meta_description:
           type: string
           description: Description contained within this page’s `<meta/>` element. HTML to use for this page’s body when viewed in the mobile template.
@@ -1647,7 +1636,7 @@ components:
         mobile_body:
           type: string
           description: HTML to use for this page’s body when viewed in the mobile template (deprecated - Blueprint only).
-          example: '0' 
+          example: '0'
         content_type:
           type: string
           example: text/html
@@ -1659,9 +1648,6 @@ components:
           type: string
           description: Relative URL on the storefront for this page.
           example: /contact-us/
-        feed:
-          type: string
-          description: If page type is `rss_feed`, then this field is visible.
         link:
           type: string
           description: If page type is `link`, this field is returned.


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [STRF-13437]

## What changed?
<!-- Provide a bulleted list in the present tense -->
* Remove rss feed page type from public documentation

## Release notes draft
* Remove rss feed page type from a list of supported page type since it has been deprecated many years ago.

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}


[STRF-13437]: https://bigcommercecloud.atlassian.net/browse/STRF-13437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ