### PR TITLE
Mark order_taxes.tax_rate_id as deprecated, document sales_tax_id

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -2816,6 +2816,7 @@ components:
                   order_id: 138
                   order_address_id: 39
                   tax_rate_id: 1
+                  sales_tax_id: 'TaxId123'
                   tax_class_id: 0
                   name: Tax
                   class: Default Tax Class
@@ -2828,6 +2829,7 @@ components:
                   order_id: 138
                   order_address_id: 40
                   tax_rate_id: 1
+                  sales_tax_id: 'TaxId123'
                   tax_class_id: 0
                   name: Tax
                   class: Default Tax Class
@@ -3370,9 +3372,14 @@ components:
           example: 29
           type: integer
         tax_rate_id:
-          description: The unique numeric identifier of the tax rate.
+          description: The unique numeric identifier of the tax rate. This field has been deprecated, use sales_tax_id instead.
           example: 1
           type: integer
+          deprecated: true
+        sales_tax_id:
+          description: A unique identifier for the applied tax rate. This may be a third-party tax provider's identifier.
+          example: 'TaxId123'
+          type: string
         tax_class_id:
           description: |-
             A unique numeric identifier for the tax class. If not provided or null, the default fee tax class from the control panel is used.


### PR DESCRIPTION
# [TAX-2463]

## What changed?
* Mark `order_taxes.tax_rate_id` as deprecated.
* Document `order_taxes.sales_tax_id` (this has actually actually been in the response for a while now).

## Release notes draft
- To support a wider range of use cases, the `order_taxes.tax_rate_id` (int) is now deprecated and will be removed in the near future. Please update to use the `order_taxes.sales_tax_id` (string) field.

[TAX-2463]: https://bigcommercecloud.atlassian.net/browse/TAX-2463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ