### PR TITLE
doc(catalog): CATALOG-11068 Remove redundant meta properties from 422 responses for categories

### DIFF
--- a/reference/catalog/category-trees_catalog.v3.yml
+++ b/reference/catalog/category-trees_catalog.v3.yml
@@ -191,21 +191,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/PartialSuccessResponse'
         '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorRequest'
+          $ref: '#/components/responses/BadRequestError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/GeneralError'
         '422':
-          description: 'The Category was not valid. This is the result of missing required fields, or of invalid data. See the response for more details.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/GeneralErrorWithErrors'
       operationId: createCategories
     put:
       summary: Update Categories
@@ -237,21 +229,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/PartialSuccessNoContentResponse'
         '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorRequest'
+         $ref: '#/components/responses/BadRequestError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/GeneralError'
         '422':
-          description: 'The Category was not valid. This is the result of missing required fields, or of invalid data. See the response for more details.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/GeneralErrorWithErrors'
       operationId: updateCategories
     delete:
       summary: Delete categories
@@ -274,11 +258,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/SuccessNoContentResponse'
         '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorRequest'
+          $ref: '#/components/responses/BadRequestError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -324,7 +304,7 @@ paths:
         '403':
           $ref: '#/components/responses/GeneralError'
         '422':
-          $ref: '#/components/responses/GeneralErrorWithErrors'
+          $ref: '#/components/responses/GeneralErrorWithErrorsAndMeta'
       tags:
         - Category trees
     put:
@@ -395,7 +375,7 @@ paths:
         '403':
           $ref: '#/components/responses/GeneralError'
         '422':
-          $ref: '#/components/responses/GeneralErrorWithErrors'
+          $ref: '#/components/responses/GeneralErrorWithErrorsAndMeta'
       tags:
         - Category trees
     parameters:
@@ -782,15 +762,6 @@ components:
           $ref: '#/components/schemas/MetaData'
       x-tags:
         - Models
-    ErrorResponse:
-      type: object
-      properties:
-        errors:
-          $ref: '#/components/schemas/MetaError'
-        meta:
-          $ref: '#/components/schemas/MetaData'
-      x-tags:
-        - Models
     Tree:
       type: object
       properties:
@@ -1037,7 +1008,13 @@ components:
           schema:
             $ref: '#/components/schemas/GeneralError'
     GeneralErrorWithErrors:
-      description: ''
+      description: 'The request was not valid. This is the result of missing required fields, or of invalid data. See the response for more details.'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GeneralErrorWithErrors'
+    GeneralErrorWithErrorsAndMeta:
+      description: 'The request was not valid. This is the result of missing required fields, or of invalid data. See the response for more details.'
       content:
         application/json:
           schema:


### PR DESCRIPTION
[CATALOG-11068](https://bigcommercecloud.atlassian.net/browse/CATALOG-11068)

## What changed?
Removed `meta` property in responses with `422` status code for the `/v3/catalog/trees/categories` `GET`, `PUT`, `POST` and `DELETE` endpoints.

<img width="1199" height="290" alt="image" src="https://github.com/user-attachments/assets/d922c797-f9b7-4929-811b-f11d3553faf9" />
<img width="1199" height="290" alt="image" src="https://github.com/user-attachments/assets/55eba311-686c-49f6-acfd-a66fe92108fd" />
<img width="1199" height="290" alt="image" src="https://github.com/user-attachments/assets/e9364bfe-a50a-4d7e-9293-8c456166788a" />
<img width="1199" height="290" alt="image" src="https://github.com/user-attachments/assets/2c7fa09b-491c-4089-ac9d-632ed8340ddf" />


## Release notes draft
I believe that [this comment](https://bigcommercecloud.atlassian.net/browse/CATALOG-11068?focusedCommentId=2169377) describes why we removed this property.

## Anything else?
NA

ping @bigcommerce/team-catalog 


[CATALOG-11068]: https://bigcommercecloud.atlassian.net/browse/CATALOG-11068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ