### PR TITLE
PROMO-1256: Added prefix, suffix and code_length fields for bulk coup…

### DIFF
--- a/reference/promotions.v3.yml
+++ b/reference/promotions.v3.yml
@@ -320,6 +320,24 @@ paths:
                   example: 5
                   minimum: 0
                   maximum: 100000
+                prefix:
+                  pattern: '[A-Z0-9_-]'
+                  type: string
+                  description: 'The fixed text or characters that will appear at the beginning of every generated coupon code. Only capital letters, numbers, underscores and hyphens are allowed.'
+                  example: PRE-
+                  maxLength: 20
+                suffix:
+                  pattern: '[A-Z0-9_-]'
+                  type: string
+                  description: 'The fixed text or characters that will appear at the end of every generated coupon code. Only capital letters, numbers, underscores and hyphens are allowed.'
+                  example: _POST
+                  maxLength: 20
+                code_length:
+                  type: integer
+                  description: 'The length of the random string to be generated for each coupon code. The value must be between 6 and 20. The total length of each generated coupon code is calculated as: `code_length` + length of `prefix` + length of `suffix`. The maximum total length of a coupon code is 50.'
+                  example: 10
+                  minimum: 6
+                  maximum: 20
         required: true
       responses:
         '201':


### PR DESCRIPTION
<!-- Ticket number or summary of work -->
[https://bigcommercecloud.atlassian.net/browse/PROMO-1256](https://bigcommercecloud.atlassian.net/browse/PROMO-1256)


## What changed?
<!-- Provide a bulleted list in the present tense -->
* Added prefix, suffix and code_length fields for bulk coupon api /v3/promotions/{promotion id}/codegen

## Release notes draft
We're happy to announce new enhanced controls for bulk coupon code generation! This feature can help you organize and track your promotions better by allowing you to define a static prefix (e.g., HOLIDAY-) and a static suffix (e.g., -VIP) for all your codes. By controlling the code length and these static fields, you can generate clean, structured codes that are easy for both you and your customers to read.

ping @bc-anshumishra 
