### PR TITLE
DEVDOCS-6453 - add resourceId to translation gql docs

### DIFF
--- a/docs/store-operations/translations/brands.mdx
+++ b/docs/store-operations/translations/brands.mdx
@@ -18,12 +18,14 @@ Below are examples of GraphQL queries and mutations for retrieving and managing 
 
 ### Query translations
 
+#### Query a list of translations
+
 This query returns a paginated list of translations by resourceType, channel and locale with a maximum of 50 results per request.  
 
 <Tabs items={['Request', 'Response']}>
 <Tab>
 
-```graphql filename="Example mutation: Query a translation" showLineNumbers copy
+```graphql filename="Example query: Query a translation" showLineNumbers copy
 GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
 X-Auth-Token: {{token}}
 
@@ -96,6 +98,97 @@ query {
               ]
             },
             "cursor": "eyJpZCI6MjR9"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+#### Query a translation by resourceId
+
+<Callout type='warning'>
+	When querying a translation by resourceId, you must provide the full resourceId in the format `bc/store/brand/{brand_id}`.
+</Callout>
+
+This query returns a translation by resourceId.
+
+<Tabs items={['Request', 'Response']}>
+<Tab>
+
+```graphql filename="Example query: Query a translation by resource id" showLineNumbers copy
+GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
+X-Auth-Token: {{token}}
+
+query {
+  store {
+    translations(filters: {
+        resourceId: "bc/store/brand/24"
+      }) {
+      edges {
+        node {
+          resourceId
+            fields {
+              fieldName
+              original
+              translation
+            }
+          }
+      }
+    }
+  }
+}
+```
+
+</Tab>
+<Tab>
+
+```json filename="Example query: Query a translation by resource id" showLineNumbers copy
+{
+  "data": {
+    "store": {
+      "translations": {
+        "edges": [
+          {
+            "node": {
+              "resourceId": "bc/store/brand/24",
+              "fields": [
+                {
+                  "fieldName": "name",
+                  "original": "my channel level brands",
+                  "translation": "name (OVR) 1"
+                },
+                {
+                  "fieldName": "description",
+                  "original": "<p>my channel level brands description</p>",
+                  "translation": "description (OVR)"
+                },
+                {
+                  "fieldName": "page_title",
+                  "original": "Second Home page title",
+                  "translation": "page_title (OVR)"
+                },
+                {
+                  "fieldName": "meta_description",
+                  "original": "Second Meta description",
+                  "translation": "meta_description (OVR)"
+                },
+                {
+                  "fieldName": "meta_keywords",
+                  "original": "Second Meta Keywords",
+                  "translation": "meta keywords (OVR)"
+                },
+                {
+                  "fieldName": "search_keywords",
+                  "original": "Second Search keywords",
+                  "translation": "search_keywords (OVR)"
+                }
+              ]
+            }
           }
         ]
       }

--- a/docs/store-operations/translations/brands.mdx
+++ b/docs/store-operations/translations/brands.mdx
@@ -25,7 +25,7 @@ This query returns a paginated list of translations by resourceType, channel and
 <Tabs items={['Request', 'Response']}>
 <Tab>
 
-```graphql filename="Example query: Query a translation" showLineNumbers copy
+```graphql filename="Example query: Query a list of translations" showLineNumbers copy
 GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
 X-Auth-Token: {{token}}
 
@@ -55,7 +55,7 @@ query {
 </Tab>
 <Tab>
 
-```json filename="Example query: Query a translation" showLineNumbers copy
+```json filename="Example query: Query a list of translations" showLineNumbers copy
 {
   "data": {
     "store": {

--- a/docs/store-operations/translations/brands.mdx
+++ b/docs/store-operations/translations/brands.mdx
@@ -218,51 +218,50 @@ GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
 X-Auth-Token: {{token}}
 
 mutation {
-translation {
-updateTranslations(input: {
-resourceType: BRANDS,
-channelId: "bc/store/channel/1",
-localeId: "bc/store/locale/en",
-entities: [
-{
-resourceId: "bc/store/brand/18",
-fields: [
-{
-fieldName: "name",
-value: "name (OVR)"
-},
-{
-fieldName: "page_title",
-value: "page_title (OVR)"
-},
-{
-fieldName: "meta_description",
-value: "meta_description (OVR)"
-},
-{
-fieldName: "meta_keywords",
-value: "meta keywords (OVR)"
-},
-{
-fieldName: "search_keywords",
-value: "search_keywords (OVR)"
+  translation {
+    updateTranslations(input: {
+      resourceType: BRANDS,
+      channelId: "bc/store/channel/1",
+      localeId: "bc/store/locale/en",
+      entities: [
+        {
+          resourceId: "bc/store/brand/18",
+          fields: [
+            {
+              fieldName: "name",
+              value: "name (OVR)"
+            },
+            {
+              fieldName: "page_title",
+              value: "page_title (OVR)"
+            },
+            {
+              fieldName: "meta_description",
+              value: "meta_description (OVR)"
+            },
+            {
+              fieldName: "meta_keywords",
+              value: "meta keywords (OVR)"
+            },
+            {
+              fieldName: "search_keywords",
+              value: "search_keywords (OVR)"
+            }
+          ]
+        }
+      ]
+    }) {
+      __typename
+      errors {
+        __typename
+        ... on Error {
+          message
+        }
+      }
+    }
+  }
 }
-]
-}
-]
-}) {
-**typename
-errors {
-**typename
-... on Error {
-message
-}
-}
-}
-}
-}
-
-````
+```
 
 </Tab>
 <Tab>

--- a/docs/store-operations/translations/brands.mdx
+++ b/docs/store-operations/translations/brands.mdx
@@ -1,16 +1,17 @@
 # Translations for Brands (Beta)
 
-<Callout type="info">
-The Translations Admin GraphQL API is currently available on Catalyst storefronts only.
+<Callout type='info'>
+	The Translations Admin GraphQL API is currently available on Catalyst
+	storefronts only.
 </Callout>
 
 The brands translatable fields are:
 
-* Name
-* Page Title
-* Meta Keywords
-* Meta Description
-* Search Keywords
+- Name
+- Page Title
+- Meta Keywords
+- Meta Description
+- Search Keywords
 
 ## Examples
 
@@ -20,7 +21,7 @@ Below are examples of GraphQL queries and mutations for retrieving and managing 
 
 #### Query a list of translations
 
-This query returns a paginated list of translations by resourceType, channel and locale with a maximum of 50 results per request.  
+This query returns a paginated list of translations by resourceType, channel and locale with a maximum of 50 results per request.
 
 <Tabs items={['Request', 'Response']}>
 <Tab>
@@ -57,52 +58,52 @@ query {
 
 ```json filename="Example query: Query a list of translations" showLineNumbers copy
 {
-  "data": {
-    "store": {
-      "translations": {
-        "edges": [
-          {
-            "node": {
-              "resourceId": "bc/store/brand/24",
-              "fields": [
-                {
-                  "fieldName": "name",
-                  "original": "my channel level brands",
-                  "translation": "name (OVR) 1"
-                },
-                {
-                  "fieldName": "description",
-                  "original": "<p>my channel level brands description</p>",
-                  "translation": "description (OVR)"
-                },
-                {
-                  "fieldName": "page_title",
-                  "original": "Second Home page title",
-                  "translation": "page_title (OVR)"
-                },
-                {
-                  "fieldName": "meta_description",
-                  "original": "Second Meta description",
-                  "translation": "meta_description (OVR)"
-                },
-                {
-                  "fieldName": "meta_keywords",
-                  "original": "Second Meta Keywords",
-                  "translation": "meta keywords (OVR)"
-                },
-                {
-                  "fieldName": "search_keywords",
-                  "original": "Second Search keywords",
-                  "translation": "search_keywords (OVR)"
-                }
-              ]
-            },
-            "cursor": "eyJpZCI6MjR9"
-          }
-        ]
-      }
-    }
-  }
+	"data": {
+		"store": {
+			"translations": {
+				"edges": [
+					{
+						"node": {
+							"resourceId": "bc/store/brand/24",
+							"fields": [
+								{
+									"fieldName": "name",
+									"original": "my channel level brands",
+									"translation": "name (OVR) 1"
+								},
+								{
+									"fieldName": "description",
+									"original": "<p>my channel level brands description</p>",
+									"translation": "description (OVR)"
+								},
+								{
+									"fieldName": "page_title",
+									"original": "Second Home page title",
+									"translation": "page_title (OVR)"
+								},
+								{
+									"fieldName": "meta_description",
+									"original": "Second Meta description",
+									"translation": "meta_description (OVR)"
+								},
+								{
+									"fieldName": "meta_keywords",
+									"original": "Second Meta Keywords",
+									"translation": "meta keywords (OVR)"
+								},
+								{
+									"fieldName": "search_keywords",
+									"original": "Second Search keywords",
+									"translation": "search_keywords (OVR)"
+								}
+							]
+						},
+						"cursor": "eyJpZCI6MjR9"
+					}
+				]
+			}
+		}
+	}
 }
 ```
 
@@ -112,7 +113,8 @@ query {
 #### Query a translation by resourceId
 
 <Callout type='warning'>
-	When querying a translation by resourceId, you must provide the full resourceId in the format `bc/store/brand/{brand_id}`.
+	When querying a translation by resourceId, you must provide the full
+	resourceId in the format `bc/store/brand/{brand_id}`.
 </Callout>
 
 This query returns a translation by resourceId.
@@ -125,22 +127,26 @@ GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
 X-Auth-Token: {{token}}
 
 query {
-  store {
-    translations(filters: {
-        resourceId: "bc/store/brand/24"
-      }) {
-      edges {
-        node {
-          resourceId
-            fields {
-              fieldName
-              original
-              translation
+    store {
+        translations(filters: {
+            resourceType: BRANDS,
+            channelId: "bc/store/channel/2",
+            localeId: "bc/store/locale/it",
+            resourceIds: ["bc/store/brand/37"]
+        }) {
+            edges {
+                node {
+                      resourceId
+                        fields {
+                            fieldName
+                            original
+                            translation
+                        }
+                    }
+                cursor
             }
-          }
-      }
+        }
     }
-  }
 }
 ```
 
@@ -149,51 +155,52 @@ query {
 
 ```json filename="Example query: Query a translation by resource id" showLineNumbers copy
 {
-  "data": {
-    "store": {
-      "translations": {
-        "edges": [
-          {
-            "node": {
-              "resourceId": "bc/store/brand/24",
-              "fields": [
-                {
-                  "fieldName": "name",
-                  "original": "my channel level brands",
-                  "translation": "name (OVR) 1"
-                },
-                {
-                  "fieldName": "description",
-                  "original": "<p>my channel level brands description</p>",
-                  "translation": "description (OVR)"
-                },
-                {
-                  "fieldName": "page_title",
-                  "original": "Second Home page title",
-                  "translation": "page_title (OVR)"
-                },
-                {
-                  "fieldName": "meta_description",
-                  "original": "Second Meta description",
-                  "translation": "meta_description (OVR)"
-                },
-                {
-                  "fieldName": "meta_keywords",
-                  "original": "Second Meta Keywords",
-                  "translation": "meta keywords (OVR)"
-                },
-                {
-                  "fieldName": "search_keywords",
-                  "original": "Second Search keywords",
-                  "translation": "search_keywords (OVR)"
-                }
-              ]
-            }
-          }
-        ]
-      }
-    }
-  }
+	"data": {
+		"store": {
+			"translations": {
+				"edges": [
+					{
+						"node": {
+							"resourceId": "bc/store/brand/37",
+							"fields": [
+								{
+									"fieldName": "name",
+									"original": "my channel level brands",
+									"translation": "name (OVR) 1"
+								},
+								{
+									"fieldName": "description",
+									"original": "<p>my channel level brands description</p>",
+									"translation": "description (OVR)"
+								},
+								{
+									"fieldName": "page_title",
+									"original": "Second Home page title",
+									"translation": "page_title (OVR)"
+								},
+								{
+									"fieldName": "meta_description",
+									"original": "Second Meta description",
+									"translation": "meta_description (OVR)"
+								},
+								{
+									"fieldName": "meta_keywords",
+									"original": "Second Meta Keywords",
+									"translation": "meta keywords (OVR)"
+								},
+								{
+									"fieldName": "search_keywords",
+									"original": "Second Search keywords",
+									"translation": "search_keywords (OVR)"
+								}
+							]
+						},
+						"cursor": "eyJpZCI6MjR9"
+					}
+				]
+			}
+		}
+	}
 }
 ```
 
@@ -211,50 +218,51 @@ GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
 X-Auth-Token: {{token}}
 
 mutation {
-  translation {
-    updateTranslations(input: {
-      resourceType: BRANDS,
-      channelId: "bc/store/channel/1",
-      localeId: "bc/store/locale/en",
-      entities: [
-        {
-          resourceId: "bc/store/brand/18",
-          fields: [
-            {
-              fieldName: "name",
-              value: "name (OVR)"
-            },
-            {
-              fieldName: "page_title",
-              value: "page_title (OVR)"
-            },
-            {
-              fieldName: "meta_description",
-              value: "meta_description (OVR)"
-            },
-            {
-              fieldName: "meta_keywords",
-              value: "meta keywords (OVR)"
-            },
-            {
-              fieldName: "search_keywords",
-              value: "search_keywords (OVR)"
-            }
-          ]
-        }
-      ]
-    }) {
-      __typename
-      errors {
-        __typename
-        ... on Error {
-          message
-        }
-      }
-    }
-  }
+translation {
+updateTranslations(input: {
+resourceType: BRANDS,
+channelId: "bc/store/channel/1",
+localeId: "bc/store/locale/en",
+entities: [
+{
+resourceId: "bc/store/brand/18",
+fields: [
+{
+fieldName: "name",
+value: "name (OVR)"
+},
+{
+fieldName: "page_title",
+value: "page_title (OVR)"
+},
+{
+fieldName: "meta_description",
+value: "meta_description (OVR)"
+},
+{
+fieldName: "meta_keywords",
+value: "meta keywords (OVR)"
+},
+{
+fieldName: "search_keywords",
+value: "search_keywords (OVR)"
 }
-```
+]
+}
+]
+}) {
+**typename
+errors {
+**typename
+... on Error {
+message
+}
+}
+}
+}
+}
+
+````
 
 </Tab>
 <Tab>
@@ -270,7 +278,7 @@ mutation {
     }
   }
 }
-```
+````
 
 </Tab>
 </Tabs>
@@ -316,14 +324,14 @@ mutation {
 
 ```json filename="Example mutation: Delete a translation" showLineNumbers copy
 {
-  "data": {
-    "translation": {
-      "deleteTranslations": {
-        "__typename": "DeleteTranslationsResult",
-        "errors": []
-      }
-    }
-  }
+	"data": {
+		"translation": {
+			"deleteTranslations": {
+				"__typename": "DeleteTranslationsResult",
+				"errors": []
+			}
+		}
+	}
 }
 ```
 

--- a/docs/store-operations/translations/brands.mdx
+++ b/docs/store-operations/translations/brands.mdx
@@ -132,7 +132,7 @@ query {
             resourceType: BRANDS,
             channelId: "bc/store/channel/2",
             localeId: "bc/store/locale/it",
-            resourceIds: ["bc/store/brand/37"]
+            resourceIds: ["bc/store/brand/1", "bc/store/brand/2"]
         }) {
             edges {
                 node {
@@ -161,7 +161,7 @@ query {
 				"edges": [
 					{
 						"node": {
-							"resourceId": "bc/store/brand/37",
+							"resourceId": "bc/store/brand/1",
 							"fields": [
 								{
 									"fieldName": "name",
@@ -196,6 +196,44 @@ query {
 							]
 						},
 						"cursor": "eyJpZCI6MjR9"
+					},
+          {
+						"node": {
+							"resourceId": "bc/store/brand/2",
+							"fields": [
+								{
+									"fieldName": "name",
+									"original": "my channel level brands",
+									"translation": "name (OVR) 1"
+								},
+								{
+									"fieldName": "description",
+									"original": "<p>my channel level brands description</p>",
+									"translation": "description (OVR)"
+								},
+								{
+									"fieldName": "page_title",
+									"original": "Second Home page title",
+									"translation": "page_title (OVR)"
+								},
+								{
+									"fieldName": "meta_description",
+									"original": "Second Meta description",
+									"translation": "meta_description (OVR)"
+								},
+								{
+									"fieldName": "meta_keywords",
+									"original": "Second Meta Keywords",
+									"translation": "meta keywords (OVR)"
+								},
+								{
+									"fieldName": "search_keywords",
+									"original": "Second Search keywords",
+									"translation": "search_keywords (OVR)"
+								}
+							]
+						},
+						"cursor": "eyJpZCI6MjJ7"
 					}
 				]
 			}

--- a/docs/store-operations/translations/categories.mdx
+++ b/docs/store-operations/translations/categories.mdx
@@ -128,7 +128,7 @@ query {
             resourceType: CATEGORIES,
             channelId: "bc/store/channel/2",
             localeId: "bc/store/locale/it",
-            resourceIds: ["bc/store/category/28"]
+            resourceIds: ["bc/store/category/1", "bc/store/category/2"]
         }) {
             edges {
                 node {
@@ -157,7 +157,7 @@ query {
 				"edges": [
 					{
 						"node": {
-							"resourceId": "bc/store/category/28",
+							"resourceId": "bc/store/category/1",
 							"fields": [
 								{
 									"fieldName": "name",
@@ -187,6 +187,39 @@ query {
 							]
 						},
 						"cursor": "eyJpZCI6MjR9"
+					},
+          {
+						"node": {
+							"resourceId": "bc/store/category/2",
+							"fields": [
+								{
+									"fieldName": "name",
+									"original": "my channel level categories",
+									"translation": "name (OVR) 1"
+								},
+								{
+									"fieldName": "description",
+									"original": "<p>my channel level categories description</p>",
+									"translation": "description (OVR)"
+								},
+								{
+									"fieldName": "page_title",
+									"original": "Second Home page title",
+									"translation": "page_title (OVR)"
+								},
+								{
+									"fieldName": "meta_description",
+									"original": "Second Meta description",
+									"translation": "meta_description (OVR)"
+								},
+								{
+									"fieldName": "search_keywords",
+									"original": "Second Search keywords",
+									"translation": "search_keywords (OVR)"
+								}
+							]
+						},
+						"cursor": "eyJpZCI6MjJ7"
 					}
 				]
 			}

--- a/docs/store-operations/translations/categories.mdx
+++ b/docs/store-operations/translations/categories.mdx
@@ -209,51 +209,50 @@ GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
 X-Auth-Token: {{token}}
 
 mutation {
-translation {
-updateTranslations(input: {
-resourceType: CATEGORIES,
-channelId: "bc/store/channel/1",
-localeId: "bc/store/locale/en",
-entities: [
-{
-resourceId: "bc/store/category/18",
-fields: [
-{
-fieldName: "name",
-value: "name (OVR)"
-},
-{
-fieldName: "description",
-value: "description (OVR)"
-},
-{
-fieldName: "page_title",
-value: "page_title (OVR)"
-},
-{
-fieldName: "meta_description",
-value: "meta_description (OVR)"
-},
-{
-fieldName: "search_keywords",
-value: "search_keywords (OVR)"
+  translation {
+    updateTranslations(input: {
+      resourceType: CATEGORIES,
+      channelId: "bc/store/channel/1",
+      localeId: "bc/store/locale/en",
+      entities: [
+        {
+          resourceId: "bc/store/category/18",
+          fields: [
+            {
+              fieldName: "name",
+              value: "name (OVR)"
+            },
+            {
+              fieldName: "description",
+              value: "description (OVR)"
+            },
+            {
+              fieldName: "page_title",
+              value: "page_title (OVR)"
+            },
+            {
+              fieldName: "meta_description",
+              value: "meta_description (OVR)"
+            },
+            {
+              fieldName: "search_keywords",
+              value: "search_keywords (OVR)"
+            }
+          ]
+        }
+      ]
+    }) {
+      __typename
+      errors {
+        __typename
+        ... on Error {
+          message
+        }
+      }
+    }
+  }
 }
-]
-}
-]
-}) {
-**typename
-errors {
-**typename
-... on Error {
-message
-}
-}
-}
-}
-}
-
-````
+```
 
 </Tab>
 <Tab>

--- a/docs/store-operations/translations/categories.mdx
+++ b/docs/store-operations/translations/categories.mdx
@@ -1,17 +1,18 @@
 # Translations for Categories (Beta)
 
-<Callout type="info">
-The Translations Admin GraphQL API is currently available on Catalyst storefronts only.
+<Callout type='info'>
+	The Translations Admin GraphQL API is currently available on Catalyst
+	storefronts only.
 </Callout>
 
 The categories translatable fields are:
 
-* Name
-* Description
-* Page Title
-* Meta Keywords
-* Meta Description
-* Search Keywords
+- Name
+- Description
+- Page Title
+- Meta Keywords
+- Meta Description
+- Search Keywords
 
 ## Examples
 
@@ -21,7 +22,7 @@ Below are examples of GraphQL queries and mutations for retrieving and managing 
 
 #### Query a list of translations
 
-This query returns a paginated list of translations by resourceType, channel and locale with a maximum of 50 results per request.  
+This query returns a paginated list of translations by resourceType, channel and locale with a maximum of 50 results per request.
 
 <Tabs items={['Request', 'Response']}>
 <Tab>
@@ -58,47 +59,47 @@ query {
 
 ```json filename="Example query: Query a list of translations" showLineNumbers copy
 {
-  "data": {
-    "store": {
-      "translations": {
-        "edges": [
-          {
-            "node": {
-              "resourceId": "bc/store/category/24",
-              "fields": [
-                {
-                  "fieldName": "name",
-                  "original": "my channel level categories",
-                  "translation": "name (OVR) 1"
-                },
-                {
-                  "fieldName": "description",
-                  "original": "<p>my channel level categories description</p>",
-                  "translation": "description (OVR)"
-                },
-                {
-                  "fieldName": "page_title",
-                  "original": "Second Home page title",
-                  "translation": "page_title (OVR)"
-                },
-                {
-                  "fieldName": "meta_description",
-                  "original": "Second Meta description",
-                  "translation": "meta_description (OVR)"
-                },
-                {
-                  "fieldName": "search_keywords",
-                  "original": "Second Search keywords",
-                  "translation": "search_keywords (OVR)"
-                }
-              ]
-            },
-            "cursor": "eyJpZCI6MjR9"
-          }
-        ]
-      }
-    }
-  }
+	"data": {
+		"store": {
+			"translations": {
+				"edges": [
+					{
+						"node": {
+							"resourceId": "bc/store/category/24",
+							"fields": [
+								{
+									"fieldName": "name",
+									"original": "my channel level categories",
+									"translation": "name (OVR) 1"
+								},
+								{
+									"fieldName": "description",
+									"original": "<p>my channel level categories description</p>",
+									"translation": "description (OVR)"
+								},
+								{
+									"fieldName": "page_title",
+									"original": "Second Home page title",
+									"translation": "page_title (OVR)"
+								},
+								{
+									"fieldName": "meta_description",
+									"original": "Second Meta description",
+									"translation": "meta_description (OVR)"
+								},
+								{
+									"fieldName": "search_keywords",
+									"original": "Second Search keywords",
+									"translation": "search_keywords (OVR)"
+								}
+							]
+						},
+						"cursor": "eyJpZCI6MjR9"
+					}
+				]
+			}
+		}
+	}
 }
 ```
 
@@ -108,7 +109,8 @@ query {
 #### Query a translation by resourceId
 
 <Callout type='warning'>
-	When querying a translation by resourceId, you must provide the full resourceId in the format `bc/store/category/{category_id}`.
+	When querying a translation by resourceId, you must provide the full
+	resourceId in the format `bc/store/category/{category_id}`.
 </Callout>
 
 This query returns a translation by resourceId.
@@ -121,22 +123,26 @@ GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
 X-Auth-Token: {{token}}
 
 query {
-  store {
-    translations(filters: {
-        resourceId: "bc/store/category/24"
-      }) {
-      edges {
-        node {
-          resourceId
-            fields {
-              fieldName
-              original
-              translation
+    store {
+        translations(filters: {
+            resourceType: CATEGORIES,
+            channelId: "bc/store/channel/2",
+            localeId: "bc/store/locale/it",
+            resourceIds: ["bc/store/category/28"]
+        }) {
+            edges {
+                node {
+                      resourceId
+                        fields {
+                            fieldName
+                            original
+                            translation
+                        }
+                    }
+                cursor
             }
-          }
-      }
+        }
     }
-  }
 }
 ```
 
@@ -145,52 +151,52 @@ query {
 
 ```json filename="Example query: Query a translation by id" showLineNumbers copy
 {
-  "data": {
-    "store": {
-      "translations": {
-        "edges": [
-          {
-            "node": {
-              "resourceId": "bc/store/category/24",
-              "fields": [
-                {
-                  "fieldName": "name",
-                  "original": "my channel level categories",
-                  "translation": "name (OVR) 1"
-                },
-                {
-                  "fieldName": "description",
-                  "original": "<p>my channel level categories description</p>",
-                  "translation": "description (OVR)"
-                },
-                {
-                  "fieldName": "page_title",
-                  "original": "Second Home page title",
-                  "translation": "page_title (OVR)"
-                },
-                {
-                  "fieldName": "meta_description",
-                  "original": "Second Meta description",
-                  "translation": "meta_description (OVR)"
-                },
-                {
-                  "fieldName": "search_keywords",
-                  "original": "Second Search keywords",
-                  "translation": "search_keywords (OVR)"
-                }
-              ]
-            },
-          }
-        ]
-      }
-    }
-  }
+	"data": {
+		"store": {
+			"translations": {
+				"edges": [
+					{
+						"node": {
+							"resourceId": "bc/store/category/28",
+							"fields": [
+								{
+									"fieldName": "name",
+									"original": "my channel level categories",
+									"translation": "name (OVR) 1"
+								},
+								{
+									"fieldName": "description",
+									"original": "<p>my channel level categories description</p>",
+									"translation": "description (OVR)"
+								},
+								{
+									"fieldName": "page_title",
+									"original": "Second Home page title",
+									"translation": "page_title (OVR)"
+								},
+								{
+									"fieldName": "meta_description",
+									"original": "Second Meta description",
+									"translation": "meta_description (OVR)"
+								},
+								{
+									"fieldName": "search_keywords",
+									"original": "Second Search keywords",
+									"translation": "search_keywords (OVR)"
+								}
+							]
+						},
+						"cursor": "eyJpZCI6MjR9"
+					}
+				]
+			}
+		}
+	}
 }
 ```
 
 </Tab>
 </Tabs>
-
 
 ### Update a translation
 
@@ -203,50 +209,51 @@ GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
 X-Auth-Token: {{token}}
 
 mutation {
-  translation {
-    updateTranslations(input: {
-      resourceType: CATEGORIES,
-      channelId: "bc/store/channel/1",
-      localeId: "bc/store/locale/en",
-      entities: [
-        {
-          resourceId: "bc/store/category/18",
-          fields: [
-            {
-              fieldName: "name",
-              value: "name (OVR)"
-            },
-            {
-              fieldName: "description",
-              value: "description (OVR)"
-            },
-            {
-              fieldName: "page_title",
-              value: "page_title (OVR)"
-            },
-            {
-              fieldName: "meta_description",
-              value: "meta_description (OVR)"
-            },
-            {
-              fieldName: "search_keywords",
-              value: "search_keywords (OVR)"
-            }
-          ]
-        }
-      ]
-    }) {
-      __typename
-      errors {
-        __typename
-        ... on Error {
-          message
-        }
-      }
-    }
-  }
+translation {
+updateTranslations(input: {
+resourceType: CATEGORIES,
+channelId: "bc/store/channel/1",
+localeId: "bc/store/locale/en",
+entities: [
+{
+resourceId: "bc/store/category/18",
+fields: [
+{
+fieldName: "name",
+value: "name (OVR)"
+},
+{
+fieldName: "description",
+value: "description (OVR)"
+},
+{
+fieldName: "page_title",
+value: "page_title (OVR)"
+},
+{
+fieldName: "meta_description",
+value: "meta_description (OVR)"
+},
+{
+fieldName: "search_keywords",
+value: "search_keywords (OVR)"
 }
-```
+]
+}
+]
+}) {
+**typename
+errors {
+**typename
+... on Error {
+message
+}
+}
+}
+}
+}
+
+````
 
 </Tab>
 <Tab>
@@ -262,7 +269,7 @@ mutation {
     }
   }
 }
-```
+````
 
 </Tab>
 </Tabs>
@@ -308,14 +315,14 @@ mutation {
 
 ```json filename="Example mutation: Delete a translation" showLineNumbers copy
 {
-  "data": {
-    "translation": {
-      "deleteTranslations": {
-        "__typename": "DeleteTranslationsResult",
-        "errors": []
-      }
-    }
-  }
+	"data": {
+		"translation": {
+			"deleteTranslations": {
+				"__typename": "DeleteTranslationsResult",
+				"errors": []
+			}
+		}
+	}
 }
 ```
 

--- a/docs/store-operations/translations/categories.mdx
+++ b/docs/store-operations/translations/categories.mdx
@@ -1,18 +1,17 @@
 # Translations for Categories (Beta)
 
-<Callout type='info'>
-	The Translations Admin GraphQL API is currently available on Catalyst
-	storefronts only.
+<Callout type="info">
+The Translations Admin GraphQL API is currently available on Catalyst storefronts only.
 </Callout>
 
 The categories translatable fields are:
 
-- Name
-- Description
-- Page Title
-- Meta Keywords
-- Meta Description
-- Search Keywords
+* Name
+* Description
+* Page Title
+* Meta Keywords
+* Meta Description
+* Search Keywords
 
 ## Examples
 
@@ -22,12 +21,12 @@ Below are examples of GraphQL queries and mutations for retrieving and managing 
 
 #### Query a list of translations
 
-This query returns a paginated list of translations by resourceType, channel and locale with a maximum of 50 results per request.
+This query returns a paginated list of translations by resourceType, channel and locale with a maximum of 50 results per request.  
 
 <Tabs items={['Request', 'Response']}>
 <Tab>
 
-```graphql filename="Example query: Query a translation" showLineNumbers copy
+```graphql filename="Example query: Query a list of translations" showLineNumbers copy
 GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
 X-Auth-Token: {{token}}
 
@@ -57,49 +56,49 @@ query {
 </Tab>
 <Tab>
 
-```json filename="Example query: Query a translation" showLineNumbers copy
+```json filename="Example query: Query a list of translations" showLineNumbers copy
 {
-	"data": {
-		"store": {
-			"translations": {
-				"edges": [
-					{
-						"node": {
-							"resourceId": "bc/store/category/24",
-							"fields": [
-								{
-									"fieldName": "name",
-									"original": "my channel level categories",
-									"translation": "name (OVR) 1"
-								},
-								{
-									"fieldName": "description",
-									"original": "<p>my channel level categories description</p>",
-									"translation": "description (OVR)"
-								},
-								{
-									"fieldName": "page_title",
-									"original": "Second Home page title",
-									"translation": "page_title (OVR)"
-								},
-								{
-									"fieldName": "meta_description",
-									"original": "Second Meta description",
-									"translation": "meta_description (OVR)"
-								},
-								{
-									"fieldName": "search_keywords",
-									"original": "Second Search keywords",
-									"translation": "search_keywords (OVR)"
-								}
-							]
-						},
-						"cursor": "eyJpZCI6MjR9"
-					}
-				]
-			}
-		}
-	}
+  "data": {
+    "store": {
+      "translations": {
+        "edges": [
+          {
+            "node": {
+              "resourceId": "bc/store/category/24",
+              "fields": [
+                {
+                  "fieldName": "name",
+                  "original": "my channel level categories",
+                  "translation": "name (OVR) 1"
+                },
+                {
+                  "fieldName": "description",
+                  "original": "<p>my channel level categories description</p>",
+                  "translation": "description (OVR)"
+                },
+                {
+                  "fieldName": "page_title",
+                  "original": "Second Home page title",
+                  "translation": "page_title (OVR)"
+                },
+                {
+                  "fieldName": "meta_description",
+                  "original": "Second Meta description",
+                  "translation": "meta_description (OVR)"
+                },
+                {
+                  "fieldName": "search_keywords",
+                  "original": "Second Search keywords",
+                  "translation": "search_keywords (OVR)"
+                }
+              ]
+            },
+            "cursor": "eyJpZCI6MjR9"
+          }
+        ]
+      }
+    }
+  }
 }
 ```
 
@@ -109,8 +108,7 @@ query {
 #### Query a translation by resourceId
 
 <Callout type='warning'>
-	When querying a translation by resourceId, you must provide the full
-	resourceId in the format `bc/store/category/{category_id}`.
+	When querying a translation by resourceId, you must provide the full resourceId in the format `bc/store/category/{category_id}`.
 </Callout>
 
 This query returns a translation by resourceId.
@@ -118,7 +116,7 @@ This query returns a translation by resourceId.
 <Tabs items={['Request', 'Response']}>
 <Tab>
 
-```graphql filename="Example query: Query a translation by resource id" showLineNumbers copy
+```graphql filename="Example query: Query a translation by id" showLineNumbers copy
 GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
 X-Auth-Token: {{token}}
 
@@ -144,53 +142,55 @@ query {
 
 </Tab>
 <Tab>
-```json filename="Example query: Query a translation by resource id" showLineNumbers copy
+
+```json filename="Example query: Query a translation by id" showLineNumbers copy
 {
-	"data": {
-		"store": {
-			"translations": {
-				"edges": [
-					{
-						"node": {
-							"resourceId": "bc/store/category/24",
-							"fields": [
-								{
-									"fieldName": "name",
-									"original": "my channel level categories",
-									"translation": "name (OVR) 1"
-								},
-								{
-									"fieldName": "description",
-									"original": "<p>my channel level categories description</p>",
-									"translation": "description (OVR)"
-								},
-								{
-									"fieldName": "page_title",
-									"original": "Second Home page title",
-									"translation": "page_title (OVR)"
-								},
-								{
-									"fieldName": "meta_description",
-									"original": "Second Meta description",
-									"translation": "meta_description (OVR)"
-								},
-								{
-									"fieldName": "search_keywords",
-									"original": "Second Search keywords",
-									"translation": "search_keywords (OVR)"
-								}
-							]
-						}
-					}
-				]
-			}
-		}
-	}
+  "data": {
+    "store": {
+      "translations": {
+        "edges": [
+          {
+            "node": {
+              "resourceId": "bc/store/category/24",
+              "fields": [
+                {
+                  "fieldName": "name",
+                  "original": "my channel level categories",
+                  "translation": "name (OVR) 1"
+                },
+                {
+                  "fieldName": "description",
+                  "original": "<p>my channel level categories description</p>",
+                  "translation": "description (OVR)"
+                },
+                {
+                  "fieldName": "page_title",
+                  "original": "Second Home page title",
+                  "translation": "page_title (OVR)"
+                },
+                {
+                  "fieldName": "meta_description",
+                  "original": "Second Meta description",
+                  "translation": "meta_description (OVR)"
+                },
+                {
+                  "fieldName": "search_keywords",
+                  "original": "Second Search keywords",
+                  "translation": "search_keywords (OVR)"
+                }
+              ]
+            },
+          }
+        ]
+      }
+    }
+  }
 }
 ```
 
 </Tab>
 </Tabs>
+
 
 ### Update a translation
 
@@ -203,51 +203,50 @@ GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
 X-Auth-Token: {{token}}
 
 mutation {
-translation {
-updateTranslations(input: {
-resourceType: CATEGORIES,
-channelId: "bc/store/channel/1",
-localeId: "bc/store/locale/en",
-entities: [
-{
-resourceId: "bc/store/category/18",
-fields: [
-{
-fieldName: "name",
-value: "name (OVR)"
-},
-{
-fieldName: "description",
-value: "description (OVR)"
-},
-{
-fieldName: "page_title",
-value: "page_title (OVR)"
-},
-{
-fieldName: "meta_description",
-value: "meta_description (OVR)"
-},
-{
-fieldName: "search_keywords",
-value: "search_keywords (OVR)"
+  translation {
+    updateTranslations(input: {
+      resourceType: CATEGORIES,
+      channelId: "bc/store/channel/1",
+      localeId: "bc/store/locale/en",
+      entities: [
+        {
+          resourceId: "bc/store/category/18",
+          fields: [
+            {
+              fieldName: "name",
+              value: "name (OVR)"
+            },
+            {
+              fieldName: "description",
+              value: "description (OVR)"
+            },
+            {
+              fieldName: "page_title",
+              value: "page_title (OVR)"
+            },
+            {
+              fieldName: "meta_description",
+              value: "meta_description (OVR)"
+            },
+            {
+              fieldName: "search_keywords",
+              value: "search_keywords (OVR)"
+            }
+          ]
+        }
+      ]
+    }) {
+      __typename
+      errors {
+        __typename
+        ... on Error {
+          message
+        }
+      }
+    }
+  }
 }
-]
-}
-]
-}) {
-**typename
-errors {
-**typename
-... on Error {
-message
-}
-}
-}
-}
-}
-
-````
+```
 
 </Tab>
 <Tab>
@@ -263,7 +262,7 @@ message
     }
   }
 }
-````
+```
 
 </Tab>
 </Tabs>
@@ -309,14 +308,14 @@ mutation {
 
 ```json filename="Example mutation: Delete a translation" showLineNumbers copy
 {
-	"data": {
-		"translation": {
-			"deleteTranslations": {
-				"__typename": "DeleteTranslationsResult",
-				"errors": []
-			}
-		}
-	}
+  "data": {
+    "translation": {
+      "deleteTranslations": {
+        "__typename": "DeleteTranslationsResult",
+        "errors": []
+      }
+    }
+  }
 }
 ```
 

--- a/docs/store-operations/translations/categories.mdx
+++ b/docs/store-operations/translations/categories.mdx
@@ -1,17 +1,18 @@
 # Translations for Categories (Beta)
 
-<Callout type="info">
-The Translations Admin GraphQL API is currently available on Catalyst storefronts only.
+<Callout type='info'>
+	The Translations Admin GraphQL API is currently available on Catalyst
+	storefronts only.
 </Callout>
 
 The categories translatable fields are:
 
-* Name
-* Description
-* Page Title
-* Meta Keywords
-* Meta Description
-* Search Keywords
+- Name
+- Description
+- Page Title
+- Meta Keywords
+- Meta Description
+- Search Keywords
 
 ## Examples
 
@@ -19,7 +20,9 @@ Below are examples of GraphQL queries and mutations for retrieving and managing 
 
 ### Query translations
 
-This query returns a paginated list of translations by resourceType, channel and locale with a maximum of 50 results per request.  
+#### Query a translation by resourceType, channel and locale
+
+This query returns a paginated list of translations by resourceType, channel and locale with a maximum of 50 results per request.
 
 <Tabs items={['Request', 'Response']}>
 <Tab>
@@ -56,47 +59,129 @@ query {
 
 ```json filename="Example query: Query a translation" showLineNumbers copy
 {
-  "data": {
-    "store": {
-      "translations": {
-        "edges": [
-          {
-            "node": {
-              "resourceId": "bc/store/category/24",
-              "fields": [
-                {
-                  "fieldName": "name",
-                  "original": "my channel level categories",
-                  "translation": "name (OVR) 1"
-                },
-                {
-                  "fieldName": "description",
-                  "original": "<p>my channel level categories description</p>",
-                  "translation": "description (OVR)"
-                },
-                {
-                  "fieldName": "page_title",
-                  "original": "Second Home page title",
-                  "translation": "page_title (OVR)"
-                },
-                {
-                  "fieldName": "meta_description",
-                  "original": "Second Meta description",
-                  "translation": "meta_description (OVR)"
-                },
-                {
-                  "fieldName": "search_keywords",
-                  "original": "Second Search keywords",
-                  "translation": "search_keywords (OVR)"
-                }
-              ]
-            },
-            "cursor": "eyJpZCI6MjR9"
+	"data": {
+		"store": {
+			"translations": {
+				"edges": [
+					{
+						"node": {
+							"resourceId": "bc/store/category/24",
+							"fields": [
+								{
+									"fieldName": "name",
+									"original": "my channel level categories",
+									"translation": "name (OVR) 1"
+								},
+								{
+									"fieldName": "description",
+									"original": "<p>my channel level categories description</p>",
+									"translation": "description (OVR)"
+								},
+								{
+									"fieldName": "page_title",
+									"original": "Second Home page title",
+									"translation": "page_title (OVR)"
+								},
+								{
+									"fieldName": "meta_description",
+									"original": "Second Meta description",
+									"translation": "meta_description (OVR)"
+								},
+								{
+									"fieldName": "search_keywords",
+									"original": "Second Search keywords",
+									"translation": "search_keywords (OVR)"
+								}
+							]
+						},
+						"cursor": "eyJpZCI6MjR9"
+					}
+				]
+			}
+		}
+	}
+}
+```
+
+</Tab>
+</Tabs>
+
+#### Query a translation by resourceId
+
+This query returns a translation by resourceId.
+
+<Tabs items={['Request', 'Response']}>
+<Tab>
+
+```graphql filename="Example mutation: Query a translation by resource id" showLineNumbers copy
+GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
+X-Auth-Token: {{token}}
+
+query {
+  store {
+    translations(filters: {
+        resourceId: "bc/store/category/24"
+      }) {
+      edges {
+        node {
+          resourceId
+            fields {
+              fieldName
+              original
+              translation
+            }
           }
-        ]
       }
     }
   }
+}
+```
+
+</Tab>
+<Tab>
+
+```json filename="Example query: Query a translation" showLineNumbers copy
+{
+	"data": {
+		"store": {
+			"translations": {
+				"edges": [
+					{
+						"node": {
+							"resourceId": "bc/store/category/24",
+							"fields": [
+								{
+									"fieldName": "name",
+									"original": "my channel level categories",
+									"translation": "name (OVR) 1"
+								},
+								{
+									"fieldName": "description",
+									"original": "<p>my channel level categories description</p>",
+									"translation": "description (OVR)"
+								},
+								{
+									"fieldName": "page_title",
+									"original": "Second Home page title",
+									"translation": "page_title (OVR)"
+								},
+								{
+									"fieldName": "meta_description",
+									"original": "Second Meta description",
+									"translation": "meta_description (OVR)"
+								},
+								{
+									"fieldName": "search_keywords",
+									"original": "Second Search keywords",
+									"translation": "search_keywords (OVR)"
+								}
+							]
+						}
+					}
+				]
+			}
+		}
+	}
 }
 ```
 
@@ -114,50 +199,51 @@ GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
 X-Auth-Token: {{token}}
 
 mutation {
-  translation {
-    updateTranslations(input: {
-      resourceType: CATEGORIES,
-      channelId: "bc/store/channel/1",
-      localeId: "bc/store/locale/en",
-      entities: [
-        {
-          resourceId: "bc/store/category/18",
-          fields: [
-            {
-              fieldName: "name",
-              value: "name (OVR)"
-            },
-            {
-              fieldName: "description",
-              value: "description (OVR)"
-            },
-            {
-              fieldName: "page_title",
-              value: "page_title (OVR)"
-            },
-            {
-              fieldName: "meta_description",
-              value: "meta_description (OVR)"
-            },
-            {
-              fieldName: "search_keywords",
-              value: "search_keywords (OVR)"
-            }
-          ]
-        }
-      ]
-    }) {
-      __typename
-      errors {
-        __typename
-        ... on Error {
-          message
-        }
-      }
-    }
-  }
+translation {
+updateTranslations(input: {
+resourceType: CATEGORIES,
+channelId: "bc/store/channel/1",
+localeId: "bc/store/locale/en",
+entities: [
+{
+resourceId: "bc/store/category/18",
+fields: [
+{
+fieldName: "name",
+value: "name (OVR)"
+},
+{
+fieldName: "description",
+value: "description (OVR)"
+},
+{
+fieldName: "page_title",
+value: "page_title (OVR)"
+},
+{
+fieldName: "meta_description",
+value: "meta_description (OVR)"
+},
+{
+fieldName: "search_keywords",
+value: "search_keywords (OVR)"
 }
-```
+]
+}
+]
+}) {
+**typename
+errors {
+**typename
+... on Error {
+message
+}
+}
+}
+}
+}
+
+````
 
 </Tab>
 <Tab>
@@ -173,7 +259,7 @@ mutation {
     }
   }
 }
-```
+````
 
 </Tab>
 </Tabs>
@@ -219,14 +305,14 @@ mutation {
 
 ```json filename="Example mutation: Delete a translation" showLineNumbers copy
 {
-  "data": {
-    "translation": {
-      "deleteTranslations": {
-        "__typename": "DeleteTranslationsResult",
-        "errors": []
-      }
-    }
-  }
+	"data": {
+		"translation": {
+			"deleteTranslations": {
+				"__typename": "DeleteTranslationsResult",
+				"errors": []
+			}
+		}
+	}
 }
 ```
 

--- a/docs/store-operations/translations/categories.mdx
+++ b/docs/store-operations/translations/categories.mdx
@@ -20,14 +20,14 @@ Below are examples of GraphQL queries and mutations for retrieving and managing 
 
 ### Query translations
 
-#### Query a translation by resourceType, channel and locale
+#### Query a list of translations
 
 This query returns a paginated list of translations by resourceType, channel and locale with a maximum of 50 results per request.
 
 <Tabs items={['Request', 'Response']}>
 <Tab>
 
-```graphql filename="Example mutation: Query a translation" showLineNumbers copy
+```graphql filename="Example query: Query a translation" showLineNumbers copy
 GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
 X-Auth-Token: {{token}}
 
@@ -108,12 +108,17 @@ query {
 
 #### Query a translation by resourceId
 
+<Callout type='warning'>
+	When querying a translation by resourceId, you must provide the full
+	resourceId in the format `bc/store/category/{category_id}`.
+</Callout>
+
 This query returns a translation by resourceId.
 
 <Tabs items={['Request', 'Response']}>
 <Tab>
 
-```graphql filename="Example mutation: Query a translation by resource id" showLineNumbers copy
+```graphql filename="Example query: Query a translation by resource id" showLineNumbers copy
 GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
 X-Auth-Token: {{token}}
 
@@ -139,8 +144,7 @@ query {
 
 </Tab>
 <Tab>
-
-```json filename="Example query: Query a translation" showLineNumbers copy
+```json filename="Example query: Query a translation by resource id" showLineNumbers copy
 {
 	"data": {
 		"store": {

--- a/docs/store-operations/translations/index.mdx
+++ b/docs/store-operations/translations/index.mdx
@@ -5,7 +5,7 @@ The Translations Admin GraphQL API is currently available on Catalyst storefront
 
 With a single storefront setup, the shopper's experience remains consistent, but the content is displayed in their preferred language. This use case is particularly common in multilingual countries like Canada and for customers selling cross-border, where the same storefront serves shoppers in multiple languages without altering the overall user experience.
 
-The API currently supports translations for the following components, and more are expected in the future:
+The API currently supports translations for the following resource types, and more are expected in the future:
 
 * Categories
 * Brands

--- a/docs/store-operations/translations/locations.mdx
+++ b/docs/store-operations/translations/locations.mdx
@@ -1,21 +1,20 @@
 # Translations for Locations (Beta)
 
-<Callout type="info">
-The Translations Admin GraphQL API is currently available on Catalyst storefronts only.
+<Callout type='info'>
+	The Translations Admin GraphQL API is currently available on Catalyst
+	storefronts only.
 </Callout>
-
 
 The locations translatable fields are:
 
-* Name
-* Address 1
-* Address 2
-* Description
-* City
-* State (optional)
-* Meta Keywords
-* Name (Special hours)
-
+- Name
+- Address 1
+- Address 2
+- Description
+- City
+- State (optional)
+- Meta Keywords
+- Name (Special hours)
 
 ## Examples
 
@@ -55,6 +54,7 @@ This query returns a paginated list of translations by resourceType, channel, an
           }
       }
     ```
+
   </Tab>
 <Tab>
 ```json filename="Example query: Query a list of translations" showLineNumbers copy
@@ -108,7 +108,8 @@ This query returns a paginated list of translations by resourceType, channel, an
 #### Query a translation by resourceId
 
 <Callout type='warning'>
-	When querying a translation by resourceId, you must provide the full resourceId in the format `bc/store/inventoryLocation/{location_id}`.
+	When querying a translation by resourceId, you must provide the full
+	resourceId in the format `bc/store/inventoryLocation/{location_id}`.
 </Callout>
 
 This query returns a translation by resourceId.
@@ -119,25 +120,30 @@ This query returns a translation by resourceId.
         GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
         X-Auth-Token: {{token}}
 
-      query {
-          store {
-              translations(filters: {
-                resourceId: "bc/store/inventoryLocation/1"
-              }) {
-                  edges {
-                      node {
+        query {
+            store {
+                translations(filters: {
+                    resourceType: INVENTORY_LOCATIONS,
+                    channelId: "bc/store/channel/2",
+                    localeId: "bc/store/locale/it",
+                    resourceIds: ["bc/store/inventoryLocation/1"]
+                }) {
+                    edges {
+                        node {
                             resourceId
-                              fields {
-                                  fieldName
-                                  original
-                                  translation
-                              }
-                          }
-                  }
-              }
-          }
-      }
+                                fields {
+                                    fieldName
+                                    original
+                                    translation
+                                }
+                            }
+                        cursor
+                    }
+                }
+            }
+        }
     ```
+
   </Tab>
 <Tab>
 ```json filename="Example query: Query a translation by resource id" showLineNumbers copy
@@ -176,7 +182,8 @@ This query returns a translation by resourceId.
                                     "translation": null
                                 }
                             ]
-                        }
+                        },
+                        "cursor": "eyJpZCI6MjR9"
                     }
                 ]
             }
@@ -186,7 +193,6 @@ This query returns a translation by resourceId.
 ```
 </Tab>
 </Tabs>
-
 
 ### Update a translation
 
@@ -242,8 +248,10 @@ This mutation updates a translation.
             }
         }
     }
+
 }
-```
+
+````
   </Tab>
 <Tab>
 ```json filename="Example mutation: Update a translation" showLineNumbers copy
@@ -257,7 +265,8 @@ This mutation updates a translation.
       }
     }
   }
-```
+````
+
 </Tab>
 </Tabs>
 
@@ -294,7 +303,8 @@ The following mutation deletes a translation.
         }
     }
     }
-```
+
+````
   </Tab>
 <Tab>
 ```json filename="Example mutation: Delete a translation" showLineNumbers copy
@@ -308,6 +318,7 @@ The following mutation deletes a translation.
     }
   }
 }
-```
+````
+
 </Tab>
 </Tabs>

--- a/docs/store-operations/translations/locations.mdx
+++ b/docs/store-operations/translations/locations.mdx
@@ -126,7 +126,7 @@ This query returns a translation by resourceId.
                     resourceType: INVENTORY_LOCATIONS,
                     channelId: "bc/store/channel/2",
                     localeId: "bc/store/locale/it",
-                    resourceIds: ["bc/store/inventoryLocation/1"]
+                    resourceIds: ["bc/store/inventoryLocation/1", "bc/store/inventoryLocation/2"]
                 }) {
                     edges {
                         node {
@@ -184,6 +184,39 @@ This query returns a translation by resourceId.
                             ]
                         },
                         "cursor": "eyJpZCI6MjR9"
+                    },
+                    {
+                        "node": {
+                            "resourceId": "bc/store/inventoryLocation/2",
+                            "fields": [
+                                {
+                                    "fieldName": "city",
+                                    "original": "AUSTIN",
+                                    "translation": "Ville (OVR) TEST EN"
+                                },
+                                {
+                                    "fieldName": "state",
+                                    "original": "TX",
+                                    "translation": "État (OVR) TEST EN"
+                                },
+                                {
+                                    "fieldName": "description",
+                                    "original": "",
+                                    "translation": null
+                                },
+                                {
+                                    "fieldName": "label",
+                                    "original": "LOCATION 1",
+                                    "translation": null
+                                },
+                                {
+                                    "fieldName": "address2",
+                                    "original": "apt 111",
+                                    "translation": null
+                                }
+                            ]
+                        },
+                        "cursor": "eyJpZCI6MjJ7"
                     }
                 ]
             }

--- a/docs/store-operations/translations/locations.mdx
+++ b/docs/store-operations/translations/locations.mdx
@@ -23,12 +23,14 @@ Below are examples of GraphQL queries and mutations for retrieving and managing 
 
 ### Query translations
 
+#### Query a list of translations
+
 This query returns a paginated list of translations by resourceType, channel, and locale with a maximum of 50 results per request.
 
 <Tabs items={['Request', 'Response']}>
   <Tab>
-    ```json filename="Example mutation: Query a translation" showLineNumbers copy
-        GRAPHQL {{host}}/stores/{{store_hash}}/graphql
+    ```json filename="Example query: Query a translation" showLineNumbers copy
+        GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
         X-Auth-Token: {{token}}
 
       query {
@@ -103,6 +105,89 @@ This query returns a paginated list of translations by resourceType, channel, an
 </Tab>
 </Tabs>
 
+#### Query a translation by resourceId
+
+<Callout type='warning'>
+	When querying a translation by resourceId, you must provide the full resourceId in the format `bc/store/inventoryLocation/{location_id}`.
+</Callout>
+
+This query returns a translation by resourceId.
+
+<Tabs items={['Request', 'Response']}>
+  <Tab>
+    ```json filename="Example query: Query a translation by resource id" showLineNumbers copy
+        GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
+        X-Auth-Token: {{token}}
+
+      query {
+          store {
+              translations(filters: {
+                resourceId: "bc/store/inventoryLocation/1"
+              }) {
+                  edges {
+                      node {
+                            resourceId
+                              fields {
+                                  fieldName
+                                  original
+                                  translation
+                              }
+                          }
+                  }
+              }
+          }
+      }
+    ```
+  </Tab>
+<Tab>
+```json filename="Example query: Query a translation by resource id" showLineNumbers copy
+  {
+    "data": {
+        "store": {
+            "translations": {
+                "edges": [
+                    {
+                        "node": {
+                            "resourceId": "bc/store/inventoryLocation/1",
+                            "fields": [
+                                {
+                                    "fieldName": "city",
+                                    "original": "AUSTIN",
+                                    "translation": "Ville (OVR) TEST EN"
+                                },
+                                {
+                                    "fieldName": "state",
+                                    "original": "TX",
+                                    "translation": "État (OVR) TEST EN"
+                                },
+                                {
+                                    "fieldName": "description",
+                                    "original": "",
+                                    "translation": null
+                                },
+                                {
+                                    "fieldName": "label",
+                                    "original": "LOCATION 1",
+                                    "translation": null
+                                },
+                                {
+                                    "fieldName": "address2",
+                                    "original": "apt 111",
+                                    "translation": null
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}
+```
+</Tab>
+</Tabs>
+
+
 ### Update a translation
 
 This mutation updates a translation.
@@ -110,7 +195,7 @@ This mutation updates a translation.
 <Tabs items={['Request', 'Response']}>
   <Tab>
     ```json filename="Example mutation: Update a translation" showLineNumbers copy
-        GRAPHQL {{host}}/stores/{{store_hash}}/graphql
+        GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
         X-Auth-Token: {{token}}
 
       mutation {
@@ -183,7 +268,7 @@ The following mutation deletes a translation.
 <Tabs items={['Request', 'Response']}>
   <Tab>
     ```json filename="Example mutation: Delete a translation" showLineNumbers copy
-        GRAPHQL {{host}}/stores/{{store_hash}}/graphql
+        GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
         X-Auth-Token: {{token}}
 
       mutation {

--- a/docs/store-operations/translations/locations.mdx
+++ b/docs/store-operations/translations/locations.mdx
@@ -29,7 +29,7 @@ This query returns a paginated list of translations by resourceType, channel, an
 
 <Tabs items={['Request', 'Response']}>
   <Tab>
-    ```json filename="Example query: Query a translation" showLineNumbers copy
+    ```json filename="Example query: Query a list of translations" showLineNumbers copy
         GRAPHQL https://api.bigcommerce.com/stores/{{store_hash}}/graphql
         X-Auth-Token: {{token}}
 
@@ -57,7 +57,7 @@ This query returns a paginated list of translations by resourceType, channel, an
     ```
   </Tab>
 <Tab>
-```json filename="Example query: Query a translation" showLineNumbers copy
+```json filename="Example query: Query a list of translations" showLineNumbers copy
   {
     "data": {
         "store": {


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6453]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Documentation for filtering translations by resourceId for brands, categories, and locations resource types.

## Release notes draft
Updated documentation for filtering translations by resourceId

ping @bc-janet 


[DEVDOCS-6453]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ