### PR TITLE
DEVDOCS-6464 - fix issue around displaying fields

### DIFF
--- a/reference/storefront_tokens.v3.yml
+++ b/reference/storefront_tokens.v3.yml
@@ -54,6 +54,8 @@ paths:
 
         **Required Scopes**
         * `Manage` `Storefront API Tokens`
+
+        > NOTE: Both `channel_id` and `channel_ids` are labelled as required, but only one should be included in the request body. Including both will result in unexpected behaviors.
       operationId: createToken
       parameters:
         - $ref: '#/components/parameters/ContentType'
@@ -64,11 +66,19 @@ paths:
               allOf:
                 - $ref: '#/components/schemas/TokenPostSimple'
                 - $ref: '#/components/schemas/TokenPostImpersonation'
-            example:
-              allowed_cors_origins:
-                -  'https://www.yourstorefront.com'
-              channel_id: 1
-              expires_at: 1885635176
+            examples:
+              Single Channel:
+                value:
+                  allowed_cors_origins:
+                    -  'https://www.yourstorefront.com'
+                  channel_id: 1
+                  expires_at: 1885635176
+              Multi Channel:
+                value:
+                  allowed_cors_origins:
+                    -  'https://www.yourstorefront.com'
+                  channel_ids: [1,12]
+                  expires_at: 1885635176
         required: false
       responses:
         '200':
@@ -86,7 +96,6 @@ paths:
         '422':
           description: Invalid JSON request body - missing or invalid data.
           content: {}
-      x-codegen-request-body-name: body
     delete:
       tags:
         - API Token
@@ -125,6 +134,8 @@ paths:
 
         **Required Scopes**
         * `Manage` `Storefront API Customer Impersonation Tokens`
+
+        > NOTE: Both `channel_id` and `channel_ids` are labelled as required, but only one should be included in the request body. Including both will result in unexpected behaviors.
       operationId: createTokenWithCustomerImpersonation
       parameters:
         - $ref: '#/components/parameters/ContentType'
@@ -133,6 +144,15 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TokenPostImpersonation'
+            examples:
+              Single Channel:
+                value:
+                  channel_id: 1
+                  expires_at: 1885635176
+              Multi Channel:
+                value:
+                  channel_ids: [1,12]
+                  expires_at: 1885635176
         required: false
       responses:
         '200':
@@ -170,7 +190,6 @@ components:
         default: 'application/json'
   schemas:
     TokenPostImpersonation:
-      x-internal: false
       allOf:
         - type: object
           properties:
@@ -181,9 +200,8 @@ components:
               minimum: 0
           required:
             - expires_at
-        - oneOf:
-          - $ref: "#/components/schemas/Channels"
-          - $ref: "#/components/schemas/Channel"
+        - $ref: "#/components/schemas/Channels"
+        - $ref: "#/components/schemas/Channel"
       required:
         - expires_at
     TokenPostSimple:
@@ -197,7 +215,6 @@ components:
           items:
             minLength: 1
             type: string
-      x-internal: false
     Token_Full:
       type: object
       properties:
@@ -214,11 +231,9 @@ components:
         token:
           type: string
           description: JWT Token for accessing the Storefront API
-      x-internal: false
     Channel:
       title: channel_id
       type: object
-      x-internal: false
       properties:
         channel_id:
           type: integer
@@ -230,7 +245,6 @@ components:
     Channels:
       title: channel_ids
       type: object
-      x-internal: false
       properties:
         channel_ids:
           type: array
@@ -247,7 +261,6 @@ components:
           properties:
             errors:
               $ref: '#/components/schemas/DetailedErrors'
-      x-internal: false
     BaseError:
       type: object
       properties:
@@ -263,13 +276,11 @@ components:
           type: string
       description: |
         Error payload for the BigCommerce API.
-      x-internal: false
     DetailedErrors:
       type: object
       properties: {}
       additionalProperties:
         type: string
-      x-internal: false
   responses:
     TokenResponse:
       description: ''
@@ -303,4 +314,3 @@ components:
         For a list of API status codes, see [API Status Codes](/docs/start/about/status-codes).
       name: X-Auth-Token
       in: header
-

--- a/reference/storefront_tokens.v3.yml
+++ b/reference/storefront_tokens.v3.yml
@@ -55,7 +55,7 @@ paths:
         **Required Scopes**
         * `Manage` `Storefront API Tokens`
 
-        > NOTE: Both `channel_id` and `channel_ids` are labelled as required, but only one should be included in the request body. Including both will result in unexpected behaviors.
+        > NOTE: While neither `channel_id` nor `channel_ids` is labelled as required, one must be included in the request body. Including neither will throw an error, and including both will result in unexpected behaviors.
       operationId: createToken
       parameters:
         - $ref: '#/components/parameters/ContentType'
@@ -135,7 +135,7 @@ paths:
         **Required Scopes**
         * `Manage` `Storefront API Customer Impersonation Tokens`
 
-        > NOTE: Both `channel_id` and `channel_ids` are labelled as required, but only one should be included in the request body. Including both will result in unexpected behaviors.
+        > NOTE: While neither `channel_id` nor `channel_ids` is labelled as required, one must be included in the request body. Including neither will throw an error, and including both will result in unexpected behaviors.
       operationId: createTokenWithCustomerImpersonation
       parameters:
         - $ref: '#/components/parameters/ContentType'
@@ -240,8 +240,6 @@ components:
           minimum: 1
           description: Channel ID that is valid for the requested token. Use this field to enter a channel ID. Do not use this field if you have more than one channel. We support this field for backwards compatibility, but `channel_ids` is preferred. You can not use both `channel_id` and `channel_ids` in your request.
           example: 1
-      required:
-        - channel_id
     Channels:
       title: channel_ids
       type: object
@@ -252,8 +250,6 @@ components:
           items:
             type: integer
           example: [667251, 1]
-      required:
-        - channel_ids
     ErrorResponse:
       allOf:
         - $ref: '#/components/schemas/BaseError'


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6464]


## What changed?
* The `allowed_cors_origin` field was not displaying correctly, and now it is.

## Release notes draft
* We've fixed the display of fields associated with `POST` bodies.

## Anything else?

ping { @bigcommerce/dev-docs }


[DEVDOCS-6464]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ