### PR TITLE
DEVDOCS-6442 - proration update for UB

### DIFF
--- a/docs/integrations/apps/unified-billing/example-queries.mdx
+++ b/docs/integrations/apps/unified-billing/example-queries.mdx
@@ -515,7 +515,9 @@ This mutation cancels the subscription at the end of the merchant's current bill
    * If a subscription is canceled while it's still in the trial period, the cancellation takes effect immediately. The trial ends, and no invoice is ever generated.
 
 * Post Trial Cancellation Behavior
-   * Once the trial ends, the subscription begins billing. Any cancellation initiated will take effect at the end of the current billing cycle (e.g., monthly or annual term), not immediately.
+   * Once the trial ends, the subscription begins billing. 
+   * Any cancellation initiated before the next billing cycle date will be prorated for the period from trial end until cancellation date.
+   * Charges for prorated fees will appear on the merchant's next invoice.
 
 ### Query subscriptions
 Subscriptions can be queried using the `subscriptions` query endpoint.


### PR DESCRIPTION
# [DEVDOCS-6442]

## What changed?
* Previously, merchants were unable to cancel subscriptions between the end of a free trial and the next billing cycle date.
* Now, merchants that cancel in this window will be prorated the fees and charged on their next invoice.

## Release notes draft
* We've adjusted the way cancellation is managed for unified billing so that cancellations post-trial and pre-billing cycle will be prorated instead of preventing cancellation.

## Anything else?

ping { @bigcommerce/dev-docs-team }


[DEVDOCS-6442]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ