### PR TITLE
DEVDOCS-6455 - fix anchors for two endpoints

### DIFF
--- a/docs/b2b-edition/specs/api-v3/company/company.yaml
+++ b/docs/b2b-edition/specs/api-v3/company/company.yaml
@@ -298,7 +298,7 @@ paths:
 
         If you have configured required information fields in your store’s Extra Fields settings for Company accounts or Company users, you must include the field’s name and value in the `extraFields` array of the request body. For more information on extra fields, see [B2B Edition Settings](https://support.bigcommerce.com/s/article/B2B-Edition-Settings) in the Help Center.
 
-        After you have created a new Company account, you can configure all of its features and settings by using the [Update a Company](#update-a-company) endpoint.
+        After you have created a new Company account, you can configure all of its features and settings by using the [](#update-a-company) endpoint.
 
         ### Independent vs Dependent Companies Behavior
 
@@ -524,7 +524,7 @@ paths:
     put:
       tags:
         - Companies
-      summary: Update a Company
+      summary: 
       operationId: put-companies-companyId
       description: |-
         Updates a Company’s attributes.
@@ -993,7 +993,7 @@ paths:
         - Companies
       summary: Update Companies (Batch)
       operationId: put-companies
-      description: "Updates up to `10` Company accounts at once. See [Update a Company](#update-a-company) for recommendations on formatting individual Companies in the array."
+      description: "Updates up to `10` Company accounts at once. See [](#update-a-company) for recommendations on formatting individual Companies in the array."
       parameters: []
       security:
         - authToken: []
@@ -1074,7 +1074,7 @@ paths:
     put:
       tags:
         - Companies
-      summary: Update a Company's Catalog
+      summary: Update a Company Catalog
       operationId: put-companies-companyId-catalog
       description: "Updates the price list assigned to the Company account. This endpoint **is not supported** for stores using Independent Companies behavior."
       parameters: []
@@ -1101,7 +1101,7 @@ paths:
     put:
       tags:
         - Companies
-      summary: Update a Company's Status
+      summary: Update a Company Status
       operationId: put-companies-companyId-status
       description: "Updates a Company’s account status. See [Company Status Codes](#company-status-codes) for a description of the available statuses."
       parameters: []


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6455]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* An issue with the endpoints using `'` in their summary prevented them from linking properly in the side navigation menu.

## Release notes draft
* Made a minor adjustment to the summaries of two endpoints

## Anything else?

ping { @bigcommerce/dev-docs-team }
