### PR TITLE
DEVDOCS-6417 - Deprecate shopper_language_selection_method

### DIFF
--- a/reference/settings.v3.yml
+++ b/reference/settings.v3.yml
@@ -812,7 +812,10 @@ paths:
     get:
       summary: Get Locale Settings
       operationId: getSettingsLocale
-      description: Returns global locale settings.
+      description: |-
+        Returns global locale settings.
+
+        On stores with Multi-Language enabled, the `shopper_language_selection_method` field is deprecated. Using this endpoint on those stores will return a warning about the deprecation. For additional information, refer to [Locale Configuration](/docs/store-operations/settings/locales).
       parameters:
         - $ref: '#/components/parameters/Accept'
       responses:
@@ -821,13 +824,21 @@ paths:
           content:
             application/json:
               examples:
-                Example:
+                Default Example:
                   value:
                     data:
                       default_shopper_language: en
                       shopper_language_selection_method: default_shopper_language
                       store_country: United States
                     meta: {}
+                Multi-Language Example:
+                  value:
+                    data:
+                      default_shopper_language: en
+                      shopper_language_selection_method: default_shopper_language
+                      store_country: United States
+                    meta:
+                      deprecated_fields: shopper_language_selection_method property has been replaced for the stores with Catalyst channels by the explicit list of languages enabled on a channel. For additional information please check https://developer.bigcommerce.com/docs/store-operations/settings/locales.
               schema:
                 type: object
                 properties:
@@ -842,6 +853,8 @@ paths:
       operationId: updateSettingsLocale
       description: |-
         Updates global locale settings.
+
+        On stores with Multi-Language enabled, the `shopper_language_selection_method` field is deprecated. Using this endpoint on those stores will return a warning about the deprecation. For additional information, refer to [Locale Configuration](/docs/store-operations/settings/locales).
       parameters:
         - $ref: '#/components/parameters/Accept'
         - $ref: '#/components/parameters/ContentType'
@@ -862,13 +875,21 @@ paths:
           content:
             application/json:
               examples:
-                Example:
+                Default Example:
                   value:
                     data:
                       default_shopper_language: en
                       shopper_language_selection_method: default_shopper_language
                       store_country: United States
                     meta: {}
+                Multi-Lang Example:
+                  value:
+                    data:
+                      default_shopper_language: en
+                      shopper_language_selection_method: default_shopper_language
+                      store_country: United States
+                    meta:
+                      deprecated_fields: shopper_language_selection_method property has been replaced for the stores with Catalyst channels by the explicit list of languages enabled on a channel. For additional information please check https://developer.bigcommerce.com/docs/store-operations/settings/locales.
               schema:
                 type: object
                 properties:


### PR DESCRIPTION
# [DEVDOCS-6417]

## What changed?
* On Multi-Language stores, `shopper_language_selection_method` field is deprecated.

## Release notes draft
* We've added a message on Multi-Language stores alerting them to new behaviour regarding the `shopper_language_selection_method` field

## Anything else?

ping { @bigcommerce/dev-docs-collaborators }
