### PR TITLE
ORDERS-7119 add 405 error code when method not allowed

### DIFF
--- a/reference/promotions.v3.yml
+++ b/reference/promotions.v3.yml
@@ -336,6 +336,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse403'
+        '405':
+          description: Method not allowed. Bulk code generation is only supported for promotions with redemption_type of 'COUPON' and coupon_type of 'BULK'.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
         '422':
           description: The request payload is invalid.
           content:
@@ -1254,6 +1260,20 @@ components:
           type: string
         title:
           description: 'The error title describing the particular error.'
+          type: string
+        error:
+          description: Error payload for the BigCommerce API.
+          type: string
+    ErrorResponse405:
+      type: object
+      title: 405 Error Response
+      description: The requested method is not allowed for the specified resource.
+      properties:
+        status:
+          description: Method not allowed.
+          type: string
+        title:
+          description: The error title describing the particular error.
           type: string
         error:
           description: Error payload for the BigCommerce API.


### PR DESCRIPTION
# [ORDERS-7119](https://bigcommercecloud.atlassian.net/browse/ORDERS-7119)


## What changed?
<!-- Provide a bulleted list in the present tense -->
* add 405 error code when method not allowed


## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* Update status 405 for bulk coupon codes generation
<img width="656" height="290" alt="Screenshot 2025-07-21 at 1 22 07 pm" src="https://github.com/user-attachments/assets/270538ef-d293-4f56-873b-3e33180e086f" />


## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping @bigcommerce/team-orders


[ORDERS-7119]: https://bigcommercecloud.atlassian.net/browse/ORDERS-7119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ