### PR TITLE
DEVDOCS-6499 - add alert about maximum directory depth in Stencil Themes

### DIFF
--- a/docs/storefront/stencil/themes/foundations/directory-structure.mdx
+++ b/docs/storefront/stencil/themes/foundations/directory-structure.mdx
@@ -1,6 +1,11 @@
 # Directory Structure
 
- 
+<Callout type="info">
+Stencil has a hard limit on directory depth within theme files when using the control panel Theme Files Editor.
+
+Themes with a maximum directory depth greater than `9` will be uneditable within the control panel and will require local development to make edits.
+</Callout>
+
 The default directory structure for [Cornerstone](https://github.com/bigcommerce/cornerstone)-based themes is as follows:
   
 


### PR DESCRIPTION
# [DEVDOCS-6499]

## What changed?
* Added a callout to two separate pages for maximum directory depth in Stencil

## Release notes draft
* [No update to the platform, only documentation]
* Added a callout to two separate pages for maximum directory depth in Stencil

## Anything else?

ping { @bigcommerce/dev-docs-team }


[DEVDOCS-6499]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ