### PR TITLE
DEVDOCS-6250 - Content Refresh - "Users" (S2S)

### DIFF
--- a/docs/b2b-edition/specs/api-v3/user/user.yaml
+++ b/docs/b2b-edition/specs/api-v3/user/user.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  title: User
+  title: Users
   description: |-
     > NOTE:  
     > While Super Admins are B2B Edition user accounts, they are not included in the response data for this API. To manage Super Admin accounts, refer to the [B2B Edition Super Admin API](/b2b-edition/apis/rest-management/super-admin).
@@ -25,14 +25,14 @@ servers:
 security:
   - authToken: []
 tags:
-  - name: User
+  - name: Users
 paths:
   /users:
     get:
       summary: Get All B2B users
       description: Returns a paginated list of B2B users with optional filters.
       operationId: companies_users_list
-      tags: [users]
+      tags: [Users]
       parameters:
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/limit'
@@ -163,7 +163,7 @@ paths:
         
         If no default customer group is configured, or the set value of `customerGroupId` is 0, the B2B Company will not be associated with any customer group. The Company users will have their corresponding customer records assigned to No Group in BigCommerce.
       operationId: companies_users_create
-      tags: [Users]
+      : [Users]
       requestBody:
         content:
           application/json:
@@ -197,7 +197,7 @@ paths:
 
         With (Independent Company behavior)[/b2b-edition/apis/rest-management/company/companies#independent-vs-dependent-companies-behavior] enabled, B2B Edition Company accounts are the source of truth for defining a Company user’s customer group assignment. If no default customer group is configured or the set value of `customerGroupId` is 0, the B2B Company will not be associated with any customer group. The Company users will have their corresponding customer records assigned to No Group in BigCommerce.
       operationId: companies_users_bulk_create_create
-      tags: [Users]
+      : [Users]
       requestBody:
         content:
           application/json:
@@ -261,7 +261,7 @@ paths:
       summary: Get User Details
       description: "Returns detailed user information for the user specified by `userId`. Unlike [Get All Users](#get-all-users), this endpoint includes extra fields by default."
       operationId: companies_user_by_id
-      tags: [Users]
+      : [Users]
       responses:
         '200':
           description: Success


### PR DESCRIPTION
Corrected article tags so that they all match

# [DEVDOCS-6250](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6250)


## What changed?

* Fixes an issue with endpoint display due to mismatched tags
* Article name is now "Users"

## Release notes draft

* This change fixes an issue that caused endpoint information to be hidden in the document.

## Anything else?

ping @bc-terra 
