### PR TITLE
DEVDOCS-6410 - Remove password connected mutations

### DIFF
--- a/docs/graphql-account/users.mdx
+++ b/docs/graphql-account/users.mdx
@@ -815,54 +815,6 @@ The following mutation removes a user from an account:
   </Tab>
 </Tabs>
 
-### Create user
-
-The following mutation creates a user:
-
-<Tabs items={['Request', 'Response']}>
-  <Tab>
-
-    ```graphql filename="Example mutation: Create a user" showLineNumbers copy
-    mutation {
-      user {
-        createUserWithPassword(
-          input: {
-            email: "jane.doe@example.com",
-            firstName: "Jane",
-            lastName: "Doe",
-            locale: "en-US",
-            password: "Password1234!",
-            passwordConfirmation: "Password1234!"
-          }
-        ) {
-          user {
-            id
-          }
-        }
-      }
-    }
-    ```
-
-  </Tab>
-  <Tab>
-
-    ```json filename="Example mutation: Create a user" showLineNumbers copy
-    {
-      "data": {
-        "user": {
-          "createUserWithPassword": {
-            "user": {
-              "id": "bc/account/user/{user_id}"
-            }
-          }
-        }
-      }
-    }
-    ```
-
-  </Tab>
-</Tabs>
-
 ### Add user to store
 
 The following mutations add a user to a store:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6410](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6410)


## What changed?
* Removed password linked mutation as part of security upgrade.

## Release notes draft
* To enhance security, we've removed the ability to create a control panel user account with password via GraphQL. Users can still be added to an account using the non-password linked mutation.

## Anything else?

ping { @bigcommerce/dev-docs-team }


[DEVDOCS-6410]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ