### PR TITLE
DEVDOCS-6253 - Content Refresh - "Orders" (Storefront)

### DIFF
--- a/docs/b2b-edition/specs/storefront/storefront/order.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/order.yaml
@@ -2427,4 +2427,4 @@ components:
       type: http
       scheme: bearer
 tags:
-  - name: Order
+  - name: Orders


### PR DESCRIPTION
Fixed tag value in yaml to display endpoints.

# [DEVDOCS-6253](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6253)


## What changed?

* Fixes an issue with endpoint display

## Release notes draft

* This update fixes an issue that resulted in hidden endpoints on the document.

## Anything else?

ping @bc-terra 
