### PR TITLE
DEVDOCS-6537 - Fix link to Quote Statuses content in Quotes Storefront API reference

### DIFF
--- a/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
+++ b/docs/b2b-edition/specs/storefront/storefront/rfq.yaml
@@ -50,7 +50,7 @@ info:
     
     Each status is assigned a numeric ID, which appears in the `status` field of the response body when using the [Get All Quotes](#get-all-quotes) and [Get Quote Details](#get-quote-details) endpoints. You can also use a quote's `status` as a parameter of the [Get All Quotes](#get-all-quotes) endpoint in order to filter for quotes in a specific status.
 
-    The Quotes Storefront API uses the buyer-facing quote status , as opposed to the [internal statuses](https://developer.bigcommerce.com/b2b-edition/apis/rest-management/quote#quote-statuses) that are visible to your staff. See the table below for information on each quote status, as well as its corresponding `status` code.
+    The Quotes Storefront API uses the buyer-facing quote status , as opposed to the [internal statuses](/b2b-edition/apis/rest-management/quote#quote-statuses) that are visible to your staff. See the table below for information on each quote status, as well as its corresponding `status` code.
     | Status Name | Description | Status ID |
     | --- | --- | --- |
     | Open | The quote has not been purchased and is not expired. | 1 |
@@ -155,7 +155,7 @@ paths:
               - 4
               - 5
           example: "1"
-          description: "The frontend status of the quote. Note that these are not the same as statuses observed in the B2B Edition control panel. See [Quote Statuses](#quote-statuses) for more information."
+          description: "The frontend status of the quote. Note that these are not the same as statuses observed in the B2B Edition control panel. See [Quote Statuses](/b2b-edition/apis/rest-storefront/request-for-quote#quote-statuses) for more information."
         - name: quoteTitle
           in: query
           schema:
@@ -1562,7 +1562,7 @@ components:
         - 4
         - 5
       example: 1
-      description: "The numeric ID associated with the quote's status. See [Quote Statuses](#quote-statuses) to learn about the statuses that correspond to each ID."
+      description: "The numeric ID associated with the quote's status. See [Quote Statuses](/b2b-edition/apis/rest-storefront/request-for-quote#quote-statuses) to learn about the statuses that correspond to each ID."
     quoteReference:
       type: string
       example: "04292025-0001"


### PR DESCRIPTION
Fixed links to the Quote Statuses section of the spec file overview.

# [DEVDOCS-6537](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6537)


## What changed?

* The `status` field's description now correctly links to the information on Storefront API quote status values.

## Release notes draft

* We've fixed link quote status information in the article.

## Anything else?

ping @bc-terra 


[DEVDOCS-6537]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-6537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ