### PR TITLE
DEVDOCS-6486 - Enhance userEmail field description

### DIFF
--- a/docs/b2b-edition/specs/api-v3/quote/quote.yaml
+++ b/docs/b2b-edition/specs/api-v3/quote/quote.yaml
@@ -1498,7 +1498,10 @@ components:
             userEmail:
               type: string
               format: email
-              description: "The email address of the quote’s sales rep."
+              description: |-
+                The email address of the quote’s sales rep. Any user email found within the B2B Edition System Users menu is considered a valid value for this field.
+                
+                This field is optional. If left blank, it will default to the store owner's email address as shown in the B2B Edition System Users menu.
             expiredAt:
               type: string
               description: "The date when the buyer can no longer purchase the quote. Use '%m/%d/%Y' format when entering the expiration date."


### PR DESCRIPTION
Updated the `userEmail` description to clarify valid values and default behavior.

<!-- Ticket number or summary of work -->
# [DEVDOCS-6486]


## What changed?
* Updated `userEmail` description to clarify usage and fallback behaviour.

## Release notes draft
* Updated `userEmail` description to clarify usage and fallback behaviour.

## Anything else?

ping { @bigcommerce/dev-docs-team }


[DEVDOCS-6486]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ