### PR TITLE
DEVDOCS-6456 - add page limit to pages v3 API spec

### DIFF
--- a/reference/pages.v3.yml
+++ b/reference/pages.v3.yml
@@ -29,10 +29,6 @@ info:
     | `raw` | A user-defined page that contains HTML markup or other stringified code. | HTML, other code |
     | `blog` | A page that contains blog posts. Use caution; `blog`-type pages can only be created in the store control panel, but you may be able to change the type of a blog page to something else with this API. Use the [blog feature of the REST Content API](/docs/rest-content/store-content/blog-posts#create-a-blog-post) to work with blog posts and tags. | empty string |
     | `link` | A link to an external absolute URL that follows [RFC 3986 standards](https://www.rfc-editor.org/rfc/rfc3986). Displays in the menu of other pages that contain markup. | &mdash; |
-
-    ### Page Limits
-
-    Web pages created via this endpoint are subject to the 4000 web page platform limit. Attempting to create pages over the limit will return an error. For more information on platform limits, see [Platform Limits (Help Center)](https://support.bigcommerce.com/s/article/Platform-Limits).
 servers:
   - url: 'https://api.bigcommerce.com/stores/{store_hash}/v3'
     variables:
@@ -84,7 +80,10 @@ paths:
       operationId: createPages
       tags:
         - Pages (Bulk)
-      description: Creates one or more content pages. This endpoint supports bulk operations.
+      description: |-
+        Creates one or more content pages. This endpoint supports bulk operations.
+
+        Web pages created via this endpoint are subject to the 4000 web page platform limit. Attempting to create pages over the limit will return an error. For more information on platform limits, see [Platform Limits (Help Center)](https://support.bigcommerce.com/s/article/Platform-Limits).
       requestBody:
         content:
           application/json:

--- a/reference/pages.v3.yml
+++ b/reference/pages.v3.yml
@@ -29,6 +29,10 @@ info:
     | `raw` | A user-defined page that contains HTML markup or other stringified code. | HTML, other code |
     | `blog` | A page that contains blog posts. Use caution; `blog`-type pages can only be created in the store control panel, but you may be able to change the type of a blog page to something else with this API. Use the [blog feature of the REST Content API](/docs/rest-content/store-content/blog-posts#create-a-blog-post) to work with blog posts and tags. | empty string |
     | `link` | A link to an external absolute URL that follows [RFC 3986 standards](https://www.rfc-editor.org/rfc/rfc3986). Displays in the menu of other pages that contain markup. | &mdash; |
+
+    ### Page Limits
+
+    Web pages created via this endpoint are subject to the 4000 web page platform limit. Attempting to create pages over the limit will return an error. For more information on platform limits, see [Platform Limits (Help Center)](https://support.bigcommerce.com/s/article/Platform-Limits).
 servers:
   - url: 'https://api.bigcommerce.com/stores/{store_hash}/v3'
     variables:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6456]


## What changed?
* Added 4000 page limit to pages v3 api spec

## Release notes draft
The Pages v3 API Spec now includes page limits for reference.

ping @bc-terra


[DEVDOCS-6456]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ