### PR TITLE
DEVDOCS-6531 - Mark B2B Edition documentation as deprecated

### DIFF
--- a/docs/storefront/catalyst/development/b2b.mdx
+++ b/docs/storefront/catalyst/development/b2b.mdx
@@ -1,5 +1,11 @@
 # B2B Edition
 
+<Callout type="warning">
+As of September 25, 2025, the information in this doc is **deprecated**.
+
+The current integration is experimental, and the code branch `integrations/b2b-buyer-portal` is deprecated. A more robust guide is in development and will be published soon.
+</Callout>
+
 Following these steps will help you integrate Catalyst with B2B Edition's Open Source Buyer Portal, which is a traditional client-side rendered React application. The steps below also document the process for running the B2B Buyer Portal React application locally, so that you can customize the experience inside of the Buyer Portal if required.
 
 This implementation primarily handles authentication with the B2B Storefront API and triggering the render of the Buyer Portal on top of Catalyst. It is similar to the experience currently available for BigCommerce's Stencil storefront framework.


### PR DESCRIPTION
Added deprecation notice for B2B Edition documentation.

<!-- Ticket number or summary of work -->
# [DEVDOCS-6531]


## What changed?
<!-- Provide a bulleted list in the present tense -->
* 

## Release notes draft
<!-- Provide an entry for the release notes using simple, conversational language. Don't be too technical. Explain how the change will benefit the merchant and link to the feature.

Examples:
* The newly-released [X feature] is now available to use. Now, you’ll be able to [perform Y action].
* We're happy to announce [X feature], which can help you  [perform Y action].
* [X feature] helps you to create [Y response] using the [Z query parameter]. Now, you can deliver [ex, localized shopping experiences for your customers].
* Fixed a bug in the [X endpoint]. Now the [Y field] will appear when you click [Z option]. -->
* 

## Anything else?
<!-- Add related PRs, salient notes, additional ticket numbers, etc. -->

ping {names}
