### PR TITLE
DEVDOCS-6496 - Clarify date format for modifiers in documentation

### DIFF
--- a/reference/catalog/product-modifiers_catalog.v3.yml
+++ b/reference/catalog/product-modifiers_catalog.v3.yml
@@ -43,11 +43,11 @@ info:
     
     | Modifier Type(s)                   | Config Field                   | Description or Values                                                |
     |-------------------------------------|-------------------------------|---------------------------------------------------------------------|
-    | `date`                             | `default_value`                | Default ISO date string                                             |
+    | `date`                             | `default_value`                | Default ISO-8601 ATOM date string                                             |
     |                                     | `date_limited`                 | Boolean: Indicates whether the allowed date options are limited       |
     |                                     | `date_limit_mode`              | Defines the type of limit on the date option. Accepts `earliest`, `range`, and `latest`.                          |
-    |                                     | `date_earliest_value`          | ISO date: the earliest date allowed to be entered on the date option                                          |
-    |                                     | `date_latest_value`            | ISO date: the latest date allowed to be entered on the date option                                            |
+    |                                     | `date_earliest_value`          | ISO-8601 ATOM date: the earliest date allowed to be entered on the date option                                          |
+    |                                     | `date_latest_value`            | ISO-8601 ATOM date: the latest date allowed to be entered on the date option                                            |
     | `checkbox`                         | `checked_by_default`           | Boolean: Indicates whether the option is checked by default                                         |
     |                                     | `checkbox_label`               | The label that appears next to the checkbox on the storefront                                      |
     | `file`                             | `file_types_mode`              | Specifies whether you want to allow shoppers to upload any file type or if you only want to accept particular types defined in the `file_types_supported` array.                                                  |
@@ -207,6 +207,8 @@ paths:
 
         **Notes**
         It takes two separate requests to create a new checkbox modifier with option values. Perform a request to create a modifier, then perform a second request to update option values.
+
+        Date modifiers are required to be provided in [ISO-8601 ATOM](https://www.php.net/manual/en/class.datetimeinterface.php#datetimeinterface.constants.atom) format. Excluding them in a request will throw a server error.
       operationId: createProductModifier
       parameters:
         - $ref: '#/components/parameters/ContentType'
@@ -415,7 +417,10 @@ paths:
       tags:
         - Product modifiers
       summary: Update a product modifier
-      description: Updates a product modifier.
+      description: |- 
+        Updates a product modifier.
+
+        Date modifiers are required to be provided in [ISO-8601 ATOM](https://www.php.net/manual/en/class.datetimeinterface.php#datetimeinterface.constants.atom) format. Excluding them in a request will throw a server error.
       operationId: updateProductModifier
       parameters:
         - $ref: '#/components/parameters/ContentType'
@@ -460,7 +465,7 @@ paths:
                     default_value:
                       type: string
                       description: |
-                        (date, text, multi_line_text, numbers_only_text) The default value. Shown on a date option as an ISO-8601–formatted string, or on a text option as a string. See [Configs](#configs) for more details.
+                        (date, text, multi_line_text, numbers_only_text) The default value. Shown on a date option as an ISO-8601 ATOM formatted string, or on a text option as a string. See [Configs](#configs) for more details.
                     checked_by_default:
                       type: boolean
                       description: |
@@ -485,12 +490,12 @@ paths:
                     date_earliest_value:
                       type: string
                       description: |
-                        (date) The earliest date allowed to be entered on the date option, as an ISO-8601 formatted string.
+                        (date) The earliest date allowed to be entered on the date option, as an ISO-8601 ATOM formatted string.
                       format: date
                     date_latest_value:
                       type: string
                       description: |
-                        (date) The latest date allowed to be entered on the date option, as an ISO-8601 formatted string.
+                        (date) The latest date allowed to be entered on the date option, as an ISO-8601 ATOM formatted string.
                       format: date
                     file_types_mode:
                       type: string
@@ -684,7 +689,7 @@ paths:
                               default_value:
                                 type: string
                                 description: |
-                                  (date, text, multi_line_text, numbers_only_text) The default value. Shown on a date option as an ISO-8601–formatted string, or on a text option as a string. See [Configs](#configs) for more details.
+                                  (date, text, multi_line_text, numbers_only_text) The default value. Shown on a date option as an ISO-8601 ATOM formatted string, or on a text option as a string. See [Configs](#configs) for more details.
                               checked_by_default:
                                 type: boolean
                                 description: |
@@ -709,12 +714,12 @@ paths:
                               date_earliest_value:
                                 type: string
                                 description: |
-                                  (date) The earliest date allowed to be entered on the date option, as an ISO-8601 formatted string.
+                                  (date) The earliest date allowed to be entered on the date option, as an ISO-8601 ATOM formatted string.
                                 format: date
                               date_latest_value:
                                 type: string
                                 description: |
-                                  (date) The latest date allowed to be entered on the date option, as an ISO-8601 formatted string.
+                                  (date) The latest date allowed to be entered on the date option, as an ISO-8601 ATOM formatted string.
                                 format: date
                               file_types_mode:
                                 type: string
@@ -2098,7 +2103,7 @@ components:
         default_value:
           type: string
           description: |
-            (date, text, multi_line_text, numbers_only_text) The default value. Shown on a date option as an ISO-8601–formatted string, or on a text option as a string. See [Configs](#configs) for more details.
+            (date, text, multi_line_text, numbers_only_text) The default value. Shown on a date option as an ISO-8601 ATOM formatted string, or on a text option as a string. See [Configs](#configs) for more details.
         checked_by_default:
           type: boolean
           description: |
@@ -2123,12 +2128,12 @@ components:
         date_earliest_value:
           type: string
           description: |
-            (date) The earliest date allowed to be entered on the date option, as an ISO-8601 formatted string.
+            (date) The earliest date allowed to be entered on the date option, as an ISO-8601 ATOM formatted string.
           format: date
         date_latest_value:
           type: string
           description: |
-            (date) The latest date allowed to be entered on the date option, as an ISO-8601 formatted string.
+            (date) The latest date allowed to be entered on the date option, as an ISO-8601 ATOM formatted string.
           format: date
         file_types_mode:
           type: string


### PR DESCRIPTION
Updated documentation for date modifier to specify ISO-8601 ATOM format.

# [DEVDOCS-6496]

## What changed?
* When sending a PUT or POST request to create/update product modifier options, the full ISO-8601 ATOM format is required.
* Currently, if the wrong format is provided, such as “2005-08-15”, validation should fail, but it doesn’t.

## Release notes draft
* We've updated the validation workflow for creating product modifiers to require ISO-8601 ATOM format, which includes date, time, and timezone. Failing to provide dates in ISO-8601 ATOM format will now result in a validation error.

## Anything else?

ping { @bigcommerce/dev-docs-team }
