### PR TITLE
DEVDOCS-6452 - Add pricing validation logic callout back into Quotes (Storefront)

### DIFF
--- a/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
@@ -256,6 +256,8 @@ paths:
 
         Note the following considerations related to pricing fields in the request:
 
+        * Quotes created with this endpoint undergo a price validation check to prevent invalid prices. If the check fails, a `BigCommerce API Error` will be raised and logged, preventing quote creation.
+            *  To create quotes with custom pricing, use [Create a Quote Form (Server-to-Server)](/b2b-edition/apis/rest-management/quote#create-a-quote-form).
         * The `discount` field is present in the request body and the `productList` array; however, the value must be 0, since quote discounts are supplied by the sales rep.
         * The `offeredPrice` field on each item in the `productList` array must be provided, but it must equal the `basePrice` value for that product, since it is meant to reflect the quoted price which should not be different at this stage.
         * The `subtotal` and `grandTotal` fields must be equal to the sum of each product's `offeredPrice` multiplied by the `quantity`.


### PR DESCRIPTION
Added the information on pricing validation logic in Create a Quote, which was unintentionally removed by a subsequent PR.

# [DEVDOCS-6452](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6452)


## What changed?

* "Storefront quote creation" API calls have pricing validation logic, which triggers an error upon failure.

## Release notes draft

* We've added pricing validation to storefront quote creation.
* The validation check prevents invalid prices from being passed from the storefront.
* Custom prices are still allowed in the server-to-server endpoint.

## Anything else?

**Note to release notes compiler:** This content had originally existed in the SF Quotes reference doc, but it was unintentionally removed by [PR-902](https://github.com/bigcommerce/docs/pull/902). I've replicated the release notes draft from the original PR above.

ping @bc-terra 
