### PR TITLE
DEVDOCS-6450 - add account api rate limit

### DIFF
--- a/docs/graphql-account/users.mdx
+++ b/docs/graphql-account/users.mdx
@@ -17,6 +17,14 @@ Before getting started with the GraphQL Account API's users feature, make sure y
 
 To learn more about making requests, see the next section on [Getting Started](#getting-started).
 
+## Rate Limits
+
+Account based rate limiting will affect all endpoints that begin with `/accounts`. 
+
+The limit is set to 70 requests per hour.
+
+Refer to our [API Rate Limit Best Practices Documentation](https://developer.bigcommerce.com/docs/start/best-practices/api-rate-limits#best-practices) to help you manage your API usage effectively.
+
 ## OAuth scopes
 
 | Name | Permission | Description |


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6450]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Rate limits were added for all  endpoints that begin with `/accounts`
* Documentation has been updated to reflect the new rate limit 

## Release notes draft
Rate limits were added for all endpoints beginning with `/accounts` limiting request to 70 per hour.

ping @bc-terra @bc-janet 
