### PR TITLE
B2B-3407 - update B2B support cta

### DIFF
--- a/docs/storefront/catalyst/development/b2b.mdx
+++ b/docs/storefront/catalyst/development/b2b.mdx
@@ -160,5 +160,5 @@ This step is only required if the merchant wants to run the Buyer Portal locally
 <br/>
 
 <Callout type="info">
-If you have any questions or feedback, we'd enjoy hearing it! Start a GitHub Discussion or contact the B2B Edition team at [b2b@bigcommerce.com](mailto:b2b@bigcommerce.com)
+If you have any questions or feedback, we'd enjoy hearing it! Start a GitHub Discussion or contact us by [creating a support case.](https://support.bigcommerce.com/s/article/Creating-Viewing-Support-Cases)
 </Callout>


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
# [B2B-3407](https://bigcommercecloud.atlassian.net/browse/B2B-3407)


## What changed?
<!-- Provide a bulleted list in the present tense -->
* B2B support call to action link redirects to the BC support cases guide 

## Release notes draft
* Changing call to action in the support section of the Catalyst B2B docs


## Anything else?

[B2B-3407]: https://bigcommercecloud.atlassian.net/browse/B2B-3407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ