### PR TITLE
DEVDOCS-6484 - update create coupon code response from 200 to 201

### DIFF
--- a/reference/promotions.v3.yml
+++ b/reference/promotions.v3.yml
@@ -255,7 +255,7 @@ paths:
                   example: 5
         required: true
       responses:
-        '200':
+        '201':
           $ref: '#/components/responses/PromotionCodeResponse'
     delete:
       tags:


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [DEVDOCS-6484]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Feedback provided from merchant that the response code for creating a coupon code is 201 and not 200.
* Documentation has been updated to reflect

## Release notes draft
Documentation updated to reflect proper 201 response code when creating a single coupon code.

ping @bc-terra 


[DEVDOCS-6484]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ